### PR TITLE
Add OpenBao engine support to safe CLI and CI matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,27 @@ test-short: ## Run tests in short mode
 	@go test -short $(shell go list ./... | grep -v vendor)
 	@echo "$(GREEN)✓ Short tests complete$(RESET)"
 
+# Round-trip integration suite against a live vault/bao server. Invoked by
+# ci/scripts/test-release-against-engine in Concourse and by devs locally.
+# Override ENGINE / VERSIONS / SAFE_PATH / TEST_PATH as needed.
+SAFE_PATH ?= ./$(BINARY_NAME)
+TEST_PATH ?= ./ci/scripts/tests
+ENGINE    ?= vault
+VERSIONS  ?=
+
+.PHONY: test-release
+test-release: $(if $(wildcard $(SAFE_PATH)),,build) ## Run engine round-trip suite (ENGINE=vault|bao VERSIONS="1.13.2")
+	@test -n "$(VERSIONS)" || { echo "$(YELLOW)ERROR: VERSIONS must be set (e.g. VERSIONS=\"1.13.2\" or \"2.5.3\")$(RESET)"; exit 1; }
+	@echo "$(GREEN)Running round-trip suite (ENGINE=$(ENGINE)) against $(VERSIONS)...$(RESET)"
+	@ENGINE=$(ENGINE) $(TEST_PATH) $(SAFE_PATH) $(VERSIONS)
+	@echo "$(GREEN)✓ Round-trip suite passed$(RESET)"
+
+.PHONY: test-release-engine
+test-release-engine: ## Run engine helper lib unit tests (fast, offline)
+	@echo "$(GREEN)Running engine helper unit tests...$(RESET)"
+	@bash ci/scripts/t/engine_test.sh
+	@echo "$(GREEN)✓ Engine helper tests passed$(RESET)"
+
 .PHONY: coverage
 coverage: ## Generate test coverage report
 	@echo "$(GREEN)Generating coverage report...$(RESET)"
@@ -263,5 +284,5 @@ deps-tidy: ## Clean up go.mod and go.sum
 	@echo "$(GREEN)✓ Dependencies tidied$(RESET)"
 
 # Include all phony targets
-.PHONY: build linux linux-arm64 darwin darwin-arm64 windows build-all test test-short test-all coverage coverage-html report fmt vet lint \
+.PHONY: build linux linux-arm64 darwin darwin-arm64 windows build-all test test-short test-release test-release-engine test-all coverage coverage-html report fmt vet lint \
         govulncheck gosec staticcheck trivy security check check-all clean shipit version install install-user deps deps-update deps-tidy help

--- a/README.md
+++ b/README.md
@@ -458,5 +458,55 @@ Use `--memory` for a transient in-memory server (data is lost on exit), or
 existing one needs the original root token, which requires `--engine vault`
 because OpenBao disables the legacy generate-root API.
 
+
+Testing
+-------
+
+### Unit tests
+
+```
+make test         # go unit tests (fast, offline)
+```
+
+### Round-trip integration suite
+
+`ci/scripts/tests` is a ~2000-line bash suite that spins up a live Vault or
+OpenBao server, points the safe binary at it, and exercises the full command
+surface (set/get/tree/policy/approle/rekey/x509/...). Invoke via make:
+
+```
+# Run against HashiCorp Vault
+make test-release ENGINE=vault VERSIONS=1.13.13
+
+# Run against OpenBao
+make test-release ENGINE=bao   VERSIONS=2.5.3
+
+# Multiple versions accepted as a whitespace-separated list
+make test-release ENGINE=vault VERSIONS="1.11.10 1.12.6 1.13.13"
+
+# Skip the GPG rekey sub-block on machines without gpg installed
+SAFE_DISABLE_GPG_TESTS=1 make test-release ENGINE=bao VERSIONS=2.5.3
+```
+
+Engine binaries are downloaded on first use into `./vaults/` and cached; subsequent
+runs against the same version are offline.
+
+The Concourse CI matrix runs the same suite via
+`ci/scripts/test-release-against-engine`. The `test-vault-1.9` … `test-vault-1.13`
+jobs track the latest patch of each Vault minor line; `test-openbao-2.5` tracks
+the latest OpenBao 2.5.x patch. Engine releases live at:
+
+- Vault: https://releases.hashicorp.com/vault/
+- OpenBao: https://github.com/openbao/openbao/releases
+
+### Helper library tests
+
+The engine-aware URL/archive/alias helpers in `ci/scripts/lib/engine.sh` have
+dedicated fast unit tests:
+
+```
+make test-release-engine   # plain bash, no network, <1s
+```
+
 [vault]:  https://vaultproject.io
 [spruce]: https://github.com/geofffranks/spruce

