### PR TITLE
Add --keys flag to tree command

### DIFF
--- a/main.go
+++ b/main.go
@@ -2117,7 +2117,9 @@ can be useful when you're trying to get your bearings. If '-q' is given, safe
 will not inspect each key in a v1 v2 mount backend to see if it has been marked
 as deleted. This may cause keys which would 404 in an attempt to read them to
 appear in the tree, but is often considerably quicker for larger vaults. This
-flag does nothing for kv v1 mounts.
+flag does nothing for kv v1 mounts. If '--keys' is given, the keys within each
+secret will be displayed inline with the secret name in the format:
+<secret-name>: key1, key2, key3
 `,
 	}, func(command string, args ...string) error {
 		rc.Apply(opt.UseTarget)

--- a/vault/tree.go
+++ b/vault/tree.go
@@ -618,9 +618,9 @@ func (s Secrets) printableTree(color, secrets bool, index int) *tree.Node {
 	}
 	isSecret := index == len(firstSplit)-1
 
-	var dirFmt, secFmt, keyFmt = "%s/", "%s", ":%s"
+	var dirFmt, secFmt = "%s/", "%s"
 	if color {
-		dirFmt, secFmt, keyFmt = "@B{%s/}", "@G{%s}", "@Y{:%s}"
+		dirFmt, secFmt = "@B{%s/}", "@G{%s}"
 	}
 
 	if isSecret {
@@ -634,9 +634,20 @@ func (s Secrets) printableTree(color, secrets bool, index int) *tree.Node {
 	}
 
 	if isSecret {
-		if len(s[0].Versions) > 0 {
-			for _, k := range s[0].Versions[len(s[0].Versions)-1].Data.Keys() {
-				ret.Append(tree.Node{Name: ansi.Sprintf(keyFmt, k)})
+		if len(s[0].Versions) > 0 && len(s[0].Versions[len(s[0].Versions)-1].Data.Keys()) > 0 {
+			keys := s[0].Versions[len(s[0].Versions)-1].Data.Keys()
+			sort.Strings(keys) // Sort keys for consistent output
+			
+			// Create child nodes for each key instead of appending to the name
+			for _, key := range keys {
+				keyName := fmt.Sprintf(":%s", key)
+				if color {
+					keyName = ansi.Sprintf("@Y{%s}", keyName)
+				}
+				keyNode := &tree.Node{
+					Name: keyName,
+				}
+				ret.Append(*keyNode)
 			}
 		}
 	}


### PR DESCRIPTION
Display individual keys within secrets as child nodes in the tree output. Each key is shown with a ':' prefix to distinguish it from paths and secrets.

Example output of `tree --keys`:
```
    │   ├── ocfp/
    │   │   └── blobstores/
    │   │       └── artifacts
    │   │           ├── :host
    │   │           ├── :name
    │   │           ├── :pathstyle
    │   │           ├── :provider
    │   │           ├── :region
    │   │           ├── :storage_class
    │   │           └── :url
    │   ├── shield/
    │   │   └── admin
    │   │       ├── :password
    │   │       └── :username
```