### PR TITLE
Cancel rekey on EOF and fix stale test expectations

### DIFF
--- a/ci/scripts/tests
+++ b/ci/scripts/tests
@@ -884,7 +884,7 @@ EOF
   (run; ${SAFE_CMD} set secret/from-file/content nothing@non-existent-file 2>t/home/got) ; exitok $? 1
   now checking the output error
   cat > t/home/want<<EOF ; diffok
-!! Failed to read contents of non-existent-file: open non-existent-file: no such file or directory
+!! failed to read contents of non-existent-file: open non-existent-file: no such file or directory
 EOF
 
   now checking that we did not set a secret in vault
@@ -895,7 +895,7 @@ EOF
 
   now checking the output error
   cat > t/home/want<<EOF ; diffok
-!! No file specified: expecting no-file@<filename>
+!! no file specified: expecting no-file@<filename>
 EOF
 
   now checking that we did not set a secret in vault

--- a/ci/scripts/tests
+++ b/ci/scripts/tests
@@ -3124,9 +3124,13 @@ EOF
   ne "$(${SAFE_CMD} x509 show secret/reissue/orig | grep 'valid from')" \
       "$(${SAFE_CMD} x509 show secret/reissue/cert | grep 'valid from')"
 
-  now checking that reissue does not change certificate attributes, other than ttl
-  eq_or_diff "$(${SAFE_CMD} x509 show secret/reissue/orig | grep -Ev 'secret/re|valid from|expires in|serial')" \
-              "$(${SAFE_CMD} x509 show secret/reissue/cert | grep -Ev 'secret/re|valid from|expires in|serial')"
+  now checking that reissue does not change certificate attributes, other than ttl and key size
+  eq_or_diff "$(${SAFE_CMD} x509 show secret/reissue/orig | grep -Ev 'secret/re|valid from|expires in|serial|^  key:')" \
+              "$(${SAFE_CMD} x509 show secret/reissue/cert | grep -Ev 'secret/re|valid from|expires in|serial|^  key:')"
+
+  now checking that reissue applied the requested key size
+  eq "$(${SAFE_CMD} x509 show secret/reissue/cert | grep '^  key:')" \
+     "  key: RSA (1024 bit)"
 
 
 

--- a/ci/scripts/tests
+++ b/ci/scripts/tests
@@ -1927,7 +1927,6 @@ secret/export/robot:
 secret/export/a/b/c:
   subkey: the-value-given
 EOF
-EOF
 
 
 

--- a/ci/scripts/tests
+++ b/ci/scripts/tests
@@ -2081,7 +2081,7 @@ EOF
   sed -i -e 's/must specified/must be specified/' t/home/got
   cat <<'EOF' > t/home/want ; diffok
 Vault rekey canceled successfully
-!! Key submission failed: no key provided
+!! key submission failed: no key provided
 EOF
 
   now after failures to rekey, the cancel command was sent to reset the rekey

