### PR TITLE
feat: add values command to search for secrets containing specific va…

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,27 @@ secret/dc1concourse/pipeline-the-second/dockerhub
 secret/dc1concourse/pipeline-the-second/github
 ```
 
+### values \[--keys\] \[-p path ...\] value \[value ...\]
+
+Find the secrets whose latest live version contains one of the given
+values, matched exactly and case-sensitively. Handy for auditing
+credential reuse or locating every place a leaked value must be
+rotated. Repeat `-p` to search several subtrees (default: `secret`);
+with `--keys`, each match is printed as `path:key`. Values may also be
+read from a file (`@file`), standard input (`@-`), or a hidden prompt
+(no arguments). Subtrees the token cannot read are skipped with a
+warning on standard error.
+
+```
+safe values -p secret/prod hunter2
+secret/prod/db
+secret/prod/legacy/db
+
+safe values --keys hunter2
+secret/prod/db:password
+secret/prod/legacy/db:old-password
+```
+
 ### delete path \[path ...\]
 
 Removes multiple paths from the Vault.

--- a/internal/cli/arg_guard_test.go
+++ b/internal/cli/arg_guard_test.go
@@ -17,6 +17,11 @@ package cli
 // For each handler we build a minimal *CLI with NewRunner (so r.Usage works),
 // ensure the guard fires, and assert the returned error is a *UsageError.
 // No Vault connection is made because connect() is only called after the guard.
+//
+// Intentionally exempt:
+//   - cmdValues — zero args prompts for a value instead of returning a
+//     UsageError; its pre-connect guards (@ expansion errors, empty prompt)
+//     are covered in values_cmd_test.go.
 
 import (
 	"errors"

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -209,6 +209,11 @@ type Options struct {
 		Quick      bool `cli:"-q, --quick"`
 	} `cli:"tree"`
 
+	Values struct {
+		ShowKeys bool     `cli:"--keys"`
+		Paths    []string `cli:"-p, --path"`
+	} `cli:"values"`
+
 	Target struct {
 		JSON        bool     `cli:"--json"`
 		Interactive bool     `cli:"-i, --interactive"`
@@ -751,6 +756,36 @@ marked as deleted. This may cause keys which would 404 in an attempt to read
 them to appear in the tree, but is often considerably quicker for larger
 vaults. This flag does nothing for kv v1 mounts.
 `}, c.cmdPaths)
