### PR TITLE
Fix path escaping across tree operations

### DIFF
--- a/internal/cli/delete_guard_test.go
+++ b/internal/cli/delete_guard_test.go
@@ -1,0 +1,31 @@
+package cli
+
+// End-to-end coverage for the -r guard in cmdDelete, driven through the fake
+// Vault in vault_fake_test.go.
+
+import "testing"
+
+// safe rm -r on a path naming a key or a version must not recurse. The comment
+// at the guard says so; the condition must agree with it. Without the guard the
+// recursive branch drops the key and the version and deletes the whole subtree.
+func TestCmdDeleteRecurseIgnoredForKeyOrVersion(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	fv.set("secret/foo", map[string]string{"key": "v", "other": "keep"})
+	fv.set("secret/foo/a", map[string]string{"k": "1"})
+	fv.set("secret/foo/b", map[string]string{"k": "2"})
+
+	c := newTestCLI(t)
+	c.opt.Delete.Recurse = true
+	c.opt.Delete.Force = true
+	_ = c.cmdDelete("delete", "secret/foo:key^2")
+
+	for _, path := range []string{"secret/foo/a", "secret/foo/b"} {
+		if fv.get(path) == nil {
+			t.Errorf("%s was deleted; -r must not recurse when the path names a key or version", path)
+		}
+	}
+	if kv := fv.get("secret/foo"); kv == nil || kv["other"] != "keep" {
+		t.Errorf("secret/foo = %v, want its other key intact", kv)
+	}
+}

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -1,0 +1,50 @@
+package cli
+
+// End-to-end coverage for safe import replaying a v1 export, driven through
+// the fake Vault in vault_fake_test.go.
+
+import (
+	"os"
+	"testing"
+)
+
+// withStdin replaces os.Stdin with a pipe carrying s for the test's duration,
+// so a command that reads stdin can be driven from a literal.
+func withStdin(t *testing.T, s string) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	go func() {
+		_, _ = w.WriteString(s)
+		_ = w.Close()
+	}()
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = orig
+		_ = r.Close()
+	})
+}
+
+// The keys of a v1 export are literal Vault paths. Write reads its argument as
+// path:key syntax, so a colon-bearing path has to be encoded on the way back
+// in. Without that the whole import aborts on the first such path, taking the
+// colon-free secrets that follow with it.
+func TestCmdImportColonBearingPath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	withStdin(t, `{"secret/o:d":{"k":"v"},"secret/plain":{"k":"w"}}`)
+
+	c := newTestCLI(t)
+	if err := c.cmdImport("import"); err != nil {
+		t.Fatalf("cmdImport: %v", err)
+	}
+	if kv := fv.get("secret/o:d"); kv["k"] != "v" {
+		t.Errorf("secret/o:d = %v, want map[k:v]", kv)
+	}
+	if kv := fv.get("secret/plain"); kv["k"] != "w" {
+		t.Errorf("secret/plain = %v, want map[k:w]", kv)
+	}
+}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -532,7 +532,7 @@ func (c *CLI) cmdDelete(command string, args ...string) error {
 		_, key, version := vault.ParsePath(path)
 
 		//Ignore -r if path has a version or key because that seems like a mistake
-		if opt.Delete.Recurse && (key == "" || version > 0) {
+		if opt.Delete.Recurse && key == "" && version == 0 {
 			if !opt.Delete.Force && !recursively(verb, path) {
 				continue /* skip this command, process the next */
 			}
@@ -974,7 +974,7 @@ func (c *CLI) cmdImport(command string, args ...string) error {
 // moveCopyParams captures the per-command differences between move and copy.
 // op is the underlying vault operation (v.Move or v.Copy); verb names the
 // command for messages and the recurse prompt; guardRecurseVersion enables the
-// copy-only check that forbids recursively copying a versioned source.
+// check that forbids recursively moving or copying a versioned source.
 type moveCopyParams struct {
 	verb                string
 	recurse             bool
@@ -1003,7 +1003,7 @@ func (c *CLI) moveCopy(v *vault.Vault, args []string, p moveCopyParams) error {
 	}
 
 	if p.guardRecurseVersion && p.recurse && vault.PathHasVersion(args[0]) {
-		return fmt.Errorf("Cannot recursively copy a path with specific version")
+		return fmt.Errorf("Cannot recursively %s a path with specific version", p.verb)
 	}
 
 	opts := vault.MoveCopyOpts{
@@ -1045,11 +1045,12 @@ func (c *CLI) cmdMove(command string, args ...string) error {
 
 	v := connect(true)
 	return c.moveCopy(v, args, moveCopyParams{
-		verb:    "move",
-		recurse: opt.Move.Recurse,
-		force:   opt.Move.Force,
-		deep:    opt.Move.Deep,
-		op:      v.Move,
+		verb:                "move",
+		recurse:             opt.Move.Recurse,
+		force:               opt.Move.Force,
+		deep:                opt.Move.Deep,
+		guardRecurseVersion: true,
+		op:                  v.Move,
 	})
 }
 

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -844,7 +844,9 @@ func (c *CLI) cmdImport(command string, args ...string) error {
 			return err
 		}
 		for path, s := range data {
-			err = v.Write(path, s)
+			//The keys of an export are literal Vault paths; Write reads its
+			// argument as path:key syntax.
+			err = v.Write(vault.EncodePath(path, "", 0), s)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/vault_fake_test.go
+++ b/internal/cli/vault_fake_test.go
@@ -1,0 +1,122 @@
+package cli
+
+// A fake Vault that command handlers can actually reach. connect() builds its
+// client from VAULT_ADDR and VAULT_TOKEN (cli.go), so an httptest server plus
+// t.Setenv is enough to drive a command end to end without a real Vault.
+//
+// Call newCLIFake after isolateHome: isolateHome clears VAULT_ADDR and
+// VAULT_TOKEN, which would undo the values set here.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// cliFakeVault serves a minimal KV v1 API: mount discovery plus GET, PUT,
+// DELETE and LIST under /v1/secret/. Paths are stored verbatim, so a secret
+// name containing a colon round-trips unchanged.
+type cliFakeVault struct {
+	mu   sync.Mutex
+	data map[string]map[string]string
+}
+
+func (f *cliFakeVault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if strings.HasPrefix(r.URL.Path, "/v1/sys/internal/ui/mounts") {
+		_, _ = w.Write([]byte(`{"data":{"secret/":{"type":"kv","options":{"version":"1"}}}}`))
+		return
+	}
+	if !strings.HasPrefix(r.URL.Path, "/v1/secret/") {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":[]}`))
+		return
+	}
+
+	path := strings.TrimPrefix(r.URL.Path, "/v1/")
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	switch {
+	case r.URL.Query().Get("list") == "true":
+		keys := f.childrenOf(path)
+		if len(keys) == 0 {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errors":[]}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"keys": keys}})
+
+	case r.Method == http.MethodPut || r.Method == http.MethodPost:
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"errors":["malformed body"]}`))
+			return
+		}
+		f.data[path] = body
+		w.WriteHeader(http.StatusNoContent)
+
+	case r.Method == http.MethodDelete:
+		delete(f.data, path)
+		w.WriteHeader(http.StatusNoContent)
+
+	default:
+		kv, ok := f.data[path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errors":[]}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": kv})
+	}
+}
+
+// childrenOf returns the immediate children of a directory, with a trailing
+// slash on those that are themselves directories. Callers hold f.mu.
+func (f *cliFakeVault) childrenOf(dir string) []string {
+	seen := map[string]bool{}
+	keys := []string{}
+	for stored := range f.data {
+		rest, ok := strings.CutPrefix(stored, dir+"/")
+		if !ok {
+			continue
+		}
+		if i := strings.Index(rest, "/"); i >= 0 {
+			rest = rest[:i+1]
+		}
+		if !seen[rest] {
+			seen[rest] = true
+			keys = append(keys, rest)
+		}
+	}
+	return keys
+}
+
+// newCLIFake starts a fake Vault and points VAULT_ADDR and VAULT_TOKEN at it.
+func newCLIFake(t *testing.T) *cliFakeVault {
+	t.Helper()
+	fv := &cliFakeVault{data: map[string]map[string]string{}}
+	srv := httptest.NewServer(fv)
+	t.Cleanup(srv.Close)
+	t.Setenv("VAULT_ADDR", srv.URL)
+	t.Setenv("VAULT_TOKEN", "test-token")
+	return fv
+}
+
+// set stores a secret at a literal Vault path.
+func (f *cliFakeVault) set(path string, kv map[string]string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.data[path] = kv
+}
+
+// get returns the secret at a literal Vault path, or nil if it is absent.
+func (f *cliFakeVault) get(path string) map[string]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.data[path]
+}

--- a/pkg/vault/colon_key_test.go
+++ b/pkg/vault/colon_key_test.go
@@ -123,3 +123,51 @@ func TestDrawEscapesColonKeys(t *testing.T) {
 		t.Errorf("Draw output %q should contain escaped key %q", out, `:odd\:key`)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Recursive roots that name a key or a version
+// ---------------------------------------------------------------------------
+
+// A recursive delete whose root names a key or a version is a user mistake.
+// It must be refused, not silently widened to the whole subtree.
+func TestDeleteTreeRejectsKeyOrVersionRoot(t *testing.T) {
+	t.Parallel()
+	for _, root := range []string{"secret/foo:key^2", "secret/foo:key", "secret/foo^2"} {
+		t.Run(root, func(t *testing.T) {
+			t.Parallel()
+			v, fv := newTestVault(t)
+			fv.set("secret/foo", map[string]string{"key": "v", "other": "keep"})
+			fv.set("secret/foo/a", map[string]string{"k": "1"})
+
+			err := v.DeleteTree(root, vault.DeleteOpts{})
+			if err == nil || !strings.Contains(err.Error(), "specific key or version") {
+				t.Fatalf("DeleteTree(%q) = %v, want a specific-key-or-version refusal", root, err)
+			}
+			if kv := mustGetSecret(t, fv, "secret/foo"); kv["other"] != "keep" {
+				t.Errorf("secret/foo was modified: %v", kv)
+			}
+			if kv := mustGetSecret(t, fv, "secret/foo/a"); kv["k"] != "1" {
+				t.Errorf("secret/foo/a was deleted: %v", kv)
+			}
+		})
+	}
+}
+
+// The same for a recursive copy or move: a versioned or keyed root silently
+// drops the version, so refuse it instead of relocating the whole subtree.
+func TestMoveCopyTreeRejectsKeyOrVersionRoot(t *testing.T) {
+	t.Parallel()
+	for _, root := range []string{"secret/src^2", "secret/src:k"} {
+		t.Run(root, func(t *testing.T) {
+			t.Parallel()
+			v, fv := newTestVault(t)
+			fv.set("secret/src/a", map[string]string{"k": "1"})
+
+			err := v.MoveCopyTree(root, "secret/dst", v.Copy, vault.MoveCopyOpts{Quiet: true})
+			if err == nil || !strings.Contains(err.Error(), "specific key or version") {
+				t.Fatalf("MoveCopyTree(%q) = %v, want a specific-key-or-version refusal", root, err)
+			}
+			secretAbsent(t, fv, "secret/dst/a")
+		})
+	}
+}

--- a/pkg/vault/colon_key_test.go
+++ b/pkg/vault/colon_key_test.go
@@ -250,6 +250,75 @@ func TestMoveCopyTreePreservesColonPaths(t *testing.T) {
 	}
 }
 
+// A user who escapes a literal colon must get a walk rooted at the real path.
+func TestDeleteTreeAcceptsEscapedRoot(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/od:d/leaf", map[string]string{"k": "v"})
+	fv.set("secret/od/other", map[string]string{"k": "v"})
+
+	if err := v.DeleteTree(`secret/od\:d`, vault.DeleteOpts{}); err != nil {
+		t.Fatalf("DeleteTree: %v", err)
+	}
+	secretAbsent(t, fv, "secret/od:d/leaf")
+	if kv := mustGetSecret(t, fv, "secret/od/other"); kv["k"] != "v" {
+		t.Errorf("unrelated secret/od/other was disturbed: %v", kv)
+	}
+}
+
+// The same at both ends of a recursive copy: source and destination roots may
+// each carry an escaped colon.
+func TestMoveCopyTreeAcceptsEscapedRoots(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/od:d/leaf", map[string]string{"k": "v"})
+
+	err := v.MoveCopyTree(`secret/od\:d`, `secret/ne\:w`, v.Copy, vault.MoveCopyOpts{Quiet: true})
+	if err != nil {
+		t.Fatalf("MoveCopyTree: %v", err)
+	}
+	if kv := mustGetSecret(t, fv, "secret/ne:w/leaf"); kv["k"] != "v" {
+		t.Errorf("secret/ne:w/leaf = %v, want map[k:v]", kv)
+	}
+}
+
+// The prefix replace in MoveCopyTree rewrites a walked path against the root.
+// Both must be in the same vocabulary, or a colon inside the replaced prefix
+// stops matching and the subtree lands somewhere else.
+func TestMoveCopyTreeReplacesColonBearingPrefix(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/o:d/a/b", map[string]string{"k": "v"})
+
+	err := v.MoveCopyTree(`secret/o\:d`, "secret/plain", v.Copy, vault.MoveCopyOpts{Quiet: true})
+	if err != nil {
+		t.Fatalf("MoveCopyTree: %v", err)
+	}
+	if kv := mustGetSecret(t, fv, "secret/plain/a/b"); kv["k"] != "v" {
+		t.Errorf("secret/plain/a/b = %v, want map[k:v]", kv)
+	}
+}
+
+// Clobber detection compares walked paths against walked paths. Both sides must
+// move to the escaped vocabulary together, or an existing colon-bearing secret
+// becomes invisible to the check and gets overwritten. This holds before and
+// after the root change; it must not flip.
+func TestMoveCopyTreeSkipIfExistsWithColonPaths(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/sub/o:d", map[string]string{"k": "new"})
+	fv.set("secret/dst/o:d", map[string]string{"k": "old"})
+
+	err := v.MoveCopyTree("secret/sub", "secret/dst", v.Copy,
+		vault.MoveCopyOpts{Quiet: true, SkipIfExists: true})
+	if err != nil {
+		t.Fatalf("MoveCopyTree: %v", err)
+	}
+	if kv := mustGetSecret(t, fv, "secret/dst/o:d"); kv["k"] != "old" {
+		t.Errorf("dst/o:d = %v, want map[k:old] (copy should have been refused)", kv)
+	}
+}
+
 // The tree walk names key nodes "<raw path>:<escaped key>". Basename splits at
 // the last colon not preceded by a backslash, which is always the join colon,
 // so a colon or caret in the path half cannot steal the key. This locks that

--- a/pkg/vault/colon_key_test.go
+++ b/pkg/vault/colon_key_test.go
@@ -339,6 +339,25 @@ func TestDrawEscapesColonPaths(t *testing.T) {
 	}
 }
 
+// Write reads its argument as path:key syntax, so a literal Vault path has to
+// be encoded before it is handed over. This is the contract safe import relies
+// on when it replays the keys of an export.
+func TestWriteRequiresEncodedColonPath(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+	s := vault.NewSecret()
+	if err := s.Set("k", "v", false); err != nil {
+		t.Fatalf("Secret.Set: %v", err)
+	}
+
+	if err := v.Write("secret/o:d", s); err == nil {
+		t.Error("Write of a raw colon path should be rejected as path:key syntax")
+	}
+	if err := v.Write(vault.EncodePath("secret/o:d", "", 0), s); err != nil {
+		t.Errorf("Write of an encoded colon path: %v", err)
+	}
+}
+
 // The tree walk names key nodes "<raw path>:<escaped key>". Basename splits at
 // the last colon not preceded by a backslash, which is always the join colon,
 // so a colon or caret in the path half cannot steal the key. This locks that

--- a/pkg/vault/colon_key_test.go
+++ b/pkg/vault/colon_key_test.go
@@ -319,6 +319,26 @@ func TestMoveCopyTreeSkipIfExistsWithColonPaths(t *testing.T) {
 	}
 }
 
+// tree display escapes path segments and the printed root, not just keys, so
+// what is on screen is what a user can paste back into another command.
+func TestDrawEscapesColonPaths(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/o:d/leaf", map[string]string{"k": "v"})
+
+	s, err := v.ConstructSecrets("secret/o:d", vault.TreeOpts{FetchKeys: true})
+	if err != nil {
+		t.Fatalf("ConstructSecrets: %v", err)
+	}
+	out := s.Draw("secret/o:d", false, true)
+	if !strings.Contains(out, `o\:d`) {
+		t.Errorf("Draw output %q should escape the colon in the path root", out)
+	}
+	if strings.Contains(out, "o:d/") && !strings.Contains(out, `o\:d/`) {
+		t.Errorf("Draw output %q printed an unescaped path segment", out)
+	}
+}
+
 // The tree walk names key nodes "<raw path>:<escaped key>". Basename splits at
 // the last colon not preceded by a backslash, which is always the join colon,
 // so a colon or caret in the path half cannot steal the key. This locks that

--- a/pkg/vault/colon_key_test.go
+++ b/pkg/vault/colon_key_test.go
@@ -171,3 +171,114 @@ func TestMoveCopyTreeRejectsKeyOrVersionRoot(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Colons and carets in the secret PATH (as opposed to the key)
+// ---------------------------------------------------------------------------
+
+// Paths() must escape the path it emits for keyless entries, so that what the
+// tree walk hands to callers parses back to the path it came from.
+func TestSecretsPathsEscapesColonPaths(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/tree/od:d", map[string]string{"k": "v"})
+
+	s, err := v.ConstructSecrets("secret/tree", vault.TreeOpts{
+		FetchKeys: false, SkipVersionInfo: true,
+	})
+	if err != nil {
+		t.Fatalf("ConstructSecrets: %v", err)
+	}
+
+	want := []string{`secret/tree/od\:d`}
+	if got := s.Paths(); !slices.Equal(got, want) {
+		t.Errorf("Paths() = %v, want %v", got, want)
+	}
+	secret, key, _ := vault.ParsePath(`secret/tree/od\:d`)
+	if secret != "secret/tree/od:d" || key != "" {
+		t.Errorf("ParsePath round-trip = (%q, %q), want (secret/tree/od:d, \"\")", secret, key)
+	}
+}
+
+// safe rm -r must delete the colon-bearing secret it walked, not the sibling
+// whose name is that path truncated at the colon.
+func TestDeleteTreePreservesColonPaths(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/tree/od:d", map[string]string{"k": "v"})
+	fv.set("secret/tree/od", map[string]string{"k2": "v2"})
+
+	if err := v.DeleteTree("secret/tree", vault.DeleteOpts{}); err != nil {
+		t.Fatalf("DeleteTree: %v", err)
+	}
+	secretAbsent(t, fv, "secret/tree/od:d")
+	secretAbsent(t, fv, "secret/tree/od")
+}
+
+// The caret twin: a walked path ending in ^<digits> must not be read back as a
+// version of its prefix.
+func TestDeleteTreePreservesCaretPaths(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/tree/od^2", map[string]string{"k": "v"})
+	fv.set("secret/tree/od", map[string]string{"k2": "v2"})
+
+	if err := v.DeleteTree("secret/tree", vault.DeleteOpts{}); err != nil {
+		t.Fatalf("DeleteTree: %v", err)
+	}
+	secretAbsent(t, fv, "secret/tree/od^2")
+	secretAbsent(t, fv, "secret/tree/od")
+}
+
+// safe cp -R must relocate a colon-bearing secret whole, and must not mistake
+// it for a key of its truncated sibling.
+func TestMoveCopyTreePreservesColonPaths(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/sub/od:d", map[string]string{"k": "v"})
+	fv.set("secret/sub/od", map[string]string{"k2": "v2"})
+
+	err := v.MoveCopyTree("secret/sub", "secret/dst", v.Copy, vault.MoveCopyOpts{Quiet: true})
+	if err != nil {
+		t.Fatalf("MoveCopyTree: %v", err)
+	}
+	if kv := mustGetSecret(t, fv, "secret/dst/od:d"); kv["k"] != "v" {
+		t.Errorf("dst/od:d = %v, want map[k:v]", kv)
+	}
+	if kv := mustGetSecret(t, fv, "secret/dst/od"); kv["k2"] != "v2" {
+		t.Errorf("dst/od = %v, want map[k2:v2]", kv)
+	}
+}
+
+// The tree walk names key nodes "<raw path>:<escaped key>". Basename splits at
+// the last colon not preceded by a backslash, which is always the join colon,
+// so a colon or caret in the path half cannot steal the key. This locks that
+// reasoning in; it holds before and after the Paths() change.
+func TestBasenameRecoversKeyFromColonPath(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ name, leaf, key string }{
+		{"colon in path", "od:d", "k"},
+		{"colon in path and key", "od:d", "o:k"},
+		{"caret in path", "od^2", "k"},
+		{"caret-digits path, colon key", "a^9", "o:k"},
+		{"backslash-colon in path", `od\:d`, "k"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			v, fv := newTestVault(t)
+			fv.set("secret/tree/"+tc.leaf, map[string]string{tc.key: "v"})
+
+			s, err := v.ConstructSecrets("secret/tree", vault.TreeOpts{FetchKeys: true})
+			if err != nil {
+				t.Fatalf("ConstructSecrets: %v", err)
+			}
+			if len(s) != 1 || len(s[0].Versions) == 0 {
+				t.Fatalf("walk returned %+v", s)
+			}
+			keys := s[0].Versions[len(s[0].Versions)-1].Data.Keys()
+			if !slices.Equal(keys, []string{tc.key}) {
+				t.Errorf("keys = %q, want [%q]", keys, tc.key)
+			}
+		})
+	}
+}

--- a/pkg/vault/find_value_matches_test.go
+++ b/pkg/vault/find_value_matches_test.go
@@ -286,8 +286,8 @@ func TestFindValueMatchesSortsByPathLessThan(t *testing.T) {
 	}
 }
 
-// Output escaping matches Secrets.Paths(): with --keys, path and key segments
-// have colons and carets escaped; in path mode the path is emitted bare.
+// Output escaping matches Secrets.Paths(): colons and carets are escaped in
+// the path segment and, with --keys, in the key segment too.
 func TestFindValueMatchesEscapingMatchesPaths(t *testing.T) {
 	t.Parallel()
 	v, fv := newTestVault(t)
@@ -315,7 +315,7 @@ func TestFindValueMatchesEscapingMatchesPaths(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindValueMatches(paths): %v", err)
 	}
-	if want := []string{"secret/odd:colon"}; !slices.Equal(got, want) {
+	if want := []string{`secret/odd\:colon`}; !slices.Equal(got, want) {
 		t.Errorf("FindValueMatches(bare path) = %v, want %v", got, want)
 	}
 }

--- a/pkg/vault/tree.go
+++ b/pkg/vault/tree.go
@@ -608,6 +608,9 @@ func (s Secrets) Draw(root string, color, secrets bool) string {
 	if root != strings.Trim(s[0].Path, "/") {
 		root = strings.TrimSuffix(root, "/") + "/"
 	}
+	//Escape the printed root for the same reason as the segments below: a
+	// literal ':' or '^' in it would otherwise read as key or version syntax.
+	root = EscapePathSegment(root)
 	if color {
 		root = ansi.Sprintf("@C{%s}", root)
 	}
@@ -633,6 +636,9 @@ func (s Secrets) printableTree(color, secrets bool, index int) *tree.Node {
 		dirFmt, secFmt = "@B{%s/}", "@G{%s}"
 	}
 
+	//Escape the segment so a literal ':' or '^' in a path name is not read
+	// back as key or version syntax.
+	thisName = EscapePathSegment(thisName)
 	if isSecret {
 		thisName = ansi.Sprintf(secFmt, thisName)
 	} else {

--- a/pkg/vault/tree.go
+++ b/pkg/vault/tree.go
@@ -466,18 +466,15 @@ func (t *secretTree) getWorkType(opts TreeOpts) uint16 {
 func (s Secrets) Paths() []string {
 	ret := make([]string, 0)
 
+	//SecretEntry.Path is a literal Vault path. Callers parse what comes back
+	// out of here, so emit safe's path:key syntax in both branches.
 	for i := range s {
 		if len(s[i].Versions) > 0 {
 			for _, key := range s[i].Versions[len(s[i].Versions)-1].Data.Keys() {
-				ret = append(ret,
-					fmt.Sprintf("%s:%s",
-						EscapePathSegment(s[i].Path),
-						EscapePathSegment(key),
-					),
-				)
+				ret = append(ret, EncodePath(s[i].Path, key, 0))
 			}
 		} else {
-			ret = append(ret, s[i].Path)
+			ret = append(ret, EncodePath(s[i].Path, "", 0))
 		}
 	}
 
@@ -1023,9 +1020,9 @@ func (v *Vault) FindValueMatches(paths []string, targetValues []string, showKeys
 	results = make([]string, 0, len(matches))
 	for _, match := range matches {
 		if showKeys {
-			results = append(results, EscapePathSegment(match.path)+":"+EscapePathSegment(match.key))
+			results = append(results, EncodePath(match.path, match.key, 0))
 		} else {
-			results = append(results, match.path)
+			results = append(results, EncodePath(match.path, "", 0))
 		}
 	}
 

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -334,12 +334,16 @@ func (v *Vault) DeleteTree(root string, opts DeleteOpts) error {
 	//A root naming a key or a version cannot be honoured by a recursion: the
 	// walk drops both and deletes everything beneath the secret. Refuse rather
 	// than delete more than was asked for.
-	if _, key, version := ParsePath(root); key != "" || version != 0 {
+	rawRoot, key, version := ParsePath(root)
+	if key != "" || version != 0 {
 		return fmt.Errorf("cannot recursively delete a specific key or version (%s)", root)
 	}
-	root = Canonicalize(root)
+	//ParsePath unescaped the root. The walk and the mount lookup want that
+	// literal Vault path; deleteEntireSecret parses its argument again, so it
+	// gets the escaped form back.
+	root = EncodePath(rawRoot, "", 0)
 
-	secrets, err := v.ConstructSecrets(root, TreeOpts{FetchKeys: false, SkipVersionInfo: true, AllowDeletedSecrets: true})
+	secrets, err := v.ConstructSecrets(rawRoot, TreeOpts{FetchKeys: false, SkipVersionInfo: true, AllowDeletedSecrets: true})
 	if err != nil {
 		return err
 	}
@@ -350,12 +354,12 @@ func (v *Vault) DeleteTree(root string, opts DeleteOpts) error {
 		}
 	}
 
-	mount, err := v.Client().MountPath(root)
+	mount, err := v.Client().MountPath(rawRoot)
 	if err != nil {
 		return err
 	}
 
-	if strings.Trim(root, "/") != strings.Trim(mount, "/") {
+	if strings.Trim(rawRoot, "/") != strings.Trim(mount, "/") {
 		err = v.deleteEntireSecret(root, opts.Destroy, opts.All)
 	}
 
@@ -739,21 +743,26 @@ func (v *Vault) Copy(oldpath, newpath string, opts MoveCopyOpts) error {
 func (v *Vault) MoveCopyTree(oldRoot, newRoot string, f func(string, string, MoveCopyOpts) error, opts MoveCopyOpts) error {
 	//Neither root can name a key or a version: the recursion drops both and
 	// relocates the whole subtree instead of the one thing that was named.
-	_, oldKey, oldVersion := ParsePath(oldRoot)
-	_, newKey, newVersion := ParsePath(newRoot)
+	rawOldRoot, oldKey, oldVersion := ParsePath(oldRoot)
+	rawNewRoot, newKey, newVersion := ParsePath(newRoot)
 	if oldKey != "" || newKey != "" || oldVersion != 0 || newVersion != 0 {
 		return fmt.Errorf("cannot recursively copy or move a specific key or version (%s -> %s)", oldRoot, newRoot)
 	}
-	oldRoot = Canonicalize(oldRoot)
-	newRoot = Canonicalize(newRoot)
+	//The walk wants the literal Vault paths ParsePath returned. The prefix
+	// replace below and f() both work in the escaped syntax that
+	// Secrets.Paths() emits, and EscapePathSegment substitutes byte by byte,
+	// so escaping a path and escaping its root prefix agree: the replace stays
+	// exact. Re-encoding also normalizes the roots the way the walk does.
+	oldRoot = EncodePath(rawOldRoot, "", 0)
+	newRoot = EncodePath(rawNewRoot, "", 0)
 
-	tree, err := v.ConstructSecrets(oldRoot, TreeOpts{FetchKeys: false, AllowDeletedSecrets: opts.Deep, SkipVersionInfo: true})
+	tree, err := v.ConstructSecrets(rawOldRoot, TreeOpts{FetchKeys: false, AllowDeletedSecrets: opts.Deep, SkipVersionInfo: true})
 	if err != nil {
 		return err
 	}
 	if opts.SkipIfExists {
 		//Writing one secret over a deleted secret isn't clobbering. Completely overwriting a set of deleted secrets would be
-		newTree, err := v.ConstructSecrets(newRoot, TreeOpts{FetchKeys: false, AllowDeletedSecrets: !opts.Deep, SkipVersionInfo: true})
+		newTree, err := v.ConstructSecrets(rawNewRoot, TreeOpts{FetchKeys: false, AllowDeletedSecrets: !opts.Deep, SkipVersionInfo: true})
 		if err != nil && !IsNotFound(err) {
 			return err
 		}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -331,6 +331,12 @@ func (v *Vault) verifySecretExists(path string) error {
 // DeleteTree recursively deletes the leaf nodes beneath the given root until
 // the root has no children, and then deletes that.
 func (v *Vault) DeleteTree(root string, opts DeleteOpts) error {
+	//A root naming a key or a version cannot be honoured by a recursion: the
+	// walk drops both and deletes everything beneath the secret. Refuse rather
+	// than delete more than was asked for.
+	if _, key, version := ParsePath(root); key != "" || version != 0 {
+		return fmt.Errorf("cannot recursively delete a specific key or version (%s)", root)
+	}
 	root = Canonicalize(root)
 
 	secrets, err := v.ConstructSecrets(root, TreeOpts{FetchKeys: false, SkipVersionInfo: true, AllowDeletedSecrets: true})
@@ -731,6 +737,13 @@ func (v *Vault) Copy(oldpath, newpath string, opts MoveCopyOpts) error {
 // This function will get confused about 'secret:key' syntax, so don't let those
 // get routed here - they don't make sense for a recursion anyway.
 func (v *Vault) MoveCopyTree(oldRoot, newRoot string, f func(string, string, MoveCopyOpts) error, opts MoveCopyOpts) error {
+	//Neither root can name a key or a version: the recursion drops both and
+	// relocates the whole subtree instead of the one thing that was named.
+	_, oldKey, oldVersion := ParsePath(oldRoot)
+	_, newKey, newVersion := ParsePath(newRoot)
+	if oldKey != "" || newKey != "" || oldVersion != 0 || newVersion != 0 {
+		return fmt.Errorf("cannot recursively copy or move a specific key or version (%s -> %s)", oldRoot, newRoot)
+	}
 	oldRoot = Canonicalize(oldRoot)
 	newRoot = Canonicalize(newRoot)
 


### PR DESCRIPTION
Two path vocabularies exist side by side in `safe`: the mini-language
(`path:key^version`, escaped per segment) and the raw Vault path the tree
walk stores. Each commit here fixes one place where a value in one
vocabulary was handed to something expecting the other.

## Behavior change

`DeleteTree` and `MoveCopyTree` now return an error when a root names a
key or a version. This enforces an intent the code documented but never
checked (`vault.go:730-732`: *"This function will get confused about
'secret:key' syntax, so don't let those get routed here"*). Callers
passing such a root previously got silent misbehavior.

`safe mv -r` also gains the versioned-source check that only `safe cp -r`
had.

## Why the guard lands first

The `-r` guard in `cmdDelete` read `key == "" || version > 0` — the
negation of what its comment describes. It was harmless only because
`DeleteTree` could not resolve a key- or version-bearing root and did
nothing. Commit 2 makes it resolvable, which would turn that latent
inversion into silent mass deletion.

Measured on a real Vault 1.13.2 with a fixture of `secret/foo` (two
versions, two keys) plus `secret/foo/bar` and `secret/foo/baz`, running
`safe rm -r -f 'secret/foo:key^2'`:

| Build | Result |
|-------|--------|
| `develop` | exit 0, **3/3 secrets survive** (silent no-op) |
| commit 2 with the guard removed | exit 0, **0/3 survive** — entire subtree destroyed |
| every commit on this branch | narrow delete or refusal, **3/3 survive** |

The middle row is a deliberately constructed counterfactual, not a commit
on this branch. It is what commit 2 would do without commit 0, and it is
why the guard is ordered first and applied in `pkg/vault` as well as the
CLI — the package is importable, so the CLI-side fix alone would leave
the hazard for other consumers.

`safe mv -r 'secret/foo^2'` behaves identically: 0/3 survive without the
guard, refused with it.

The A/B was run against a built binary at all five commits. No commit in
the series permits the deletion.

## Verification

- `make check` green.
- Integration suite, Vault 1.13.2: **1715 passing, 9 failing** — byte-identical
  failure set to `develop` at the same commit. The 9 are pre-existing stale
  expectations, fixed separately in #11.
- `safe rm -r 'secret/foo:key'` now correctly ignores `-r` and deletes only
  that key, leaving sibling keys and child secrets intact.
