### PR TITLE
Fix raw path handoffs to re-parsing callers

### DIFF
--- a/internal/cli/keygen.go
+++ b/internal/cli/keygen.go
@@ -39,6 +39,9 @@ func (c *CLI) cmdGen(command string, args ...string) error {
 		var path, key string
 		if vault.PathHasKey(args[0]) {
 			path, key, _ = vault.ParsePath(args[0])
+			//Read and Write parse their argument as path:key syntax, so the
+			// literal path ParsePath returned goes back to the escaped form.
+			path = vault.EncodePath(path, "", 0)
 			args = args[1:]
 		} else {
 			if len(args) < 2 {
@@ -96,6 +99,9 @@ func (c *CLI) cmdUuid(command string, args ...string) error {
 	var path, key string
 	if vault.PathHasKey(args[0]) {
 		path, key, _ = vault.ParsePath(args[0])
+		//Read and Write parse their argument as path:key syntax, so the literal
+		// path ParsePath returned goes back to the escaped form.
+		path = vault.EncodePath(path, "", 0)
 
 	} else {
 		path, key = args[0], "uuid"

--- a/internal/cli/keygen_colon_test.go
+++ b/internal/cli/keygen_colon_test.go
@@ -1,0 +1,93 @@
+package cli
+
+// End-to-end coverage for safe gen and safe uuid writing to a colon-bearing
+// path, driven through the fake Vault in vault_fake_test.go.
+//
+// Both commands split the path:key argument themselves, which unescapes the
+// path, and then hand the result to Read and Write, which split again. The
+// generated value has to land at the path the user named.
+
+import (
+	"testing"
+
+	"github.com/pborman/uuid"
+)
+
+// defaultGenPolicy mirrors the character policy the CLI sets before dispatching
+// gen; random() needs a non-empty policy.
+const defaultGenPolicy = "a-zA-Z0-9"
+
+// gen writes the new password into the colon-bearing secret, keeping the keys
+// already there and leaving the truncated sibling alone.
+func TestCmdGenColonBearingPath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	fv.set("secret/we:ird", map[string]string{"existing": "keep"})
+	fv.set("secret/we", map[string]string{"other": "untouched"})
+
+	c := newKeygenCLI(t)
+	c.opt.Gen.Policy = defaultGenPolicy
+	if err := c.cmdGen("gen", `secret/we\:ird:pw`); err != nil {
+		t.Fatalf("cmdGen: %v", err)
+	}
+
+	kv := fv.get("secret/we:ird")
+	if len(kv["pw"]) != 64 {
+		t.Errorf("secret/we:ird[pw] has length %d, want 64 (keys: %v)", len(kv["pw"]), kv)
+	}
+	if kv["existing"] != "keep" {
+		t.Errorf("secret/we:ird = %v, want the existing key preserved", kv)
+	}
+	if sib := fv.get("secret/we"); sib["other"] != "untouched" {
+		t.Errorf("sibling secret/we = %v, want map[other:untouched]", sib)
+	}
+}
+
+// The colon-free control: gen against an ordinary path still writes a password.
+func TestCmdGenPlainPath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	c.opt.Gen.Policy = defaultGenPolicy
+	if err := c.cmdGen("gen", "secret/plain:pw"); err != nil {
+		t.Fatalf("cmdGen: %v", err)
+	}
+	if kv := fv.get("secret/plain"); len(kv["pw"]) != 64 {
+		t.Errorf("secret/plain[pw] has length %d, want 64 (keys: %v)", len(kv["pw"]), kv)
+	}
+}
+
+// uuid has the same shape as gen and must reach the same path.
+func TestCmdUuidColonBearingPath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	fv.set("secret/we", map[string]string{"other": "untouched"})
+
+	c := newKeygenCLI(t)
+	if err := c.cmdUuid("uuid", `secret/we\:ird:id`); err != nil {
+		t.Fatalf("cmdUuid: %v", err)
+	}
+
+	kv := fv.get("secret/we:ird")
+	if uuid.Parse(kv["id"]) == nil {
+		t.Errorf("secret/we:ird[id] = %q, want a UUID (keys: %v)", kv["id"], kv)
+	}
+	if sib := fv.get("secret/we"); sib["other"] != "untouched" {
+		t.Errorf("sibling secret/we = %v, want map[other:untouched]", sib)
+	}
+}
+
+// The colon-free control: uuid against an ordinary path still writes a UUID.
+func TestCmdUuidPlainPath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	if err := c.cmdUuid("uuid", "secret/plain:id"); err != nil {
+		t.Fatalf("cmdUuid: %v", err)
+	}
+	if kv := fv.get("secret/plain"); uuid.Parse(kv["id"]) == nil {
+		t.Errorf("secret/plain[id] = %q, want a UUID (keys: %v)", kv["id"], kv)
+	}
+}

--- a/internal/cli/revert_test.go
+++ b/internal/cli/revert_test.go
@@ -1,0 +1,63 @@
+package cli
+
+// End-to-end coverage for safe revert against a colon-bearing path, driven
+// through the fake Vault in vault_fake_test.go.
+//
+// The fake serves KV v1, which reports exactly one version per secret, so these
+// exercise the version lookup and its error paths rather than a rollback to an
+// older version.
+
+import (
+	"strings"
+	"testing"
+)
+
+// Reverting a colon-bearing path to its current version is a no-op that has to
+// find the secret first. Versions takes a literal path, so handing it the
+// escaped argument the user typed looks like a missing secret.
+func TestCmdRevertColonBearingPath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	fv.set("secret/we:ird", map[string]string{"k": "v"})
+
+	c := newTestCLI(t)
+	if err := c.cmdRevert("revert", `secret/we\:ird`, "1"); err != nil {
+		t.Fatalf("cmdRevert: %v", err)
+	}
+	if kv := fv.get("secret/we:ird"); kv["k"] != "v" {
+		t.Errorf("secret/we:ird = %v, want map[k:v]", kv)
+	}
+}
+
+// Asking for a version the colon-bearing secret does not have reports that
+// version as missing, not the secret: the lookup did reach the right secret.
+func TestCmdRevertColonBearingPathMissingVersion(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	fv.set("secret/we:ird", map[string]string{"k": "v"})
+
+	c := newTestCLI(t)
+	err := c.cmdRevert("revert", `secret/we\:ird`, "2")
+	if err == nil {
+		t.Fatal("expected an error reverting to a version that does not exist")
+	}
+	if !strings.Contains(err.Error(), "Version 2") {
+		t.Errorf("error %q should report version 2 as missing", err)
+	}
+}
+
+// The colon-free control: an ordinary revert to the current version still
+// succeeds and leaves the secret alone.
+func TestCmdRevertPlainPath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	fv.set("secret/plain", map[string]string{"k": "v"})
+
+	c := newTestCLI(t)
+	if err := c.cmdRevert("revert", "secret/plain", "1"); err != nil {
+		t.Fatalf("cmdRevert: %v", err)
+	}
+	if kv := fv.get("secret/plain"); kv["k"] != "v" {
+		t.Errorf("secret/plain = %v, want map[k:v]", kv)
+	}
+}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -634,12 +634,14 @@ func (c *CLI) cmdRevert(command string, args ...string) error {
 	//Check what the most recent version is to avoid setting the latest version if unnecessary.
 	// This should also catch if the secret is non-existent, or if we're targeting a destroyed,
 	// deleted, or non-existent version.
-	allVersions, err := v.Versions(args[0])
+	//Versions does not unescape its argument, so it takes the literal path
+	// ParsePath already produced rather than what the user typed.
+	allVersions, err := v.Versions(secret)
 	if err != nil {
 		return err
 	}
 	if len(allVersions) == 0 {
-		return fmt.Errorf("no versions found for %s", args[0])
+		return fmt.Errorf("no versions found for %s", secret)
 	}
 
 	destroyedErr := fmt.Errorf("Version %d of secret `%s' is destroyed", targetVersion, secret)
@@ -679,7 +681,9 @@ func (c *CLI) cmdRevert(command string, args ...string) error {
 		return err
 	}
 
-	err = v.Write(secret, toWrite)
+	//Write parses its argument as path:key syntax, so the literal path goes
+	// back to the escaped form before the revert is written.
+	err = v.Write(vault.EncodePath(secret, "", 0), toWrite)
 	if err != nil {
 		return err
 	}

--- a/pkg/vault/colon_key_test.go
+++ b/pkg/vault/colon_key_test.go
@@ -480,6 +480,49 @@ func TestCopyKeyToPlainPath(t *testing.T) {
 	}
 }
 