+
+	r.Dispatch("values", &Help{
+		Summary: "Find secrets containing specified values",
+		Usage:   "safe values [--keys] [-p PATH ...] [VALUE ...]",
+		Type:    NonDestructiveCommand,
+		Description: `
+Searches the hierarchy of secrets for any whose stored values equal one of
+the given values. Matching is exact, case-sensitive, and against whole
+values; no substring or pattern matching is performed. Only the latest live
+version of each secret is inspected -- secrets whose newest version has been
+deleted or destroyed are not searched.
+
+Search locations are given with -p (--path), which may be repeated to search
+several subtrees. The flag value must be a separate argument; the --path=x
+form is not supported. If no -p is given, the search defaults to the
+'secret' mount. The root of each search path must be readable or the command
+fails. Subtrees the authenticated token cannot read are skipped, and a count
+of skipped subtrees is reported on standard error, since skipped subtrees
+mean the results may be incomplete.
+
+Every non-flag argument is a value to search for. A value of @- reads the
+value from standard input, @FILE reads it from FILE, and a leading @@
+escapes a literal @. Values beginning with '-' cannot be passed on the
+command line; supply them via @FILE, @-, or the prompt. If no values are
+given, safe prompts for a single value without echoing it, which also keeps
+the value out of shell history and process listings.
+
+By default each matching secret path is printed once per line; with --keys,
+each match is printed as path:key instead.
+`}, c.cmdValues)
 
 	r.Dispatch("delete", &Help{
 		Summary: "Remove one or more path from the Vault",

--- a/internal/cli/expand_value_arg_test.go
+++ b/internal/cli/expand_value_arg_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestExpandValueArg covers all branches of expandValueArg:
+//   - plain value  (returned unchanged)
+//   - @@value      (escaped literal leading @)
+//   - @-           (read all of stdin via os.Pipe replacement)
+//   - @FILE        (read file contents verbatim)
+//   - @            (missing filename — error)
+//   - @missing     (unreadable file — error)
+func TestExpandValueArg_Plain(t *testing.T) {
+	t.Parallel()
+	for _, arg := range []string{"hunter2", "with@inside", "trailing@", ""} {
+		got, err := expandValueArg(arg)
+		if err != nil {
+			t.Fatalf("expandValueArg(%q): unexpected error: %v", arg, err)
+		}
+		if got != arg {
+			t.Errorf("expandValueArg(%q): got %q, want it unchanged", arg, got)
+		}
+	}
+}
+
+func TestExpandValueArg_DoubleAtEscape(t *testing.T) {
+	t.Parallel()
+	got, err := expandValueArg("@@literal")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "@literal" {
+		t.Errorf("got %q, want %q", got, "@literal")
+	}
+
+	// The escape strips exactly one '@'; "@@@x" yields "@@x".
+	got, err = expandValueArg("@@@x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "@@x" {
+		t.Errorf("got %q, want %q", got, "@@x")
+	}
+}
+
+func TestExpandValueArg_Stdin(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = orig })
+
+	content := "value from stdin\nwith a second line\n"
+	go func() {
+		_, _ = w.WriteString(content)
+		_ = w.Close()
+	}()
+
+	got, err := expandValueArg("@-")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != content {
+		t.Errorf("got %q, want %q (content must be verbatim, no trimming)", got, content)
+	}
+}
+
+func TestExpandValueArg_File(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "value.txt")
+	content := "file value\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	got, err := expandValueArg("@" + path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != content {
+		t.Errorf("got %q, want %q (content must be verbatim, no trimming)", got, content)
+	}
+}
+
+func TestExpandValueArg_BareAt(t *testing.T) {
+	t.Parallel()
+	_, err := expandValueArg("@")
+	if err == nil {
+		t.Fatal("expected error for bare @, got nil")
+	}
+	if !strings.Contains(err.Error(), "no file specified") {
+		t.Errorf("error %q should mention 'no file specified'", err)
+	}
+}
+
+func TestExpandValueArg_MissingFile(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	_, err := expandValueArg("@" + missing)
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("error %q should name the file %q", err, missing)
+	}
+}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -460,6 +460,56 @@ func (c *CLI) cmdPaths(command string, args ...string) error {
 	return nil
 }
 