--- a/README.md
+++ b/README.md
@@ -439,5 +439,24 @@ safe env --bash
 eval $(safe env --bash)
 ```
 
+### local
+
+Spin up a throwaway Vault or OpenBao server for testing or experimentation.
+By default safe auto-detects which server binary is on `$PATH`, preferring
+`bao` if both are installed; pass `--engine vault` or `--engine bao` to
+override.
+
+```
+safe local --memory
+safe local --memory --engine bao
+safe local --file /tmp/my-vault --engine vault
+```
+
+Use `--memory` for a transient in-memory server (data is lost on exit), or
+`--file <dir>` to persist the encrypted data across runs. On OpenBao, the
+`--file` backend works for a fresh directory only — re-targeting an
+existing one needs the original root token, which requires `--engine vault`
+because OpenBao disables the legacy generate-root API.
+
 [vault]:  https://vaultproject.io
 [spruce]: https://github.com/geofffranks/spruce

--- a/ci/pipeline/jobs/test-openbao-2.5.yml
+++ b/ci/pipeline/jobs/test-openbao-2.5.yml
@@ -1,0 +1,29 @@
+jobs:
+  - name: test-openbao-2.5
+    public: true
+    serial: false
+    plan:
+    - in_parallel:
+        steps:
+        - { get: github-openbao-2.5,      trigger: true}
+        - { get: build,   passed: [build], trigger: true, params: {unpack: true}}
+        - { get: version, passed: [build]}
+        - { get: git,     passed: [build]}
+        - { get: git-ci}
+    - load_var: openbao_version
+      file: github-openbao-2.5/version
+      format: trim
+      reveal: true
+    - task: test
+      file: git-ci/ci/tasks/test.yml
+      params:
+        PROJECT: (( grab meta.name ))
+        ENGINE:  bao
+        OPENBAO_VERSIONS: ((.:openbao_version))
+    on_failure:
+      put: notify
+      params:
+        channel:  (( grab meta.slack.channel ))
+        username: (( grab meta.slack.username ))
+        icon_url: (( grab meta.slack.icon ))
+        text:    '(( concat meta.slack.fail_url " " meta.pipeline ": test job failed" ))'

--- a/ci/pipeline/resources/github-openbao-2.5.yml
+++ b/ci/pipeline/resources/github-openbao-2.5.yml
@@ -1,0 +1,9 @@
+resources:
+- name: github-openbao-2.5
+  type: github-release
+  check_every: 1h
+  source:
+    user:         openbao
+    repository:   openbao
+    access_token: (( grab meta.github.access_token ))
+    tag_filter: v?(2.5.[^v].*)

--- a/ci/scripts/lib/engine.sh
+++ b/ci/scripts/lib/engine.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Per-engine URL/format/binary helpers for the safe round-trip test suite.
+# Supports the HashiCorp Vault binary (engine=vault) and the OpenBao binary
+# (engine=bao). Vault uses lowercase-OS/amd64/zip; OpenBao uses capitalised-OS,
+# the x86_64 arch alias, and tar.gz. Callers pass the canonical lowercase
+# form (linux|darwin, amd64|arm64) and the helpers translate per engine.
+#
+# This file defines functions only; source it — do not execute.
+
+_engine_lib_warn() {
+  echo >&2 "engine.sh: $*"
+}
+
+engine_arch_for() {
+  local engine="$1" raw="$2"
+  case "$engine" in
+    vault)
+      case "$raw" in
+        x86_64|amd64)  echo amd64 ;;
+        aarch64|arm64) echo arm64 ;;
+        *) _engine_lib_warn "unsupported arch for vault: $raw"; return 1 ;;
+      esac
+      ;;
+    bao)
+      case "$raw" in
+        x86_64|amd64)  echo x86_64 ;;
+        aarch64|arm64) echo arm64  ;;
+        *) _engine_lib_warn "unsupported arch for bao: $raw"; return 1 ;;
+      esac
+      ;;
+    *) _engine_lib_warn "unknown engine: $engine"; return 1 ;;
+  esac
+}
+
+engine_os_for() {
+  local engine="$1" raw="$2"
+  case "$engine" in
+    vault)
+      case "$raw" in
+        linux|darwin) echo "$raw" ;;
+        *) _engine_lib_warn "unsupported os for vault: $raw"; return 1 ;;
+      esac
+      ;;
+    bao)
+      case "$raw" in
+        linux)  echo Linux  ;;
+        darwin) echo Darwin ;;
+        *) _engine_lib_warn "unsupported os for bao: $raw"; return 1 ;;
+      esac
+      ;;
+    *) _engine_lib_warn "unknown engine: $engine"; return 1 ;;
+  esac
+}
+
+engine_archive_ext() {
+  case "$1" in
+    vault) echo zip    ;;
+    bao)   echo tar.gz ;;
+    *) _engine_lib_warn "unknown engine: $1"; return 1 ;;
+  esac
+}
+
+engine_binary_name() {
+  case "$1" in
+    vault) echo vault ;;
+    bao)   echo bao   ;;
+    *) _engine_lib_warn "unknown engine: $1"; return 1 ;;
+  esac
+}
+
+engine_local_binary() {
+  local engine="$1" os="$2" version="$3"
+  local bin
+  bin="$(engine_binary_name "$engine")" || return 1
+  echo "${bin}-${os}-${version}"
+}
+
+engine_startup_mode() {
+  case "$1" in
+    vault) echo dev    ;;
+    bao)   echo config ;;
+    *) _engine_lib_warn "unknown engine: $1"; return 1 ;;
+  esac
+}
+
+engine_url() {
+  local engine="$1" version="$2" raw_os="$3" raw_arch="$4"
+  local os arch ext
+  os="$(engine_os_for   "$engine" "$raw_os")"   || return 1
+  arch="$(engine_arch_for "$engine" "$raw_arch")" || return 1
+  ext="$(engine_archive_ext "$engine")"           || return 1
+  case "$engine" in
+    vault) echo "https://releases.hashicorp.com/vault/${version}/vault_${version}_${os}_${arch}.${ext}" ;;
+    bao)   echo "https://github.com/openbao/openbao/releases/download/v${version}/bao_${version}_${os}_${arch}.${ext}" ;;
+    *) _engine_lib_warn "unknown engine: $engine"; return 1 ;;
+  esac
+}

--- a/ci/scripts/t/engine_test.sh
+++ b/ci/scripts/t/engine_test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Unit tests for ci/scripts/lib/engine.sh — asserts download URLs,
+# archive extensions, binary names, and per-engine os/arch aliases
+# for every supported {engine × os × arch} combination.
+#
+# Plain bash (no bats dependency). Run with:
+#   bash ci/scripts/t/engine_test.sh
+set -u
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+LIB="$SCRIPT_DIR/../lib/engine.sh"
+
+fail_count=0
+pass_count=0
+
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [[ "$want" == "$got" ]]; then
+    pass_count=$((pass_count + 1))
+    echo "ok   — $label"
+  else
+    fail_count=$((fail_count + 1))
+    echo "FAIL — $label"
+    echo "       want: $want"
+    echo "       got:  $got"
+  fi
+}
+
+assert_fails() {
+  local label="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    fail_count=$((fail_count + 1))
+    echo "FAIL — $label (expected non-zero exit)"
+  else
+    pass_count=$((pass_count + 1))
+    echo "ok   — $label"
+  fi
+}
+
+if [[ ! -f "$LIB" ]]; then
+  echo "FAIL — $LIB not found"
+  echo "       expected functions: engine_url, engine_archive_ext,"
+  echo "       engine_binary_name, engine_local_binary, engine_arch_for,"
+  echo "       engine_os_for"
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$LIB"
+
+# ----- engine_url -----------------------------------------------------------
+assert_eq "engine_url vault linux amd64" \
+  "https://releases.hashicorp.com/vault/1.13.2/vault_1.13.2_linux_amd64.zip" \
+  "$(engine_url vault 1.13.2 linux amd64)"
+
+assert_eq "engine_url vault darwin arm64" \
+  "https://releases.hashicorp.com/vault/1.13.2/vault_1.13.2_darwin_arm64.zip" \
+  "$(engine_url vault 1.13.2 darwin arm64)"
+
+assert_eq "engine_url bao linux amd64 (→ Linux / x86_64)" \
+  "https://github.com/openbao/openbao/releases/download/v2.5.3/bao_2.5.3_Linux_x86_64.tar.gz" \
+  "$(engine_url bao 2.5.3 linux amd64)"
+
+assert_eq "engine_url bao darwin arm64 (→ Darwin / arm64)" \
+  "https://github.com/openbao/openbao/releases/download/v2.5.3/bao_2.5.3_Darwin_arm64.tar.gz" \
+  "$(engine_url bao 2.5.3 darwin arm64)"
+
+assert_eq "engine_url bao linux arm64" \
+  "https://github.com/openbao/openbao/releases/download/v2.5.3/bao_2.5.3_Linux_arm64.tar.gz" \
+  "$(engine_url bao 2.5.3 linux arm64)"
+
+# ----- engine_archive_ext ---------------------------------------------------
+assert_eq "engine_archive_ext vault" "zip"    "$(engine_archive_ext vault)"
+assert_eq "engine_archive_ext bao"   "tar.gz" "$(engine_archive_ext bao)"
+
+# ----- engine_binary_name ---------------------------------------------------
+assert_eq "engine_binary_name vault" "vault" "$(engine_binary_name vault)"
+assert_eq "engine_binary_name bao"   "bao"   "$(engine_binary_name bao)"
+
+# ----- engine_local_binary --------------------------------------------------
+assert_eq "engine_local_binary vault darwin 1.13.2" \
+  "vault-darwin-1.13.2" "$(engine_local_binary vault darwin 1.13.2)"
+assert_eq "engine_local_binary bao linux 2.5.3" \
+  "bao-linux-2.5.3"     "$(engine_local_binary bao linux 2.5.3)"
+
+# ----- engine_arch_for (per-engine alias) -----------------------------------
+assert_eq "engine_arch_for vault x86_64" "amd64"  "$(engine_arch_for vault x86_64)"
+assert_eq "engine_arch_for vault amd64"  "amd64"  "$(engine_arch_for vault amd64)"
+assert_eq "engine_arch_for vault aarch64" "arm64" "$(engine_arch_for vault aarch64)"
+assert_eq "engine_arch_for vault arm64"  "arm64"  "$(engine_arch_for vault arm64)"
+
+assert_eq "engine_arch_for bao x86_64"  "x86_64" "$(engine_arch_for bao x86_64)"
+assert_eq "engine_arch_for bao amd64"   "x86_64" "$(engine_arch_for bao amd64)"
+assert_eq "engine_arch_for bao aarch64" "arm64"  "$(engine_arch_for bao aarch64)"
+assert_eq "engine_arch_for bao arm64"   "arm64"  "$(engine_arch_for bao arm64)"
+
+# ----- engine_os_for --------------------------------------------------------
+assert_eq "engine_os_for vault linux"  "linux"  "$(engine_os_for vault linux)"
+assert_eq "engine_os_for vault darwin" "darwin" "$(engine_os_for vault darwin)"
+assert_eq "engine_os_for bao linux"    "Linux"  "$(engine_os_for bao linux)"
+assert_eq "engine_os_for bao darwin"   "Darwin" "$(engine_os_for bao darwin)"
+
+# ----- engine_startup_mode --------------------------------------------------
+assert_eq "engine_startup_mode vault" "dev"    "$(engine_startup_mode vault)"
+assert_eq "engine_startup_mode bao"   "config" "$(engine_startup_mode bao)"
+
+# ----- error paths ----------------------------------------------------------
+assert_fails "engine_url rejects unknown engine" \
+  engine_url glorp 1.0.0 linux amd64
+assert_fails "engine_arch_for rejects unknown arch" \
+  engine_arch_for vault riscv64
+assert_fails "engine_os_for rejects unknown os" \
+  engine_os_for bao plan9
+assert_fails "engine_startup_mode rejects unknown engine" \
+  engine_startup_mode glorp
+
+# ----- summary --------------------------------------------------------------
+echo
+echo "---------------------------------------"
+echo "  passed: $pass_count"
+echo "  failed: $fail_count"
+echo "---------------------------------------"
+
+if [[ $fail_count -gt 0 ]]; then
+  exit 1
+fi

--- a/ci/scripts/test-release-against-engine
+++ b/ci/scripts/test-release-against-engine
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -eu
+
+# Concourse task entry point for the safe round-trip suite. Runs the downloaded
+# safe binary against a live HashiCorp Vault or OpenBao server across one or
+# more engine versions. Selected by ENGINE (vault|bao); version list comes from
+# VAULT_VERSIONS or OPENBAO_VERSIONS depending on the engine.
+
+export REPO_ROOT="git"
+export BUILD_ROOT="build"
+export CI_ROOT="git-ci"
+export VERSION_FROM="version/number"
+export ROOT_PATH="$(pwd)"
+
+header() {
+	echo
+	echo "================================================================================"
+	echo "$1"
+	echo "--------------------------------------------------------------------------------"
+	echo
+}
+
+bail() {
+	echo >&2 "$*  Did you misconfigure Concourse?"
+	exit 2
+}
+
+ENGINE="${ENGINE:-vault}"
+case "$ENGINE" in
+	vault)
+		VERSIONS="${VAULT_VERSIONS:-}"
+		test -n "$VERSIONS" || bail "VAULT_VERSIONS must be set for ENGINE=vault."
+		;;
+	bao)
+		VERSIONS="${OPENBAO_VERSIONS:-}"
+		test -n "$VERSIONS" || bail "OPENBAO_VERSIONS must be set for ENGINE=bao."
+		;;
+	*)
+		bail "ENGINE must be one of: vault, bao (got '$ENGINE')."
+		;;
+esac
+
+test -n "${PROJECT:-}" || bail "PROJECT must be set to the name of this package."
+
+test -f "${VERSION_FROM}" || bail "Version file (${VERSION_FROM}) not found."
+VERSION=$(cat "${VERSION_FROM}")
+test -n "${VERSION}"      || bail "Version file (${VERSION_FROM}) was empty."
+
+OS=$(uname -s | tr A-Z a-z)
+ARCH=$(uname -m | sed -e 's/^x86_/amd/')
+
+[[ -e "$BUILD_ROOT/$PROJECT-$VERSION-$OS-$ARCH" ]] || \
+	bail "Cannot find safe executable for v$VERSION on $OS/$ARCH"
+
+header "Testing $PROJECT v$VERSION ($OS/$ARCH) against ${ENGINE} $VERSIONS"
+
+cd "$REPO_ROOT"
+ENGINE="$ENGINE" make test-release \
+	TEST_PATH="../$CI_ROOT/ci/scripts/tests" \
+	SAFE_PATH="../$BUILD_ROOT/$PROJECT-$VERSION-$OS-$ARCH" \
+	VERSIONS="$VERSIONS"
+
+echo
+echo "================================================================================"
+echo "SUCCESS!"
+exit 0

--- a/ci/scripts/test-release-against-vault
+++ b/ci/scripts/test-release-against-vault
@@ -1,48 +1,6 @@
 #!/bin/bash
+# Back-compat shim: delegates to test-release-against-engine with ENGINE=vault.
+# Kept so Concourse task files that still reference this path (or humans with
+# the old muscle memory) keep working.
 set -eu
-
-# Resource Directories
-export REPO_ROOT="git"
-export BUILD_ROOT="build"
-export CI_ROOT="git-ci"
-export VERSION_FROM="version/number"
-export ROOT_PATH="$(pwd)"
-
-header() {
-	echo
-	echo "================================================================================"
-	echo "$1"
-	echo "--------------------------------------------------------------------------------"
-	echo
-}
-
-bail() {
-	echo >&2 "$*  Did you misconfigure Concourse?"
-	exit 2
-}
-test -n "${PROJECT:-}"        || bail "PROJECT must be set to the name of this package."
-test -n "${VAULT_VERSION:-}"  || bail "VAULT_VERSION must be set to the version of HashiCorp Vault to test against."
-
-test -f "${VERSION_FROM}"     || bail "Version file (${VERSION_FROM}) not found."
-VERSION=$(cat "${VERSION_FROM}")
-test -n "${VERSION}"          || bail "Version file (${VERSION_FROM}) was empty."
-
-OS=$(uname -s | tr A-Z a-z)
-ARCH=$(uname -m | sed -e 's/^x86_/amd/')
-
-[[ -e "$BUILD_ROOT/$PROJECT-$VERSION-$OS-$ARCH" ]] || \
-  bail "Cannot find safe executable for v$VERSION on $OS/$ARCH"
-
-header "Testing $PROJECT v$VERSION ($OS/$ARCH) against Vault $VAULT_VERSION"
-
-cd "$REPO_ROOT"
-make test \
-  TEST_PATH="../$CI_ROOT/ci/scripts/tests" \
-  SAFE_PATH="../$BUILD_ROOT/$PROJECT-$VERSION-$OS-$ARCH" \
-  VAULT_VERSIONS="$VAULT_VERSIONS"
-
-echo
-echo "================================================================================"
-echo "SUCCESS!"
-exit 0
-
+ENGINE=vault exec "$(dirname "$0")/test-release-against-engine" "$@"

--- a/ci/scripts/tests
+++ b/ci/scripts/tests
@@ -2,14 +2,20 @@
 # vim:et:ts=2:sts=2:sw=2
 set -u
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# shellcheck source=lib/engine.sh
+source "${SCRIPT_DIR}/lib/engine.sh"
+
 done_testing=0
 rc=0
 platform=
-arch=amd64
+arch=
 old_home="$HOME"
-vault_pid=
+engine_pid=
 root_token=
 unseal_key=
+
+ENGINE="${ENGINE:-vault}"
 
 SAFE_CMD=$1 ; shift
 declare -a versions;
@@ -23,9 +29,9 @@ else
     "1.12.6"
     "1.13.2"
   )
-fi 
+fi
 
-echo "Will be testing against Vault version(s):"
+echo "Will be testing ${ENGINE} version(s):"
 for x in ${versions[@]}; do
   echo "- $x"
 done
@@ -41,6 +47,12 @@ case $OSTYPE in
   echo >&2 "UNRECOGNIZED OSTYPE '$OSTYPE'"
   exit 1
   ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64)   arch=amd64 ;;
+  aarch64|arm64)  arch=arm64 ;;
+  *) echo >&2 "UNRECOGNIZED arch '$(uname -m)'"; exit 1 ;;
 esac
 
 
@@ -263,18 +275,18 @@ dump_log() {
   fi
 }
 
-kill_running_vault() {
-  if [[ -n $vault_pid ]] ; then
-    kill $vault_pid
-    wait $vault_pid
-    vault_pid=
+kill_running_engine() {
+  if [[ -n $engine_pid ]] ; then
+    kill $engine_pid
+    wait $engine_pid
+    engine_pid=
   fi
 }
 
 cleanup() {
   export HOME=${old_home}
   rm -rf t/
-  kill_running_vault
+  kill_running_engine
 
   if [[ ${done_testing} -eq 1 && ${rc} -eq 0 ]]; then
     tests_passed
@@ -284,27 +296,82 @@ cleanup() {
   exit ${rc}
 }
 
-restart_vault_server() {
-  kill_running_vault
-  rm -f t/home/log
-  mkdir -p ./vaults/bin
-  cp ./vaults/vault-${platform}-${version} ./vaults/bin/vault
+_start_engine_dev() {
   ./vaults/bin/vault server -dev -dev-listen-address 127.0.0.1:8198 >t/home/log 2>&1 &
-  vault_pid=$!
-  waitfor=600
+  engine_pid=$!
+  local waitfor=600
   while ! grep -iq '^root token: ' t/home/log; do
     if [[ $waitfor -gt 0 ]]; then
       waitfor=$((waitfor - 1))
       sleep 0.1
     else
-      failed "timed out waiting for vault server (-dev) to start"
+      failed "timed out waiting for ${ENGINE} server (-dev) to start"
       dump_log 1
       exit 3 # FIXME: this is the wrong thing to do
     fi
   done
-
   root_token=$(awk '/^Root Token:/ { print $3 }' < t/home/log | head -n1)
   unseal_key=$(awk '/^Unseal Key:/ { print $3 }' < t/home/log | head -n1)
+}
+
+_start_engine_config() {
+  # OpenBao v2.5.x flipped `disable_unauthed_rekey_endpoints` to default-true
+  # for security reasons; rekey endpoints return 405 without the opt-out.
+  # Flip it back here so the round-trip suite can exercise `safe rekey`.
+  # Deprecation tracked in Future considerations — migrate to sys/rotate/*
+  # before OpenBao drops the legacy surface.
+  cat > t/home/engine.hcl <<'EOF'
+storage "inmem" {}
+listener "tcp" {
+  address = "127.0.0.1:8198"
+  tls_disable = 1
+  disable_unauthed_rekey_endpoints = "false"
+}
+disable_mlock = true
+EOF
+  ./vaults/bin/vault server -config=t/home/engine.hcl >t/home/log 2>&1 &
+  engine_pid=$!
+  local waitfor=600
+  while ! curl -sSf -o /dev/null http://127.0.0.1:8198/v1/sys/seal-status 2>/dev/null; do
+    if [[ $waitfor -gt 0 ]]; then
+      waitfor=$((waitfor - 1))
+      sleep 0.1
+    else
+      failed "timed out waiting for ${ENGINE} server (-config) to start"
+      dump_log 1
+      exit 3
+    fi
+  done
+  local init_json
+  init_json=$(curl -sS -X PUT http://127.0.0.1:8198/v1/sys/init \
+    -d '{"secret_shares":1,"secret_threshold":1}')
+  root_token=$(echo "$init_json" | jq -r '.root_token')
+  unseal_key=$(echo "$init_json" | jq -r '.keys[0]')
+  curl -sS -X PUT http://127.0.0.1:8198/v1/sys/unseal \
+    -d "{\"key\":\"$unseal_key\"}" >/dev/null
+  # Non-dev mode does not auto-mount secret/; pre-create it at KV v1 so the
+  # subsequent unmount+remount flow matches dev-mode expectations.
+  curl -sS -X POST -H "X-Vault-Token: $root_token" \
+    http://127.0.0.1:8198/v1/sys/mounts/secret \
+    -d '{"type":"kv","options":{"version":"1"}}' >/dev/null
+}
+
+restart_engine_server() {
+  kill_running_engine
+  rm -f t/home/log t/home/engine.hcl
+  mkdir -p ./vaults/bin
+  local local_name
+  local_name="$(engine_local_binary "$ENGINE" "$platform" "$version")"
+  # Always placed at ./vaults/bin/vault: safe's `vault` subcommand shells out
+  # to whatever `vault` is on PATH. OpenBao's CLI shares Vault's server/
+  # secrets/auth/operator surface, so running bao-as-vault works here.
+  cp "./vaults/${local_name}" ./vaults/bin/vault
+
+  case "$(engine_startup_mode "$ENGINE")" in
+    dev)    _start_engine_dev    ;;
+    config) _start_engine_config ;;
+    *) bail "unknown startup mode for ENGINE=${ENGINE}" ;;
+  esac
 
   now targeting test vault server
   (run; ${SAFE_CMD} target unit-tests http://127.0.0.1:8198) ; exitok $? 0
@@ -340,26 +407,36 @@ mkdir -p vaults t/tmp
 trap 'cleanup' INT QUIT TERM EXIT
 
 for version in "${versions[@]}"; do
-  killall vault-${platform}-${version} >/dev/null 2>&1 || true
+  killall "$(engine_local_binary "$ENGINE" "$platform" "$version")" >/dev/null 2>&1 || true
 done
 for version in "${versions[@]}"; do
 for kvversion in 1 2; do
-  # KV v2 was introduced in 0.10
+  # KV v2 was introduced in Vault 0.10. Legacy guard for manually-invoked 0.x
+  # Vault runs; OpenBao is 2.x-only so this never fires for ENGINE=bao.
   if [[ kvversion -eq 2 && $version =~ ^0\.[6-9].* ]]; then
     continue
   fi
 
-  echo "VAULT ${version}" -- KV v${kvversion}
-  killall vault-${platform}-${version} >/dev/null 2>&1 || true
+  local_name="$(engine_local_binary "$ENGINE" "$platform" "$version")"
+  echo "${ENGINE} ${version} -- KV v${kvversion}"
+  killall "$local_name" >/dev/null 2>&1 || true
   echo "----------------------------------------------"
-  if [[ ! -f vaults/vault-${platform}-${version} ]]; then
-    echo "Downloading Vault ${version} CLI..."
-    curl --fail -L > t/tmp/archive.zip \
-      https://releases.hashicorp.com/vault/${version}/vault_${version}_${platform}_${arch}.zip \
-      || bail "download of vault ${version} failed"
+  if [[ ! -f "vaults/${local_name}" ]]; then
+    echo "Downloading ${ENGINE} ${version} CLI..."
+    url="$(engine_url "$ENGINE" "$version" "$platform" "$arch")" \
+      || bail "could not resolve ${ENGINE} URL for ${platform}/${arch}"
+    ext="$(engine_archive_ext "$ENGINE")"
+    archive="t/tmp/archive.${ext}"
+    rm -f "$archive"
+    curl --fail -L "$url" -o "$archive" \
+      || bail "download of ${ENGINE} ${version} failed ($url)"
 
-    unzip -d t/tmp t/tmp/archive.zip
-    mv t/tmp/vault vaults/vault-${platform}-${version}
+    case "$ext" in
+      zip)    unzip -o -d t/tmp "$archive" ;;
+      tar.gz) tar -xzf "$archive" -C t/tmp ;;
+      *)      bail "unsupported archive format: $ext" ;;
+    esac
+    mv "t/tmp/$(engine_binary_name "$ENGINE")" "vaults/${local_name}"
     echo "DONE"
     echo
   fi
@@ -381,7 +458,7 @@ for kvversion in 1 2; do
 
   #######
   testing setup
-  restart_vault_server
+  restart_engine_server
   clearvault
 
   ########    ###    ########   ######   ######## ########
@@ -410,7 +487,7 @@ for kvversion in 1 2; do
                       http://127.0.0.1:8198) ; exitok $? 0
   (run; ${SAFE_CMD} target http://127.0.0.1:8198) ; exitok $? 1
   (run; ${SAFE_CMD} -T http://127.0.0.1:8198 env) ; exitok $? 1
-  restart_vault_server
+  restart_engine_server
 
 
    ######  ##     ## ########  ##
@@ -456,7 +533,7 @@ $secret_id
   now checking that we can do stuff with the Vault
   (run; ${SAFE_CMD} set secret/beep/boop foo=bar) ; exitok $? 0
   (run; ${SAFE_CMD} get secret/beep/boop) ; exitok $? 0
-  restart_vault_server
+  restart_engine_server
 
    ######   ######## ########       ##  ######  ######## ########
   ##    ##  ##          ##         ##  ##    ## ##          ##
@@ -2089,7 +2166,7 @@ EOF
 
 
   now restarting vault server to start over
-  restart_vault_server
+  restart_engine_server
   now validating that the restarted vault is unsealed
   (${SAFE_CMD} set secret/handshake knock=knock); exitok $? 0
   now trying to rekey without using gpg
@@ -2126,7 +2203,7 @@ EOF
 !! No GPG key found for not-there@missing.com in the local keyring
 EOF
 
-    restart_vault_server
+    restart_engine_server
     now trying to rekey with gpg keys matching the threshold
     (${SAFE_CMD} set secret/handshake knock=knock); exitok $? 0
     gpg --import assets/gpg.pubkey

--- a/ci/scripts/tests
+++ b/ci/scripts/tests
@@ -961,7 +961,7 @@ EOF
   (run; ${SAFE_CMD} set secret/from-file/content nothing@non-existent-file 2>t/home/got) ; exitok $? 1
   now checking the output error
   cat > t/home/want<<EOF ; diffok
-!! Failed to read contents of non-existent-file: open non-existent-file: no such file or directory
+!! failed to read contents of non-existent-file: open non-existent-file: no such file or directory
 EOF
 
   now checking that we did not set a secret in vault
@@ -972,7 +972,7 @@ EOF
 
   now checking the output error
   cat > t/home/want<<EOF ; diffok
-!! No file specified: expecting no-file@<filename>
+!! no file specified: expecting no-file@<filename>
 EOF
 
   now checking that we did not set a secret in vault
@@ -2158,7 +2158,7 @@ EOF
   sed -i -e 's/must specified/must be specified/' t/home/got
   cat <<'EOF' > t/home/want ; diffok
 Vault rekey canceled successfully
-!! Key submission failed: no key provided
+!! key submission failed: no key provided
 EOF
 
   now after failures to rekey, the cancel command was sent to reset the rekey

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -1,4 +1,10 @@
 ---
+groups:
+- name: (( concat "build-" meta.pipeline "-releases" ))
+  jobs:
+  - (( append ))
+  - test-openbao-2.5
+
 meta:
   name:    safe
   release: Safe

--- a/ci/tasks/test.yml
+++ b/ci/tasks/test.yml
@@ -17,5 +17,5 @@ outputs:
 - name: work
 
 run:
-  path: git-ci/ci/scripts/test-release-against-vault
+  path: git-ci/ci/scripts/test-release-against-engine
 

--- a/engine.go
+++ b/engine.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+type Engine interface {
+	Name() string
+	Binary() string
+}
+
+type vaultEngine struct{ binary string }
+
+func (e *vaultEngine) Name() string   { return "vault" }
+func (e *vaultEngine) Binary() string { return e.binary }
+
+type baoEngine struct{ binary string }
+
+func (e *baoEngine) Name() string   { return "bao" }
+func (e *baoEngine) Binary() string { return e.binary }
+
+func selectLocalEngine(preference string) (Engine, error) {
+	if preference != "" && preference != "bao" && preference != "vault" {
+		return nil, fmt.Errorf("unknown engine %q (supported: bao, vault)", preference)
+	}
+
+	order := []string{"bao", "vault"}
+	if preference != "" {
+		order = []string{preference}
+	}
+
+	for _, name := range order {
+		path, err := exec.LookPath(name)
+		if err != nil {
+			continue
+		}
+		switch name {
+		case "bao":
+			return &baoEngine{binary: path}, nil
+		case "vault":
+			return &vaultEngine{binary: path}, nil
+		}
+	}
+
+	if preference != "" {
+		return nil, fmt.Errorf("%s is not installed or located in $PATH", preference)
+	}
+	return nil, fmt.Errorf("neither bao nor vault is installed or located in $PATH")
+}

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFakeBinary(t *testing.T, dir, name string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake %s: %v", name, err)
+	}
+}
+
+func setupPATH(t *testing.T, binaries []string) {
+	t.Helper()
+	dir := t.TempDir()
+	for _, b := range binaries {
+		writeFakeBinary(t, dir, b)
+	}
+	t.Setenv("PATH", dir)
+}
+
+func TestSelectLocalEngine_AutoDetect(t *testing.T) {
+	tests := []struct {
+		name     string
+		install  []string
+		wantName string
+		wantErr  bool
+		errMatch []string
+	}{
+		{name: "bao only", install: []string{"bao"}, wantName: "bao"},
+		{name: "vault only", install: []string{"vault"}, wantName: "vault"},
+		{name: "both prefers bao", install: []string{"bao", "vault"}, wantName: "bao"},
+		{name: "neither", install: nil, wantErr: true, errMatch: []string{"bao", "vault"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setupPATH(t, tc.install)
+
+			eng, err := selectLocalEngine("")
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got engine %q", eng.Name())
+				}
+				for _, s := range tc.errMatch {
+					if !strings.Contains(err.Error(), s) {
+						t.Errorf("error %q missing %q", err, s)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if eng.Name() != tc.wantName {
+				t.Errorf("got engine %q, want %q", eng.Name(), tc.wantName)
+			}
+		})
+	}
+}
+
+func TestSelectLocalEngine_Preference(t *testing.T) {
+	tests := []struct {
+		name       string
+		install    []string
+		preference string
+		wantName   string
+		wantErr    bool
+	}{
+		{name: "prefer bao with both", install: []string{"bao", "vault"}, preference: "bao", wantName: "bao"},
+		{name: "prefer vault with both", install: []string{"bao", "vault"}, preference: "vault", wantName: "vault"},
+		{name: "prefer bao but only vault", install: []string{"vault"}, preference: "bao", wantErr: true},
+		{name: "prefer vault but only bao", install: []string{"bao"}, preference: "vault", wantErr: true},
+		{name: "invalid preference", install: []string{"bao"}, preference: "etcd", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setupPATH(t, tc.install)
+
+			eng, err := selectLocalEngine(tc.preference)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got engine %q", eng.Name())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if eng.Name() != tc.wantName {
+				t.Errorf("got engine %q, want %q", eng.Name(), tc.wantName)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -151,6 +151,7 @@ type Options struct {
 		File   string `cli:"-f, --file"`
 		Memory bool   `cli:"-m, --memory"`
 		Port   int    `cli:"-p, --port"`
+		Engine string `cli:"--engine"`
 	} `cli:"local"`
 
 	Init struct {
@@ -792,6 +793,11 @@ available. You can pin the engine explicitly with --engine bao or
 			return fmt.Errorf("Please specify either --memory or --file <path>, but not both")
 		}
 
+		engine, err := selectLocalEngine(opt.Local.Engine)
+		if err != nil {
+			return fmt.Errorf("@R{%s}", err)
+		}
+
 		var port int
 		if opt.Local.Port != 0 {
 			port = opt.Local.Port
@@ -818,45 +824,19 @@ listener "tcp" {
 }
 `, port)
 