+// A deep move destroys the source once the copy is through. That destroy talks
+// to Vault directly, so an escaped source path has to be unescaped first or the
+// data the user asked to move is left behind.
+func TestDeepMoveDestroysColonBearingSource(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/we:ird", map[string]string{"k": "v"})
+	fv.set("secret/we", map[string]string{"k2": "keep"})
+
+	err := v.Move(`secret/we\:ird`, "secret/dst", vault.MoveCopyOpts{
+		Quiet: true, Deep: true, DeletedVersions: true,
+	})
+	if err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	if kv := mustGetSecret(t, fv, "secret/dst"); kv["k"] != "v" {
+		t.Errorf("secret/dst = %v, want map[k:v]", kv)
+	}
+	secretAbsent(t, fv, "secret/we:ird")
+	if kv := mustGetSecret(t, fv, "secret/we"); kv["k2"] != "keep" {
+		t.Errorf("sibling secret/we was destroyed: %v", kv)
+	}
+}
+
+// The colon-free control: a deep move of an ordinary path still destroys its
+// source.
+func TestDeepMoveDestroysPlainSource(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/plainsrc", map[string]string{"k": "v"})
+
+	err := v.Move("secret/plainsrc", "secret/dst", vault.MoveCopyOpts{
+		Quiet: true, Deep: true, DeletedVersions: true,
+	})
+	if err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	if kv := mustGetSecret(t, fv, "secret/dst"); kv["k"] != "v" {
+		t.Errorf("secret/dst = %v, want map[k:v]", kv)
+	}
+	secretAbsent(t, fv, "secret/plainsrc")
+}
+
 // Write reads its argument as path:key syntax, so a literal Vault path has to
 // be encoded before it is handed over. This is the contract safe import relies
 // on when it replays the keys of an export.