+func (c *CLI) cmdValues(command string, args ...string) error {
+	opt := c.opt
+
+	if _, err := rc.Apply(opt.UseTarget); err != nil {
+		return err
+	}
+
+	//Expansion and prompting happen before connect() so input errors surface
+	// without network traffic. @- consumes stdin during expansion; the prompt
+	// only fires when no positionals were given, so the two never contend.
+	values := make([]string, 0, len(args))
+	for _, arg := range args {
+		value, err := expandValueArg(arg)
+		if err != nil {
+			return err
+		}
+		values = append(values, value)
+	}
+	if len(values) == 0 {
+		value := pr("value", false, true)
+		if value == "" {
+			return fmt.Errorf("no values specified to search for")
+		}
+		values = append(values, value)
+	}
+
+	paths := opt.Values.Paths
+	if len(paths) == 0 {
+		paths = []string{"secret"}
+	}
+	for i := range paths {
+		paths[i] = vault.Canonicalize(paths[i])
+	}
+	paths = dedupeExportPaths(paths)
+
+	v := connect(true)
+	results, skipped, err := v.FindValueMatches(paths, values, opt.Values.ShowKeys)
+	//Partial results still print when some paths failed; err below makes
+	// main report the failure and exit non-zero.
+	for _, result := range results {
+		_, _ = fmt.Printf("%s\n", result)
+	}
+	if skipped > 0 {
+		_, _ = fmt.Fprintf(os.Stderr,
+			"@Y{warning: skipped %d subtree(s) due to insufficient permissions; results may be incomplete}\n",
+			skipped)
+	}
+	return err
+}
+
 func (c *CLI) cmdDelete(command string, args ...string) error {
 	opt := c.opt
 	r := c.r

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -53,6 +53,35 @@ func parseKeyVal(key string, quiet bool) (string, string, bool, error) {
 	return key, "", true, nil
 }
 
+// expandValueArg resolves the @-prefix conventions for `safe values`
+// positional arguments: "@-" reads all of standard input, "@FILE" reads
+// FILE, and a "@@" prefix escapes a literal leading '@'. Anything else is
+// returned unchanged. File and stdin content is used verbatim (no newline
+// trimming), matching what `safe set key@FILE` would have stored. Unlike
+// parseKeyVal, nothing is echoed to stderr: the resolved values are search
+// targets the user may consider sensitive.
+func expandValueArg(arg string) (string, error) {
+	switch {
+	case arg == "@":
+		return "", fmt.Errorf("no file specified: expecting @<filename>")
+	case strings.HasPrefix(arg, "@@"):
+		return arg[1:], nil
+	case arg == "@-":
+		b, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("failed to read from standard input: %s", err)
+		}
+		return string(b), nil
+	case strings.HasPrefix(arg, "@"):
+		b, err := os.ReadFile(arg[1:]) // #nosec G703 - user intentionally supplies file path via @file CLI syntax
+		if err != nil {
+			return "", fmt.Errorf("failed to read contents of %s: %s", arg[1:], err)
+		}
+		return string(b), nil
+	}
+	return arg, nil
+}
+
 func pr(label string, confirm bool, secure bool) string {
 	if !confirm {
 		if secure {

--- a/internal/cli/values_cmd_test.go
+++ b/internal/cli/values_cmd_test.go
@@ -1,0 +1,58 @@
+package cli
+
+// Pre-connect guard tests for cmdValues. Argument expansion and prompting
+// happen before connect(), so bad @-arguments and an empty prompt response
+// must error without any Vault connection. Match behavior itself is covered
+// by the FindValueMatches tests in pkg/vault.
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/prompt"
+)
+
+// TestCmdValues_EmptyPrompt_NoValuesError: with no positional values, safe
+// prompts for one; an empty response is a hard error raised before connect.
+func TestCmdValues_EmptyPrompt_NoValuesError(t *testing.T) {
+	isolateHome(t)
+	prompt.SetReader(strings.NewReader("\n"))
+	t.Cleanup(func() { prompt.SetReader(nil) })
+
+	c := newTestCLI(t)
+	err := c.cmdValues("values")
+	if err == nil {
+		t.Fatal("expected an error for an empty prompt response, got nil")
+	}
+	if !strings.Contains(err.Error(), "no values specified") {
+		t.Errorf("error %q should mention 'no values specified'", err)
+	}
+}
+
+// A bare @ argument fails during expansion, before connect.
+func TestCmdValues_BareAt_Errors(t *testing.T) {
+	isolateHome(t)
+	c := newTestCLI(t)
+	err := c.cmdValues("values", "@")
+	if err == nil {
+		t.Fatal("expected an error for bare @, got nil")
+	}
+	if !strings.Contains(err.Error(), "no file specified") {
+		t.Errorf("error %q should mention 'no file specified'", err)
+	}
+}
+
+// An unreadable @FILE argument fails during expansion, before connect.
+func TestCmdValues_MissingFile_Errors(t *testing.T) {
+	isolateHome(t)
+	c := newTestCLI(t)
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	err := c.cmdValues("values", "@"+missing)
+	if err == nil {
+		t.Fatal("expected an error for a missing @FILE, got nil")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("error %q should name the file %q", err, missing)
+	}
+}

--- a/pkg/vault/find_value_matches_test.go
+++ b/pkg/vault/find_value_matches_test.go
@@ -1,0 +1,343 @@
+// Coverage for FindValueMatches: exact-value matching across a subtree, the
+// --keys vs path-only output shapes, multi-value and multi-path searches,
+// partial failure, overlapping walks, sort order, output escaping, and the
+// forbidden-skip counter.
+package vault_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// seedValueTree populates a small tree in which "secret123" appears in three
+// different secrets, under three differently-named keys.
+func seedValueTree(fv *fakeVault) {
+	fv.set("secret/test1", map[string]string{
+		"username": "admin",
+		"password": "secret123",
+		"api_key":  "abc123",
+	})
+	fv.set("secret/test2", map[string]string{
+		"token":    "secret123",
+		"username": "user",
+		"code":     "xyz789",
+	})
+	fv.set("secret/nested/path", map[string]string{
+		"password": "secret123",
+		"apikey":   "different",
+	})
+}
+
+func TestFindValueMatchesShowKeys(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	seedValueTree(fv)
+
+	got, skipped, err := v.FindValueMatches([]string{"secret"}, []string{"secret123"}, true)
+	if err != nil {
+		t.Fatalf("FindValueMatches: %v", err)
+	}
+	if skipped != 0 {
+		t.Errorf("skipped = %d, want 0", skipped)
+	}
+
+	want := []string{
+		"secret/nested/path:password",
+		"secret/test1:password",
+		"secret/test2:token",
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("FindValueMatches(--keys) = %v, want %v", got, want)
+	}
+}
+
+func TestFindValueMatchesPathsOnly(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	seedValueTree(fv)
+
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"secret123"}, false)
+	if err != nil {
+		t.Fatalf("FindValueMatches: %v", err)
+	}
+
+	want := []string{"secret/nested/path", "secret/test1", "secret/test2"}
+	if !slices.Equal(got, want) {
+		t.Errorf("FindValueMatches(paths) = %v, want %v", got, want)
+	}
+}
+
+// A secret with two matching keys must be reported exactly once when keys are
+// not being shown.
+func TestFindValueMatchesDeduplicatesPaths(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	seedValueTree(fv)
+
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"admin", "secret123"}, false)
+	if err != nil {
+		t.Fatalf("FindValueMatches: %v", err)
+	}
+
+	want := []string{"secret/nested/path", "secret/test1", "secret/test2"}
+	if !slices.Equal(got, want) {
+		t.Errorf("FindValueMatches(paths) = %v, want %v", got, want)
+	}
+}
+
+func TestFindValueMatchesMultipleValues(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	seedValueTree(fv)
+
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"secret123", "abc123"}, true)
+	if err != nil {
+		t.Fatalf("FindValueMatches: %v", err)
+	}
+
+	want := []string{
+		"secret/nested/path:password",
+		"secret/test1:api_key",
+		"secret/test1:password",
+		"secret/test2:token",
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("FindValueMatches(multi-value) = %v, want %v", got, want)
+	}
+}
+
+// Searching several explicit leaf paths must union their results, and must not
+// pick up secrets outside those paths.
+func TestFindValueMatchesMultiplePaths(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	seedValueTree(fv)
+
+	got, _, err := v.FindValueMatches(
+		[]string{"secret/test1", "secret/test2"}, []string{"admin", "user"}, true)
+	if err != nil {
+		t.Fatalf("FindValueMatches: %v", err)
+	}
+
+	want := []string{"secret/test1:username", "secret/test2:username"}
+	if !slices.Equal(got, want) {
+		t.Errorf("FindValueMatches(multi-path) = %v, want %v", got, want)
+	}
+}
+
+func TestFindValueMatchesNoMatches(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	seedValueTree(fv)
+
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"nonexistent"}, true)
+	if err != nil {
+		t.Fatalf("FindValueMatches: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("FindValueMatches(no match) = %v, want empty", got)
+	}
+}
+
+// Matching is on the whole value, not a substring of it.
+func TestFindValueMatchesIsExactNotSubstring(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/app", map[string]string{"password": "secret123456"})
+
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"secret123"}, true)
+	if err != nil {
+		t.Fatalf("FindValueMatches: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("FindValueMatches(substring) = %v, want empty", got)
+	}
+}
+
+// A value containing a colon is matched literally; only the emitted path and
+// key segments are escaped.
+func TestFindValueMatchesValueWithColon(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/app", map[string]string{"url": "https://example.com:8443"})
+
+	got, _, err := v.FindValueMatches(
+		[]string{"secret"}, []string{"https://example.com:8443"}, true)
+	if err != nil {
+		t.Fatalf("FindValueMatches: %v", err)
+	}
+
+	want := []string{"secret/app:url"}
+	if !slices.Equal(got, want) {
+		t.Errorf("FindValueMatches(colon value) = %v, want %v", got, want)
+	}
+}
+
+func TestFindValueMatchesNonexistentPathErrors(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+
+	if _, _, err := v.FindValueMatches(
+		[]string{"nonexistent/path"}, []string{"value"}, true); err == nil {
+		t.Error("FindValueMatches on a missing path should return an error")
+	}
+}
+
+// An empty target-value list must match nothing, rather than matching every
+// secret via a zero-value lookup.
+func TestFindValueMatchesEmptyTargets(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	seedValueTree(fv)
+
+	got, _, err := v.FindValueMatches([]string{"secret"}, nil, false)
+	if err != nil {
+		t.Fatalf("FindValueMatches: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("FindValueMatches(no targets) = %v, want empty", got)
+	}
+}
+
+// Vault stores no empty secrets, but a key whose value is "" must only match an
+// explicit empty target.
+func TestFindValueMatchesEmptyStringValue(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/app", map[string]string{"blank": "", "other": "x"})
+
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{""}, true)
+	if err != nil {
+		t.Fatalf("FindValueMatches: %v", err)
+	}
+
+	want := []string{"secret/app:blank"}
+	if !slices.Equal(got, want) {
+		t.Errorf("FindValueMatches(empty value) = %v, want %v", got, want)
+	}
+}
+
+// A failing path must not discard matches already gathered from the paths
+// that succeeded: partial results come back alongside the error naming the
+// path that failed.
+func TestFindValueMatchesPartialFailure(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	seedValueTree(fv)
+
+	got, _, err := v.FindValueMatches(
+		[]string{"secret", "nonexistent/x"}, []string{"secret123"}, false)
+	if err == nil {
+		t.Fatal("expected an error for the unwalkable path, got nil")
+	}
+	if !strings.Contains(err.Error(), "nonexistent/x") {
+		t.Errorf("error %q should name the failing path nonexistent/x", err)
+	}
+
+	want := []string{"secret/nested/path", "secret/test1", "secret/test2"}
+	if !slices.Equal(got, want) {
+		t.Errorf("partial results = %v, want %v", got, want)
+	}
+}
+
+// Overlapping search paths walk some secrets twice; each match must still be
+// reported once.
+func TestFindValueMatchesOverlappingPaths(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	seedValueTree(fv)
+
+	got, _, err := v.FindValueMatches(
+		[]string{"secret", "secret/nested"}, []string{"secret123"}, true)
+	if err != nil {
+		t.Fatalf("FindValueMatches: %v", err)
+	}
+
+	want := []string{
+		"secret/nested/path:password",
+		"secret/test1:password",
+		"secret/test2:token",
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("FindValueMatches(overlapping) = %v, want %v", got, want)
+	}
+}
+
+// Results sort by PathLessThan, which orders path segments hierarchically:
+// secret/a/x comes before secret/a-b even though a bytewise sort would put
+// '-' (0x2d) before '/' (0x2f).
+func TestFindValueMatchesSortsByPathLessThan(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/a-b", map[string]string{"k": "match"})
+	fv.set("secret/a/x", map[string]string{"k": "match"})
+
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"match"}, false)
+	if err != nil {
+		t.Fatalf("FindValueMatches: %v", err)
+	}
+
+	want := []string{"secret/a/x", "secret/a-b"}
+	if !slices.Equal(got, want) {
+		t.Errorf("FindValueMatches(order) = %v, want %v", got, want)
+	}
+}
+
+// Output escaping matches Secrets.Paths(): with --keys, path and key segments
+// have colons and carets escaped; in path mode the path is emitted bare.
+func TestFindValueMatchesEscapingMatchesPaths(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/odd:colon", map[string]string{"od^d": "match"})
+
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"match"}, true)
+	if err != nil {
+		t.Fatalf("FindValueMatches(--keys): %v", err)
+	}
+	want := []string{`secret/odd\:colon:od\^d`}
+	if !slices.Equal(got, want) {
+		t.Errorf("FindValueMatches(--keys escaping) = %v, want %v", got, want)
+	}
+
+	// Same expectation Secrets.Paths() produces for this secret.
+	s, err := v.ConstructSecrets("secret", vault.TreeOpts{FetchKeys: true})
+	if err != nil {
+		t.Fatalf("ConstructSecrets: %v", err)
+	}
+	if paths := s.Paths(); !slices.Equal(paths, want) {
+		t.Errorf("Secrets.Paths() = %v, want %v (escaping must stay in lockstep)", paths, want)
+	}
+
+	got, _, err = v.FindValueMatches([]string{"secret"}, []string{"match"}, false)
+	if err != nil {
+		t.Fatalf("FindValueMatches(paths): %v", err)
+	}
+	if want := []string{"secret/odd:colon"}; !slices.Equal(got, want) {
+		t.Errorf("FindValueMatches(bare path) = %v, want %v", got, want)
+	}
+}
+
+// Forbidden subtrees are skipped, counted, and do not fail the search.
+func TestFindValueMatchesCountsForbiddenSkips(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	seedValueTree(fv)
+	fv.set("secret/hidden/deep", map[string]string{"k": "secret123"})
+	fv.forbid("secret/hidden")
+
+	got, skipped, err := v.FindValueMatches([]string{"secret"}, []string{"secret123"}, false)
+	if err != nil {
+		t.Fatalf("FindValueMatches: %v", err)
+	}
+	if skipped == 0 {
+		t.Error("skipped = 0, want > 0 for the forbidden subtree")
+	}
+
+	want := []string{"secret/nested/path", "secret/test1", "secret/test2"}
+	if !slices.Equal(got, want) {
+		t.Errorf("FindValueMatches(forbidden sibling) = %v, want %v", got, want)
+	}
+}

