### PR TITLE
Render go-ansi markup in table cells

### DIFF
--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -286,7 +286,7 @@ func (c *CLI) cmdVersions(command string, args ...string) error {
 
 			table.addRow(
 				fmt.Sprintf("%d", versions[j].Version),
-				fmt.Sprintf("%s", statusString),
+				statusString,
 				createdAtString,
 			)
 		}
@@ -1098,7 +1098,7 @@ func (c *CLI) cmdOption(command string, args ...string) error {
 			if *entry.val {
 				value = "@G{true}"
 			}
-			table.addRow(entry.opt, fmt.Sprintf("%s", value))
+			table.addRow(entry.opt, value)
 		}
 
 		table.print()

--- a/internal/cli/table_test.go
+++ b/internal/cli/table_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -145,6 +146,100 @@ func TestTableStripColor(t *testing.T) {
 				t.Errorf("_stripColor(%q): got %q, want %q", tc.input, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestTableAddRowRendersMarkup verifies that go-ansi markup handed to addRow as
+// cell content is rendered rather than passed through verbatim.
+//
+// go-ansi only interprets markup appearing in the format string, and
+// ansiColorRegexp only matches already-rendered escape sequences. A cell holding
+// an unrendered "@G{...}" template therefore survives _stripColor untouched and
+// reaches stdout literally.
+//
+// Assertions are written to hold whether or not stdout is colorized: the cell's
+// display width must equal the visible text, and stripping it must yield the
+// visible text exactly.
+func TestTableAddRowRendersMarkup(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		cell string
+		want string
+	}{
+		{name: "green markup", cell: "@G{alive}", want: "alive"},
+		{name: "red markup", cell: "@R{destroyed}", want: "destroyed"},
+		{name: "yellow markup", cell: "@Y{deleted}", want: "deleted"},
+		{name: "plain text is unchanged", cell: "unknown", want: "unknown"},
+		{name: "markup surrounded by text", cell: "pre @C{mid} post", want: "pre mid post"},
+		{name: "two markup runs in one cell", cell: "@G{a}/@R{b}", want: "a/b"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tbl := &table{}
+			tbl.addRow(tc.cell)
+
+			got := tbl.rows[0][0]
+			if strings.Contains(got, "@") {
+				t.Errorf("addRow(%q): stored %q, which still contains unrendered markup", tc.cell, got)
+			}
+			if stripped := tbl._stripColor(got); stripped != tc.want {
+				t.Errorf("addRow(%q): stripped to %q, want %q", tc.cell, stripped, tc.want)
+			}
+			if width := tbl._calcDisplayWidth(got); width != len(tc.want) {
+				t.Errorf("addRow(%q): display width %d, want %d (column alignment depends on this)",
+					tc.cell, width, len(tc.want))
+			}
+		})
+	}
+}
+
+// TestTableAddRowPreservesPercent verifies that cell content is not treated as a
+// format string. Rendering a cell requires handing it to go-ansi as a format,
+// so any '%' it contains must be escaped first or it is consumed as a verb.
+func TestTableAddRowPreservesPercent(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"100%done",
+		"%",
+		"%s",
+		"%d%%",
+		"50% off",
+	}
+
+	for _, cell := range cases {
+		cell := cell
+		t.Run(cell, func(t *testing.T) {
+			t.Parallel()
+			tbl := &table{}
+			tbl.addRow(cell)
+
+			if got := tbl._stripColor(tbl.rows[0][0]); got != cell {
+				t.Errorf("addRow(%q): stored %q, want the input preserved verbatim", cell, got)
+			}
+		})
+	}
+}
+
+// TestTableAddRowRendersMarkupWithPercent covers the interaction of the two
+// fixes above in a single cell.
+func TestTableAddRowRendersMarkupWithPercent(t *testing.T) {
+	t.Parallel()
+
+	tbl := &table{}
+	tbl.addRow("@G{100%done}")
+
+	got := tbl.rows[0][0]
+	if strings.Contains(got, "@") {
+		t.Errorf("stored %q, which still contains unrendered markup", got)
+	}
+	if stripped := tbl._stripColor(got); stripped != "100%done" {
+		t.Errorf("stripped to %q, want %q", stripped, "100%done")
 	}
 }
 

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -115,10 +115,8 @@ func (t *table) setHeader(headers ...string) {
 
 func (t *table) addRow(cols ...string) {
 	t._assertValidRowWidth(len(cols))
-	if !ansi.ShouldColorize(os.Stdout) {
-		for i := range cols {
-			cols[i] = t._stripColor(cols[i])
-		}
+	for i := range cols {
+		cols[i] = t._renderCell(cols[i])
 	}
 	t.rows = append(t.rows, cols)
 }
@@ -243,6 +241,13 @@ func (t *table) _printCell(cell string, spaces int) {
 	}
 
 	_, _ = os.Stdout.Write(spaceBuf)
+}
+
+// _renderCell interprets go-ansi markup in cell content. go-ansi only renders
+// markup found in the format string, so the cell has to be passed as the format
+// itself; any '%' it contains is escaped first so it is not consumed as a verb.
+func (t *table) _renderCell(cell string) string {
+	return t._sprintf(strings.ReplaceAll(cell, "%", "%%"))
 }
 
 func (t *table) _sprintf(f string, args ...any) string {


### PR DESCRIPTION
## Problem

Table cells carrying go-ansi markup reached stdout as literal text. `safe versions` printed `@G{alive}` instead of a green `alive`, and `safe option` printed `@G{true}`.

go-ansi only interprets markup found in the **format** string. `table.addRow` received markup as cell **content** and merely ran it through `_stripColor`, whose regex (`ui.go:15`) matches `\033[..m` — escape sequences that have *already* been rendered. Stripping an unrendered `@G{...}` template is a no-op, so the template printed verbatim.

Two consequences worth calling out:

- **This affected terminals too**, not just pipes. The markup was never rendered in either mode, so the colorized path was equally broken.
- **Column alignment was also wrong.** `_calcDisplayWidth` counted the template's braces and letters as visible characters — `@G{alive}` measured 9 wide instead of 5.

Two call sites also wrapped their cells in `fmt.Sprintf("%s", ...)`. In these files `fmt` is aliased to go-ansi, and `ansi.Sprintf("%s", "@G{alive}")` returns its argument unchanged — the wrapper does nothing except make a reader believe rendering already happens. Removed.

## Fix

`addRow` renders each cell via a new `_renderCell`, which hands the cell to go-ansi as the format string and escapes any `%` first so it is not consumed as a verb. The existing `_sprintf` helper already performs the render-then-strip step that respects `ShouldColorize`, so the non-TTY path keeps working as intended.

## Testing

`table_test.go` gains 12 sub-cases covering markup rendering, `%` preservation (`100%done`, `%s`, `%d%%`), and their interaction. Assertions are written to hold whether or not stdout is colorized: display width must equal the visible text, and stripping must yield it exactly. All 12 fail before this change.

`make check` passes — gofmt, vet, staticcheck, and the unit suite.

Integration suite (`ci/scripts/tests`, Vault 1.13.2, GPG disabled), same 1694 assertions in both runs:

| | before | after |
|---|---|---|
| passing | 1670 | 1685 |
| failing | 24 | 9 |

All 15 markup failures resolved, nothing newly failing. The remaining 9 are unrelated and pre-existing — 4 `safe rekey`, 4 `set key from file`, 1 `x509 reissue` — and are addressed separately.