--- a/pkg/vault/colon_key_test.go
+++ b/pkg/vault/colon_key_test.go
@@ -339,6 +339,80 @@ func TestDrawEscapesColonPaths(t *testing.T) {
 	}
 }
 
+// Deleting one key of a colon-bearing secret must reach that secret. The
+// remaining keys stay, and the sibling whose name is the path truncated at the
+// colon is not touched.
+func TestDeleteKeyOfColonPath(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/we:ird", map[string]string{"alpha": "1", "beta": "2"})
+	fv.set("secret/we", map[string]string{"alpha": "untouched"})
+
+	if err := v.Delete(`secret/we\:ird:alpha`, vault.DeleteOpts{}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	kv := mustGetSecret(t, fv, "secret/we:ird")
+	if _, present := kv["alpha"]; present {
+		t.Errorf("secret/we:ird still has alpha: %v", kv)
+	}
+	if kv["beta"] != "2" {
+		t.Errorf("secret/we:ird = %v, want beta preserved", kv)
+	}
+	if kv := mustGetSecret(t, fv, "secret/we"); kv["alpha"] != "untouched" {
+		t.Errorf("sibling secret/we was modified: %v", kv)
+	}
+}
+
+// Deleting the last key of a colon-bearing secret removes the secret itself,
+// which routes through deleteEntireSecret — another re-parser.
+func TestDeleteLastKeyOfColonPath(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/we:ird", map[string]string{"alpha": "1"})
+	fv.set("secret/we", map[string]string{"alpha": "untouched"})
+
+	if err := v.Delete(`secret/we\:ird:alpha`, vault.DeleteOpts{}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	secretAbsent(t, fv, "secret/we:ird")
+	if kv := mustGetSecret(t, fv, "secret/we"); kv["alpha"] != "untouched" {
+		t.Errorf("sibling secret/we was deleted or modified: %v", kv)
+	}
+}
+
+// A key that is not in a colon-bearing secret is a key-not-found, not a
+// secret-not-found: the secret was located, the key was not.
+func TestDeleteMissingKeyOfColonPathReportsKeyNotFound(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/we:ird", map[string]string{"alpha": "1"})
+
+	err := v.Delete(`secret/we\:ird:nope`, vault.DeleteOpts{})
+	assertKeyNotFound(t, err)
+	if kv := mustGetSecret(t, fv, "secret/we:ird"); kv["alpha"] != "1" {
+		t.Errorf("secret/we:ird = %v, want map[alpha:1]", kv)
+	}
+}
+
+// The colon-free control: an ordinary key delete keeps working.
+func TestDeleteKeyOfPlainPath(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/plain", map[string]string{"alpha": "1", "beta": "2"})
+
+	if err := v.Delete("secret/plain:alpha", vault.DeleteOpts{}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	kv := mustGetSecret(t, fv, "secret/plain")
+	if _, present := kv["alpha"]; present {
+		t.Errorf("secret/plain still has alpha: %v", kv)
+	}
+	if kv["beta"] != "2" {
+		t.Errorf("secret/plain = %v, want beta preserved", kv)
+	}
+}
+
 // Write reads its argument as path:key syntax, so a literal Vault path has to
 // be encoded before it is handed over. This is the contract safe import relies
 // on when it replays the keys of an export.

--- a/pkg/vault/colon_key_test.go
+++ b/pkg/vault/colon_key_test.go
@@ -413,6 +413,73 @@ func TestDeleteKeyOfPlainPath(t *testing.T) {
 	}
 }
 
+// Copying a single key into a colon-bearing destination must write that
+// destination, not error out on the colon as if it named a key.
+func TestCopyKeyToColonPath(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/src", map[string]string{"k": "v"})
+
+	err := v.Copy(`secret/src:k`, `secret/de\:st:kk`, vault.MoveCopyOpts{Quiet: true})
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if kv := mustGetSecret(t, fv, "secret/de:st"); kv["kk"] != "v" {
+		t.Errorf("secret/de:st = %v, want map[kk:v]", kv)
+	}
+	secretAbsent(t, fv, "secret/de")
+}
+
+// The keys already in a colon-bearing destination survive the copy: the
+// destination has to be read back before the merged secret is written.
+func TestCopyKeyMergesIntoColonPath(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/src", map[string]string{"k": "v"})
+	fv.set("secret/de:st", map[string]string{"existing": "keep"})
+
+	err := v.Copy(`secret/src:k`, `secret/de\:st:kk`, vault.MoveCopyOpts{Quiet: true})
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	kv := mustGetSecret(t, fv, "secret/de:st")
+	if kv["kk"] != "v" || kv["existing"] != "keep" {
+		t.Errorf("secret/de:st = %v, want map[existing:keep kk:v]", kv)
+	}
+}
+
+// A whole-secret copy to a colon-bearing destination goes through the tree
+// walk, which takes literal paths, and must land at the same place.
+func TestCopySecretToColonPath(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/src", map[string]string{"k": "v"})
+
+	err := v.Copy("secret/src", `secret/de\:st`, vault.MoveCopyOpts{Quiet: true})
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if kv := mustGetSecret(t, fv, "secret/de:st"); kv["k"] != "v" {
+		t.Errorf("secret/de:st = %v, want map[k:v]", kv)
+	}
+}
+
+// The colon-free control: an ordinary single-key copy keeps working.
+func TestCopyKeyToPlainPath(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/src", map[string]string{"k": "v"})
+	fv.set("secret/dst", map[string]string{"existing": "keep"})
+
+	if err := v.Copy("secret/src:k", "secret/dst:kk", vault.MoveCopyOpts{Quiet: true}); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	kv := mustGetSecret(t, fv, "secret/dst")
+	if kv["kk"] != "v" || kv["existing"] != "keep" {
+		t.Errorf("secret/dst = %v, want map[existing:keep kk:v]", kv)
+	}
+}
+
 // Write reads its argument as path:key syntax, so a literal Vault path has to
 // be encoded before it is handed over. This is the contract safe import relies
 // on when it replays the keys of an export.

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -656,6 +656,10 @@ func (v *Vault) Copy(oldpath, newpath string, opts MoveCopyOpts) error {
 
 	srcPath, srcKey, srcVersion := ParsePath(oldpath)
 	dstPath, dstKey, dstVersion := ParsePath(newpath)
+	//ParsePath unescaped both paths. The tree walk and SecretEntry.Copy want
+	// those literal Vault paths, but Read and Write parse their argument again,
+	// so they get the destination back in the escaped syntax.
+	encodedDstPath := EncodePath(dstPath, "", 0)
 
 	if dstVersion != 0 {
 		return fmt.Errorf("copying a secret to a specific destination version is not supported")
@@ -683,7 +687,7 @@ func (v *Vault) Copy(oldpath, newpath string, opts MoveCopyOpts) error {
 			dstKey = srcKey
 		}
 
-		dstOrig, err := v.Read(dstPath)
+		dstOrig, err := v.Read(encodedDstPath)
 		if err != nil && !IsSecretNotFound(err) {
 			return err
 		}
@@ -732,7 +736,7 @@ func (v *Vault) Copy(oldpath, newpath string, opts MoveCopyOpts) error {
 	}
 
 	for i := range toWrite {
-		err := v.Write(dstPath, toWrite[i])
+		err := v.Write(encodedDstPath, toWrite[i])
 		if err != nil {
 			return err
 		}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -495,7 +495,11 @@ func (v *Vault) deleteEntireSecret(path string, destroy bool, all bool) error {
 
 func (v *Vault) deleteSpecificKey(path string) error {
 	secretPath, key, _ := ParsePath(path)
-	secret, err := v.Read(secretPath)
+	//ParsePath unescaped the secret path. Read, Write, and deleteEntireSecret
+	// all parse their argument again, so they need the escaped form back or
+	// they split a second time at a colon that belongs to the path.
+	encodedPath := EncodePath(secretPath, "", 0)
+	secret, err := v.Read(encodedPath)
 	if err != nil {
 		return err
 	}
@@ -510,9 +514,9 @@ func (v *Vault) deleteSpecificKey(path string) error {
 		//
 		//At some point, we should probably get Destroy routed into here so that we can destroy
 		// secrets through specifying keys
-		return v.deleteEntireSecret(secretPath, false, false)
+		return v.deleteEntireSecret(encodedPath, false, false)
 	}
-	return v.Write(secretPath, secret)
+	return v.Write(encodedPath, secret)
 }
 
 // DeleteVersions marks the given versions of the given secret as deleted for

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -827,7 +827,11 @@ func (v *Vault) Move(oldpath, newpath string, opts MoveCopyOpts) error {
 	}
 
 	if opts.Deep && opts.DeletedVersions {
-		err = v.client.DestroyAll(oldpath)
+		//DestroyAll goes straight to Vault, so it takes the literal path rather
+		// than the escaped syntax the caller wrote. Copy has already refused a
+		// deep move that names a key or a version, so nothing is dropped here.
+		rawOldPath, _, _ := ParsePath(oldpath)
+		err = v.client.DestroyAll(rawOldPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Completes the path-vocabulary work started in #10. `ParsePath` both splits
and unescapes, so everything it returns is a *raw* Vault path. Six call
sites then handed that raw path to something that parses its argument a
second time, splitting it at the wrong colon.

| Consumer | Wants | Why |
|----------|-------|-----|
| `Read`, `Write`, `deleteEntireSecret` | mini-language | each calls `ParsePath` |
| `Versions`, `client.Destroy*` | raw | vaultkv takes literal paths |
| `ConstructSecrets` | raw | the tree walk stores literal paths |

## Measured behavior

Fixture is a single secret at the literal Vault path `secret/we:ird`,
which the mini-language writes as `secret/we\:ird`. Vault 1.13.2, KV v2.

| Command | Before | After |
|---------|--------|-------|
| `rm 'secret/we\:ird:alpha'` | exit 0, **key not deleted** | key deleted, sibling kept |
| `mv --deep 'secret/we\:ird' dst` | exit 0, **source left intact** | source destroyed |
| `cp 'secret/src:k' 'secret/de\:st:kk'` | `cannot write to paths in /path:key notation` | copies |
| `revert 'secret/we\:ird' 1` | `no secret exists at path` | reverts |
| `gen 'secret/we\:ird:pw'` | `cannot write to paths…` | generates |
| `uuid 'secret/we\:ird:id'` | `cannot write to paths…` | generates |

The first two failed **silently**: `rm` reported success while the key
remained readable, and `mv --deep` reported success while every version of
the source survived with `destroyed:false`. A colon-free control confirms
`mv --deep` destroys the source correctly, so the colon is the variable.

## Verification

- `make check` green; every commit builds and tests green in isolation.
- Integration suite, Vault 1.13.2: **1725 passing, 0 failing** — unchanged
  from `develop`.
- All six operations were re-run against a real Vault, each paired with a
  colon-free control to show the fix is specific and does not disturb the
  ordinary path.

## Notes for reviewers

`cmdRevert` had a third handoff on the same line of reasoning — `Write`
also received the raw path — which is fixed here. It is reachable only on
KV v2, where a revert to an older version actually writes; the KV v1 test
fake short-circuits before it. It is covered by the live v2 run above
rather than by a unit test.

Reverting the fix makes `safe gen` panic on a nil dereference inside
`Secret.Password`, because `cmdGen` treats a key-not-found from the
truncated path as "secret absent" and continues with a nil secret. These
changes make that branch unreachable from `gen`/`uuid`, but the underlying
nil deref is untouched and still latent for other callers. Not fixed here:
it is a separate defect and outside this change's scope.