--- a/pkg/vault/httptest_helper_test.go
+++ b/pkg/vault/httptest_helper_test.go
@@ -32,6 +32,10 @@ type fakeVault struct {
 	mu   sync.RWMutex
 	data map[string]map[string]string // path → key → value
 
+	// forbidden marks secret paths whose list and get requests return 403,
+	// modeling a token whose policy denies part of the tree.
+	forbidden map[string]bool
+
 	// pki holds registered PKI mount names (for sys/mounts responses).
 	pki map[string]bool
 
@@ -63,9 +67,24 @@ type fakeVault struct {
 func newFakeVault() *fakeVault {
 	return &fakeVault{
 		data:        make(map[string]map[string]string),
+		forbidden:   make(map[string]bool),
 		pki:         make(map[string]bool),
 		initialized: true,
 	}
+}
+
+// forbid makes list and get requests for a secret path return 403.
+func (f *fakeVault) forbid(path string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.forbidden[path] = true
+}
+
+// isForbidden reports whether a secret path has been marked 403.
+func (f *fakeVault) isForbidden(path string) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.forbidden[path]
 }
 
 // set stores kv pairs at a secret path. Callers own the map.
@@ -222,6 +241,10 @@ func (f *fakeVault) handleKV(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case isList:
 		prefix := "secret/" + subpath
+		if f.isForbidden(strings.TrimRight(prefix, "/")) {
+			jsonErr(w, http.StatusForbidden, "permission denied")
+			return
+		}
 		children := f.listUnder(prefix)
 		if len(children) == 0 {
 			jsonErr(w, http.StatusNotFound, "")
@@ -236,6 +259,10 @@ func (f *fakeVault) handleKV(w http.ResponseWriter, r *http.Request) {
 
 	case r.Method == http.MethodGet:
 		secretPath := "secret/" + subpath
+		if f.isForbidden(secretPath) {
+			jsonErr(w, http.StatusForbidden, "permission denied")
+			return
+		}
 		kv := f.get(secretPath)
 		if kv == nil {
 			jsonErr(w, http.StatusNotFound, "")

--- a/pkg/vault/tree.go
+++ b/pkg/vault/tree.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cloudfoundry-community/goutils/tree"
 	"github.com/cloudfoundry-community/vaultkv"
@@ -308,6 +309,17 @@ type TreeOpts struct {
 	GetDeletedVersions bool
 	//Only perform gets. If the target is not a secret, then an error is returned
 	GetOnly bool
+	//SkippedForbidden, when non-nil, is incremented once for each node the
+	// walk skipped because Vault denied access to it. The pointer is shared
+	// across the concurrent tree workers.
+	SkippedForbidden *atomic.Uint64
+}
+
+// noteSkippedForbidden records one access-denied skip if a counter is wired in.
+func (o TreeOpts) noteSkippedForbidden() {
+	if o.SkippedForbidden != nil {
+		o.SkippedForbidden.Add(1)
+	}
 }
 
 func (v *Vault) constructTree(path string, opts TreeOpts) (*secretTree, error) {
@@ -773,7 +785,11 @@ func (w *treeWorker) workList(t secretTree) ([]secretTree, error) {
 		//IsForbidden: This is because you were able to list the contents of a path
 		// that this path is contained in, but you do not have the permissions to
 		// list this path.
-		if IsNotFound(err) || vaultkv.IsForbidden(err) {
+		if vaultkv.IsForbidden(err) {
+			w.opts.noteSkippedForbidden()
+			return nil, nil
+		}
+		if IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, err
@@ -824,6 +840,7 @@ func (w *treeWorker) workGet(t secretTree) ([]secretTree, error) {
 	// don't explode.
 	if err != nil {
 		if t.MountVersion == 1 && vaultkv.IsForbidden(err) {
+			w.opts.noteSkippedForbidden()
 			return nil, nil
 		}
 		return nil, err
@@ -910,6 +927,7 @@ func (w *treeWorker) workVersions(t secretTree) ([]secretTree, error) {
 	// don't explode.
 	if err != nil {
 		if t.MountVersion == 2 && vaultkv.IsForbidden(err) {
+			w.opts.noteSkippedForbidden()
 			return nil, nil
 		}
 		return nil, err

--- a/pkg/vault/tree.go
+++ b/pkg/vault/tree.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"sort"
@@ -949,4 +950,80 @@ func (w *treeWorker) workVersions(t secretTree) ([]secretTree, error) {
 	}
 
 	return ret, nil
+}
+
+// FindValueMatches walks each of the given paths and reports the secrets
+// whose latest live version contains any of targetValues, compared exactly
+// and case-sensitively against whole stored values. With showKeys, each
+// match is rendered as escaped path:key exactly as Secrets.Paths() renders
+// keyed entries; otherwise the bare path of each matching secret is
+// reported once.
+//
+// Results sort by PathLessThan on path with a bytewise key tiebreak.
+// skipped counts the subtrees the walk dropped because Vault denied access
+// to them. Walk errors are accumulated per path and returned joined,
+// alongside whatever results the remaining paths produced.
+func (v *Vault) FindValueMatches(paths []string, targetValues []string, showKeys bool) (results []string, skipped uint64, err error) {
+	valueSet := make(map[string]bool, len(targetValues))
+	for _, value := range targetValues {
+		valueSet[value] = true
+	}
+
+	type valueMatch struct{ path, key string }
+	var (
+		skipCount  atomic.Uint64
+		matches    []valueMatch
+		seenSecret = map[string]bool{}
+	)
+
+	for _, path := range paths {
+		secrets, cerr := v.ConstructSecrets(path, TreeOpts{
+			FetchKeys:        true,
+			SkippedForbidden: &skipCount,
+		})
+		if cerr != nil {
+			err = errors.Join(err, fmt.Errorf("%s: %w", path, cerr))
+			continue
+		}
+
+		for _, secret := range secrets {
+			if seenSecret[secret.Path] {
+				continue
+			}
+			seenSecret[secret.Path] = true
+			//ConstructSecrets purges zero-version entries; guard the index anyway
+			if len(secret.Versions) == 0 {
+				continue
+			}
+
+			data := secret.Versions[len(secret.Versions)-1].Data
+			for _, key := range data.Keys() {
+				if !valueSet[data.Get(key)] {
+					continue
+				}
+				matches = append(matches, valueMatch{path: secret.Path, key: key})
+				if !showKeys {
+					break
+				}
+			}
+		}
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].path != matches[j].path {
+			return PathLessThan(matches[i].path, matches[j].path)
+		}
+		return matches[i].key < matches[j].key
+	})
+
+	results = make([]string, 0, len(matches))
+	for _, match := range matches {
+		if showKeys {
+			results = append(results, EscapePathSegment(match.path)+":"+EscapePathSegment(match.key))
+		} else {
+			results = append(results, match.path)
+		}
+	}
+
+	return results, skipCount.Load(), err
 }

--- a/pkg/vault/tree_forbidden_test.go
+++ b/pkg/vault/tree_forbidden_test.go
@@ -1,0 +1,78 @@
+package vault_test
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// A walk that hits 403s below a readable root must skip those subtrees,
+// return every reachable sibling, and report how many nodes it skipped.
+func TestConstructSecrets_CountsForbiddenSkips(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+
+	fv.set("secret/ok", map[string]string{"k": "v"})
+	fv.set("secret/hidden/deep", map[string]string{"k": "v"})
+	fv.set("secret/unreadable", map[string]string{"k": "v"})
+	fv.forbid("secret/hidden")     // list of the subtree 403s
+	fv.forbid("secret/unreadable") // get of the leaf 403s
+
+	var skipped atomic.Uint64
+	s, err := v.ConstructSecrets("secret", vault.TreeOpts{
+		FetchKeys:        true,
+		SkippedForbidden: &skipped,
+	})
+	if err != nil {
+		t.Fatalf("ConstructSecrets: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, entry := range s {
+		got[entry.Path] = true
+		// The get-403 leaf stays listed by its parent, but its keys must
+		// never be fetched.
+		if entry.Path == "secret/unreadable" {
+			for _, ver := range entry.Versions {
+				if len(ver.Data.Keys()) != 0 {
+					t.Errorf("forbidden secret %s has key data: %v", entry.Path, ver.Data.Keys())
+				}
+			}
+		}
+	}
+	if !got["secret/ok"] {
+		t.Errorf("walk missing readable sibling secret/ok (got %v)", s.Paths())
+	}
+	if got["secret/hidden/deep"] {
+		t.Errorf("walk descended into forbidden subtree (got %v)", s.Paths())
+	}
+	if n := skipped.Load(); n != 2 {
+		t.Errorf("skipped = %d, want 2 (one list 403, one get 403)", n)
+	}
+}
+
+// Without a counter wired in, forbidden subtrees are still skipped silently
+// and the nil SkippedForbidden must not be touched.
+func TestConstructSecrets_NilSkipCounterUnused(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+
+	fv.set("secret/ok", map[string]string{"k": "v"})
+	fv.set("secret/hidden/deep", map[string]string{"k": "v"})
+	fv.forbid("secret/hidden")
+
+	s, err := v.ConstructSecrets("secret", vault.TreeOpts{FetchKeys: true})
+	if err != nil {
+		t.Fatalf("ConstructSecrets: %v", err)
+	}
+	found := false
+	for _, entry := range s {
+		if entry.Path == "secret/ok" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("walk missing readable sibling secret/ok (got %v)", s.Paths())
+	}
+}


### PR DESCRIPTION
…lues

Add new `safe values` command that searches through Vault secrets to find all secrets containing specified values. Supports searching multiple values and paths with optional --keys flag to show specific key locations.