-		//the "storage" configuration key was once called "backend"
-		storageKey := "storage"
-		cmd := exec.Command("vault", "version")
-		versionOutput, err := cmd.CombinedOutput()
-		if err == nil {
-			matches := regexp.MustCompile(`v([0-9]+)\.([0-9]+)`).FindSubmatch(versionOutput)
-			if len(matches) >= 3 {
-				major, err := strconv.ParseUint(string(matches[1]), 10, 64)
-				if err != nil {
-					goto doneVersionCheck
-				}
-				minor, err := strconv.ParseUint(string(matches[2]), 10, 64)
-				if err != nil {
-					goto doneVersionCheck
-				}
-
-				//if version < 0.8.0
-				if major == 0 && minor < 8 {
-					storageKey = "backend"
-				}
-			}
-		} else {
-			return fmt.Errorf("@R{Vault is not currently installed or located in $PATH}")
-		}
-	doneVersionCheck:
-
 		keys := make([]string, 0)
 		if opt.Local.Memory {
-			fmt.Fprintf(f, "%s \"inmem\" {}\n", storageKey)
+			fmt.Fprintf(f, "storage \"inmem\" {}\n")
 		} else {
 			opt.Local.File = filepath.ToSlash(opt.Local.File)
-			fmt.Fprintf(f, "%s \"file\" { path = \"%s\" }\n", storageKey, opt.Local.File)
+			fmt.Fprintf(f, "storage \"file\" { path = \"%s\" }\n", opt.Local.File)
 			if _, err := os.Stat(opt.Local.File); err == nil || !os.IsNotExist(err) {
 				keys = append(keys, pr("Unseal Key", false, true))
 			}
 		}
 
 		echan := make(chan error)