--- a/pkg/prompt/exported_test.go
+++ b/pkg/prompt/exported_test.go
@@ -1,6 +1,8 @@
 package prompt
 
 import (
+	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -119,6 +121,106 @@ func TestSecure_NonTTY(t *testing.T) {
 	want := "s3cr3t"
 	if got != want {
 		t.Errorf("Secure() non-TTY = %q, want %q", got, want)
+	}
+}
+
+// TestNormalE verifies that NormalE returns the line read from the injected
+// reader, and reports io.EOF instead of exiting once the reader is exhausted.
+//
+// No t.Parallel — test mutates the package-level `in` reader.
+func TestNormalE(t *testing.T) {
+	SetReader(strings.NewReader("hunter2\n"))
+	defer SetReader(nil)
+
+	got, err := NormalE("Password: ")
+	if err != nil {
+		t.Fatalf("NormalE() error = %v, want nil", err)
+	}
+	if got != "hunter2" {
+		t.Errorf("NormalE() = %q, want %q", got, "hunter2")
+	}
+
+	got, err = NormalE("Password: ")
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("NormalE() at EOF: error = %v, want io.EOF", err)
+	}
+	if got != "" {
+		t.Errorf("NormalE() at EOF = %q, want empty string", got)
+	}
+}
+
+// TestReadLine_Exported verifies the exported wrapper reads through the
+// injection seam and surfaces io.EOF rather than exiting.
+func TestReadLine_Exported(t *testing.T) {
+	SetReader(strings.NewReader("value\n"))
+	defer SetReader(nil)
+
+	got, err := ReadLine()
+	if err != nil {
+		t.Fatalf("ReadLine() error = %v, want nil", err)
+	}
+	if got != "value" {
+		t.Errorf("ReadLine() = %q, want %q", got, "value")
+	}
+
+	if _, err = ReadLine(); !errors.Is(err, io.EOF) {
+		t.Fatalf("ReadLine() at EOF: error = %v, want io.EOF", err)
+	}
+}
+
+// TestSecureE_NonTTY verifies the non-TTY branch of SecureE via subprocess
+// re-exec, for the same reason as TestSecure_NonTTY: the child's stdin is a
+// pipe, so isatty.IsTerminal reports false deterministically.
+//
+// The exhausted-reader case is the point of SecureE. The child exiting 0 after
+// reporting io.EOF is what proves SecureE returned to its caller instead of
+// calling os.Exit and skipping every pending defer.
+func TestSecureE_NonTTY(t *testing.T) {
+	// Guard: the child process runs the actual SecureE call.
+	if mode := os.Getenv("SAFE_TEST_SECUREE_NONTTY"); mode != "" {
+		input := "s3cr3t\n"
+		if mode == "eof" {
+			input = ""
+		}
+		SetReader(strings.NewReader(input))
+
+		value, err := SecureE("Password: ")
+		switch {
+		case errors.Is(err, io.EOF):
+			os.Stdout.WriteString("EOF\n")
+		case err != nil:
+			os.Stdout.WriteString("ERR " + err.Error() + "\n")
+		default:
+			os.Stdout.WriteString(value + "\n")
+		}
+		os.Exit(0)
+	}
+
+	tests := []struct {
+		name string
+		mode string
+		want string
+	}{
+		{"returns typed value", "value", "s3cr3t"},
+		{"returns EOF on exhausted input", "eof", "EOF"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=TestSecureE_NonTTY")
+			cmd.Env = append(os.Environ(), "SAFE_TEST_SECUREE_NONTTY="+tt.mode)
+			// Attach a pipe as stdin so isatty reports false in the child.
+			cmd.Stdin = strings.NewReader("")
+
+			out, err := cmd.Output()
+			if err != nil {
+				t.Fatalf("child process failed: %v", err)
+			}
+
+			if got := strings.TrimRight(string(out), "\n"); got != tt.want {
+				t.Errorf("SecureE() non-TTY = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -25,21 +25,32 @@ func SetReader(r io.Reader) {
 	in = bufio.NewReader(r)
 }
 
-func readline() string {
+// readLine reads a single line from the input reader without terminating the
+// process. It returns io.EOF only when the input is exhausted and no data
+// remains; a final line without a trailing newline is returned with a nil
+// error, because ReadString hands back the data it read alongside io.EOF.
+func readLine() (string, error) {
 	if in == nil {
 		in = bufio.NewReader(os.Stdin)
 	}
 
 	s, err := in.ReadString('\n')
-	// ReadString returns any data read before the error, so a final line
-	// without a trailing newline arrives together with io.EOF. Trim and
-	// return that value; only treat EOF as end-of-input when no data remains.
 	line := strings.TrimSuffix(strings.TrimSuffix(s, "\r\n"), "\n")
 	if err != nil {
+		if errors.Is(err, io.EOF) && line != "" {
+			return line, nil
+		}
+		// Discard any partial data on a real read error so it cannot be
+		// mistaken for a complete value.
+		return "", err
+	}
+	return line, nil
+}
+
+func readline() string {
+	line, err := readLine()
+	if err != nil {
 		if errors.Is(err, io.EOF) {
-			if line != "" {
-				return line
-			}
 			// stdin closed or pipe ended with no further input; print a
 			// newline so the terminal is left on a clean line, then exit.
 			// Without this the caller loops forever prompting for input
@@ -55,9 +66,35 @@ func readline() string {
 	return line
 }
 
+// readPassword prompts on stderr and reads a line with terminal echo disabled.
+// The caller must have established that stdin is a terminal.
+func readPassword(label string, args ...any) (string, error) {
+	_, _ = ansi.Fprintf(os.Stderr, label, args...)
+	b, err := term.ReadPassword(int(os.Stdin.Fd()))
+	_, _ = ansi.Fprintf(os.Stderr, "\n")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// ReadLine reads a line of input, returning io.EOF when the input is exhausted
+// instead of exiting the process. Use it when the caller has cleanup to run
+// before it gives up on the input.
+func ReadLine() (string, error) {
+	return readLine()
+}
+
 func Normal(label string, args ...any) string {
 	_, _ = ansi.Fprintf(os.Stderr, label, args...)
 	return readline()
+}
+
+// NormalE is Normal, except that it returns io.EOF when the input is exhausted
+// rather than exiting the process.
+func NormalE(label string, args ...any) (string, error) {
+	_, _ = ansi.Fprintf(os.Stderr, label, args...)
+	return readLine()
 }
 
 func Secure(label string, args ...any) string {
@@ -65,8 +102,17 @@ func Secure(label string, args ...any) string {
 		return readline()
 	}
 
-	_, _ = ansi.Fprintf(os.Stderr, label, args...)
-	b, _ := term.ReadPassword(int(os.Stdin.Fd()))
-	_, _ = ansi.Fprintf(os.Stderr, "\n")
-	return string(b)
+	b, _ := readPassword(label, args...)
+	return b
+}
+
+// SecureE is Secure, except that it returns io.EOF when the input is exhausted
+// rather than exiting the process. It also surfaces terminal read errors that
+// Secure discards.
+func SecureE(label string, args ...any) (string, error) {
+	if !isatty.IsTerminal(os.Stdin.Fd()) {
+		return readLine()
+	}
+
+	return readPassword(label, args...)
 }

--- a/pkg/prompt/prompt_test.go
+++ b/pkg/prompt/prompt_test.go
@@ -2,6 +2,8 @@ package prompt
 
 import (
 	"bufio"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 )
@@ -45,5 +47,68 @@ func TestReadlineConsumesSequentially(t *testing.T) {
 		if got := readline(); got != want {
 			t.Errorf("readline() = %q, want %q", got, want)
 		}
+	}
+}
+
+// TestReadLine covers the error-returning reader used by callers that must run
+// cleanup when the input ends. It reads the same values as readline, and hands
+// back io.EOF where readline exits the process.
+func TestReadLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantEOF bool
+	}{
+		{"line with trailing newline", "hello\nrest\n", "hello", false},
+		{"crlf line ending", "hello\r\n", "hello", false},
+		{"final line without newline", "secret", "secret", false},
+		{"empty line followed by more input", "\nnext\n", "", false},
+		{"exhausted input reports EOF", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in = bufio.NewReader(strings.NewReader(tt.input))
+			defer func() { in = nil }()
+
+			got, err := readLine()
+			if tt.wantEOF {
+				if !errors.Is(err, io.EOF) {
+					t.Fatalf("readLine() error = %v, want io.EOF", err)
+				}
+			} else if err != nil {
+				t.Fatalf("readLine() error = %v, want nil", err)
+			}
+			if got != tt.want {
+				t.Errorf("readLine() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReadLineEOFAfterLastValue verifies the final unterminated value arrives
+// with no error and the read that follows it reports io.EOF. Losing that value
+// would reintroduce the dropped-input bug the trailing-newline handling fixes.
+func TestReadLineEOFAfterLastValue(t *testing.T) {
+	in = bufio.NewReader(strings.NewReader("first\nlast"))
+	defer func() { in = nil }()
+
+	for _, want := range []string{"first", "last"} {
+		got, err := readLine()
+		if err != nil {
+			t.Fatalf("readLine() error = %v, want nil", err)
+		}
+		if got != want {
+			t.Fatalf("readLine() = %q, want %q", got, want)
+		}
+	}
+
+	got, err := readLine()
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("readLine() error = %v, want io.EOF", err)
+	}
+	if got != "" {
+		t.Errorf("readLine() = %q, want empty string at EOF", got)
 	}
 }

--- a/pkg/vault/rekey.go
+++ b/pkg/vault/rekey.go
@@ -74,7 +74,16 @@ func (v *Vault) ReKey(unsealKeyCount, numToUnseal int, pgpKeys []string) ([]stri
 	givenKeys := make([]string, rekey.Remaining())
 
 	for i := range givenKeys {
-		givenKeys[i] = prompt.Secure("Unseal Key %d: ", i+1)
+		key, err := prompt.SecureE("Unseal Key %d: ", i+1)
+		if err != nil {
+			// stdin closed before every key arrived. Submit what we have
+			// anyway: the submission is rejected, the deferred cancel runs,
+			// and the server is left without a half-started rekey. Returning
+			// here instead would report a safe-side error for what is a
+			// Vault-side validation failure.
+			break
+		}
+		givenKeys[i] = key
 	}
 
 	rekeyDone, err := rekey.Submit(givenKeys...)

--- a/pkg/vault/rekey_test.go
+++ b/pkg/vault/rekey_test.go
@@ -1,0 +1,61 @@
+package vault_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/prompt"
+)
+
+// TestReKeyCancelsOnClosedStdin covers the abort path: stdin ends before the
+// required unseal keys have been entered. ReKey must return an error to its
+// caller so the deferred cancel runs, leaving no rekey in progress on the
+// server. A prompt that terminates the process instead would skip that defer
+// and strand the Vault mid-rekey.
+//
+// Both cases assert on the fake's rekey state rather than on the cancel call
+// itself: the fake only clears rekeyActive when the DELETE arrives, and only
+// the deferred cancel sends one here.
+func TestReKeyCancelsOnClosedStdin(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"no keys entered at all", ""},
+		{"stdin closes partway through the keys", "old-key-1\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, fv := newTestVault(t)
+			fv.threshold = 2
+			fv.rekeyRequired = 2
+
+			prompt.SetReader(strings.NewReader(tt.input))
+			t.Cleanup(func() { prompt.SetReader(nil) })
+
+			keys, err := v.ReKey(5, 3, nil)
+			if err == nil {
+				t.Fatalf("ReKey: expected an error, got keys %v", keys)
+			}
+			if keys != nil {
+				t.Errorf("ReKey: expected no keys on failure, got %v", keys)
+			}
+
+			// The message comes from the client rejecting an empty key, and
+			// is what the caller prints. Asserting on it keeps safe out of
+			// the business of inventing its own wording for this failure.
+			want := "key submission failed: no key provided"
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("ReKey error = %q, want it to contain %q", err, want)
+			}
+
+			if fv.rekeyNonce == "" {
+				t.Fatal("expected the rekey to have been started before it failed")
+			}
+			if fv.rekeyActive {
+				t.Error("rekey still in progress: the deferred cancel did not run")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Takes the integration suite from 9 failing assertions to **0**.

## The rekey regression

`pkg/prompt`'s `Normal` and `Secure` call `os.Exit(1)` on EOF. That skips
deferred functions — including the one in `rekey.go:40-72` whose entire
purpose is to cancel a half-started rekey:

```go
var shouldCancelRekey = true
defer func() {
    if shouldCancelRekey {
        v.cancelRekey(termState)
    }
}()
```

Closing stdin mid-rekey therefore left the Vault in a started-rekey state
with no cancel sent — exactly the condition the deferred call exists to
prevent.

The fix is additive: new `ReadLine`/`NormalE`/`SecureE` return `io.EOF`
instead of exiting. `Normal` and `Secure` keep their exit-on-EOF behavior
for their 16 other call sites, so nothing else changes.

## Stale suite expectations

Three assertions encoded output the code no longer produces:

- two error strings were lowercased to match Go convention (staticcheck
  ST1005) without the suite being updated

- the reissue check asserted a key size that `safe x509 reissue` is
  expected to be able to change

## Stray heredoc terminator

The export check closed its heredoc twice; the second `EOF` was parsed as
a command, printing `EOF: command not found` once per Vault version on
every run.

## Verification

- `make check` green.
- Integration suite, Vault 1.13.2: **1725 passing, 0 failing, exit 0.**
  Baseline on `develop` is 1715 passing, 9 failing.

Note for reviewers: this suite must be run from a short filesystem path.
gpg's UNIX socket is subject to the ~104-byte `sun_path` limit, and a
deep checkout path makes the GPG rekey section fail with
`Input/output error` — an artifact of the path, not of the code.
