### PR TITLE
Preserve colon-bearing keys in tree walk

### DIFF
--- a/pkg/vault/colon_key_test.go
+++ b/pkg/vault/colon_key_test.go
@@ -1,0 +1,125 @@
+// Regression coverage for keys containing colons (and carets). The tree walk
+// joins path and key with ":" to name key nodes; without escaping that join,
+// Basename truncates "odd:key" to "key", silently renaming keys in every
+// consumer of the walk: copy, move, export, and paths/tree --keys.
+package vault_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// The tree walk must hand back key names exactly as stored, colons included.
+func TestConstructSecrets_PreservesColonKeys(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/odd", map[string]string{
+		"odd:key": "colon value",
+		"od^d":    "caret value",
+		"plain":   "plain value",
+	})
+
+	s, err := v.ConstructSecrets("secret/odd", vault.TreeOpts{FetchKeys: true})
+	if err != nil {
+		t.Fatalf("ConstructSecrets: %v", err)
+	}
+	if len(s) != 1 || len(s[0].Versions) == 0 {
+		t.Fatalf("expected one secret with versions, got %+v", s)
+	}
+
+	got := s[0].Versions[len(s[0].Versions)-1].Data
+	wantKeys := []string{"od^d", "odd:key", "plain"}
+	if keys := got.Keys(); !slices.Equal(keys, wantKeys) {
+		t.Fatalf("Keys() = %v, want %v", keys, wantKeys)
+	}
+	if val := got.Get("odd:key"); val != "colon value" {
+		t.Errorf("Get(odd:key) = %q, want %q", val, "colon value")
+	}
+	if val := got.Get("od^d"); val != "caret value" {
+		t.Errorf("Get(od^d) = %q, want %q", val, "caret value")
+	}
+}
+
+// Copying a whole secret must not rename its colon-bearing keys.
+func TestCopyPreservesColonKeys(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/src", map[string]string{"odd:key": "value", "plain": "x"})
+
+	if err := v.Copy("secret/src", "secret/dst", vault.MoveCopyOpts{Quiet: true}); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+
+	kv := mustGetSecret(t, fv, "secret/dst")
+	if kv["odd:key"] != "value" {
+		t.Errorf("dst[odd:key] = %q, want %q (keys: %v)", kv["odd:key"], "value", kv)
+	}
+	if _, renamed := kv["key"]; renamed {
+		t.Error("dst contains truncated key \"key\"; colon key was renamed")
+	}
+}
+
+// Tree-form copy (what safe cp -R does per path) must preserve colon keys in
+// every secret of the subtree.
+func TestMoveCopyTreePreservesColonKeys(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/sub/a", map[string]string{"odd:key": "va"})
+	fv.set("secret/sub/b/c", map[string]string{"other:key": "vc"})
+
+	err := v.MoveCopyTree("secret/sub", "secret/dst", v.Copy, vault.MoveCopyOpts{Quiet: true})
+	if err != nil {
+		t.Fatalf("MoveCopyTree: %v", err)
+	}
+
+	if kv := mustGetSecret(t, fv, "secret/dst/a"); kv["odd:key"] != "va" {
+		t.Errorf("dst/a[odd:key] = %q, want %q (keys: %v)", kv["odd:key"], "va", kv)
+	}
+	if kv := mustGetSecret(t, fv, "secret/dst/b/c"); kv["other:key"] != "vc" {
+		t.Errorf("dst/b/c[other:key] = %q, want %q (keys: %v)", kv["other:key"], "vc", kv)
+	}
+}
+
+// paths --keys output escapes colons and carets in the key segment so the
+// printed path:key round-trips through ParsePath.
+func TestSecretsPathsEscapesColonKeys(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/odd", map[string]string{"odd:key": "v", "od^d": "w"})
+
+	s, err := v.ConstructSecrets("secret/odd", vault.TreeOpts{FetchKeys: true})
+	if err != nil {
+		t.Fatalf("ConstructSecrets: %v", err)
+	}
+
+	want := []string{`secret/odd:od\^d`, `secret/odd:odd\:key`}
+	if got := s.Paths(); !slices.Equal(got, want) {
+		t.Errorf("Paths() = %v, want %v", got, want)
+	}
+
+	// The escaped form must parse back to the original secret and key.
+	secret, key, _ := vault.ParsePath(`secret/odd:odd\:key`)
+	if secret != "secret/odd" || key != "odd:key" {
+		t.Errorf("ParsePath round-trip = (%q, %q), want (secret/odd, odd:key)", secret, key)
+	}
+}
+
+// tree --keys renders key names escaped, so the display is unambiguous.
+func TestDrawEscapesColonKeys(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/odd", map[string]string{"odd:key": "v"})
+
+	s, err := v.ConstructSecrets("secret/odd", vault.TreeOpts{FetchKeys: true})
+	if err != nil {
+		t.Fatalf("ConstructSecrets: %v", err)
+	}
+
+	out := s.Draw("secret/odd", false, true)
+	if !strings.Contains(out, `:odd\:key`) {
+		t.Errorf("Draw output %q should contain escaped key %q", out, `:odd\:key`)
+	}
+}