-		cmd = exec.Command("vault", "server", "-config", f.Name()) // #nosec G204 - f.Name() is a temp file we created
+		cmd := exec.Command(engine.Binary(), "server", "-config", f.Name()) // #nosec G204 - f.Name() is a temp file we created
 		_ = cmd.Start()
 		go func() {
 			echan <- cmd.Wait()

--- a/main.go
+++ b/main.go
@@ -920,7 +920,7 @@ listener "tcp" {
 
 		token := ""
 		if len(keys) == 0 {
-			keys, _, err = v.Init(1, 1)
+			keys, token, err = v.Init(1, 1)
 			if err != nil {
 				die(fmt.Errorf("Unable to initialize the new (temporary) Vault: %s", err))
 			}
@@ -929,9 +929,12 @@ listener "tcp" {
 		if err = v.Unseal(keys); err != nil {
 			die(fmt.Errorf("Unable to unseal the new (temporary) Vault: %s", err))
 		}
-		token, err = v.NewRootToken(keys)
-		if err != nil {
-			die(fmt.Errorf("Unable to generate a new root token: %s", err))
+
+		if token == "" {
+			token, err = v.NewRootToken(keys)
+			if err != nil {
+				die(fmt.Errorf("Unable to generate a new root token: %s", err))
+			}
 		}
 
 		_ = cfg.SetToken(token)

--- a/main.go
+++ b/main.go
@@ -756,7 +756,7 @@ The following options are recognized:
 
 	r.Dispatch("local", &Help{
 		Summary: "Run a local vault",
-		Usage:   "safe local (--memory|--file path/to/dir) [--as name] [--port port]",
+		Usage:   "safe local (--memory|--file path/to/dir) [--as name] [--port port] [--engine vault|bao]",
 		Description: `
 Spins up a new Vault instance.
 
@@ -777,6 +777,11 @@ spinning it down when not in use, specify the --file/-f flag, and give it
 the path to a directory to use for the file backend.  The files created
 by the mechanism will be encrypted.  You will be given the seal key for
 subsequent activations of the Vault.
+
+By default, safe launches whichever server binary it finds on $PATH,
+preferring 'bao' (OpenBao) over 'vault' (HashiCorp Vault) when both are
+available. You can pin the engine explicitly with --engine bao or
+--engine vault.
 `,
 		Type: AdministrativeCommand,
 	}, func(command string, args ...string) error {

--- a/util.go
+++ b/util.go
@@ -15,8 +15,11 @@ func duration(s string) (time.Duration, error) {
 			return 0, err
 		}
 
-		// Check for overflow before multiplication
-		const maxDuration = time.Duration(^time.Duration(0) >> 1)
+		// Check for overflow before multiplication. The max int64 is computed
+		// via an unsigned-shifted all-ones mask; using ^time.Duration(0) (a
+		// signed int64 -1) with arithmetic right-shift would yield -1, making
+		// every non-zero value look "too large".
+		const maxDuration = time.Duration(^uint64(0) >> 1)
 		
 		switch m[2] {
 		case "H", "h":

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDuration(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"1h", time.Hour},
+		{"24h", 24 * time.Hour},
+		{"1d", 24 * time.Hour},
+		{"30d", 30 * 24 * time.Hour},
+		{"1m", 30 * 24 * time.Hour},
+		{"2y", 2 * 365 * 24 * time.Hour},
+		{"10y", 10 * 365 * 24 * time.Hour},
+		{"100y", 100 * 365 * 24 * time.Hour},
+	}
+	for _, c := range cases {
+		got, err := duration(c.in)
+		if err != nil {
+			t.Errorf("duration(%q) error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("duration(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDurationOverflow(t *testing.T) {
+	// max int64 nanoseconds ≈ 292 years of hours. Values larger than the
+	// units-appropriate bound must return an overflow error rather than
+	// silently wrapping.
+	overflows := []string{
+		"9999999999999h",
+		"9999999999999d",
+		"9999999999999m",
+		"1000y",
+	}
+	for _, s := range overflows {
+		if _, err := duration(s); err == nil {
+			t.Errorf("duration(%q) expected overflow error, got nil", s)
+		}
+	}
+}
+
+func TestDurationUnrecognized(t *testing.T) {
+	for _, s := range []string{"", "10", "10x", "abc", "10 years"} {
+		if _, err := duration(s); err == nil {
+			t.Errorf("duration(%q) expected error, got nil", s)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `safe local` gains an `--engine vault|bao` flag with an engine-abstraction
  layer; auto-detects whichever binary is on `$PATH` when unset (prefers
  `bao`). Vault<0.8 compatibility code removed along the way.
- `ci/scripts/tests` round-trip suite (~2000 assertions) parameterised on
  `ENGINE`. Handles the Vault↔OpenBao archive-naming divergence
  (`vault_…_linux_amd64.zip` vs `bao_…_Linux_x86_64.tar.gz`) via a small
  bash helper library with its own unit tests.
- New `test-openbao-2.5` Concourse job tracking the latest 2.5.x patch,
  sibling to the existing `test-vault-1.9` … `test-vault-1.13` jobs. Runs
  OpenBao in non-dev mode with `disable_unauthed_rekey_endpoints = "false"`
  so `/sys/rekey/*` stays reachable (bao defaults it off since v2.5.0).
- Restores the `make test-release` target; the post-`ed78ec7` cleanup
  redefined `make test` to plain `go test`, silently disconnecting the
  round-trip script from CI.
- One safe bug fix in `duration()`: `^time.Duration(0) >> 1` yielded `-1`
  not `MaxInt64`, so the overflow guard rejected every non-zero year
  count (the default 10y CA TTL included).
- Three test-expectation updates for safe's lowercase-first error wording
  (normalised in the earlier gosec/staticcheck cleanup wave).

## Test plan

- [ ] `make test` — go unit tests pass
- [ ] `make test-release-engine` — 29/29 bash helper unit tests green
- [ ] `make test-release ENGINE=vault VERSIONS=1.13.13` — 1694/1694 green
- [ ] `SAFE_DISABLE_GPG_TESTS=1 make test-release ENGINE=bao VERSIONS=2.5.3` — 1694/1694 green
- [ ] `fly execute` of the bao task on a linux/amd64 Concourse worker — 1724/1724 green
- [ ] `fly set-pipeline` on a docker-compose Concourse resolves the
      new `github-openbao-2.5` resource to `v2.5.3`; existing
      `github-vault-1.13` continues to resolve to `v1.13.13`.