--- a/pkg/vault/tree.go
+++ b/pkg/vault/tree.go
@@ -548,8 +548,10 @@ func (t secretTree) Basename() string {
 		splits := strings.Split(strings.TrimRight(t.Name, "/"), "/")
 		ret = splits[len(splits)-1]
 	case treeTypeKey:
-		splits := strings.Split(t.Name, ":")
-		ret = splits[len(splits)-1]
+		//The node name is path:key with the key segment escaped (workGet);
+		// ParsePath splits on the last unescaped colon and unescapes.
+		_, key, _ := ParsePath(t.Name)
+		ret = key
 	}
 
 	return ret
@@ -638,7 +640,7 @@ func (s Secrets) printableTree(color, secrets bool, index int) *tree.Node {
 
 			// Create child nodes for each key instead of appending to the name
 			for _, key := range keys {
-				keyName := fmt.Sprintf(":%s", key)
+				keyName := fmt.Sprintf(":%s", EscapePathSegment(key))
 				if color {
 					keyName = ansi.Sprintf("@Y{%s}", keyName)
 				}
@@ -844,8 +846,10 @@ func (w *treeWorker) workGet(t secretTree) ([]secretTree, error) {
 
 	ret := []secretTree{}
 	for _, key := range s.Keys() {
+		//Escape the key so a literal ':' or '^' in it survives the joined
+		// node name; Basename recovers the key with ParsePath.
 		ret = append(ret, secretTree{
-			Name:    path + ":" + key,
+			Name:    path + ":" + EscapePathSegment(key),
 			Type:    treeTypeKey,
 			Value:   string(s.data[key]),
 			Version: version,


### PR DESCRIPTION
## Problem

The tree walk names key nodes by joining path and key with a raw `:`, and `Basename` recovered the key by splitting on `:` and taking the last piece. A key containing a colon — e.g. `odd:key` — was silently truncated to its final segment (`key`).

This is data-corrupting, not merely cosmetic: `safe copy`, `safe move`, `safe export`, and tree-form move/copy all rebuild secrets from the walk, so a colon-bearing key was silently *renamed* at the destination. `paths --keys` and `tree --keys` also printed ambiguous, unparseable `path:key` forms.

## Fix

- Key-node names now escape the key segment with `EscapePathSegment` (`:` → `\:`, `^` → `\^`) when joined onto the path.
- `Basename` recovers the key via `ParsePath`, which splits on the last *unescaped* colon and unescapes — instead of a naive `strings.Split`.
- The printable tree escapes key names, so displayed `path:key` forms round-trip through `ParsePath`.

The version-caret parse in `ParsePath` cannot misfire on key-node names: the appended `:key` suffix makes the `^N` ParseUint fail, so raw carets in paths remain safe.

## Tests

Five regression tests (`pkg/vault/colon_key_test.go`), all failing before the fix and passing after:

- tree walk preserves `odd:key` and `od^d` verbatim
- `Copy` preserves colon keys (no truncated `key` at destination)
- `MoveCopyTree` preserves colon keys across a subtree
- `Secrets.Paths()` emits escaped `path:key` that round-trips through `ParsePath`
- `Draw` renders the escaped key form

`make check` and `go test -race ./...` are clean.

## Relation to PR #6

`safe values` (#6) inherits this fix transparently — it reads `Data.Keys()` after `convertToSecrets`, so once the walk stops truncating, `values --keys` output is correct with no changes needed there.