### PR TITLE
Run the integration suite in CI again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,14 @@ LDFLAGS := -X main.Version="$(VERSION)" -X main.BuildTime="$(BUILD_TIME)" -X mai
 BINARY_NAME := safe
 GO_FILES := $(shell find . -name '*.go' -type f -not -path "./vendor/*")
 
+# Integration suite. TEST_PATH is the suite script, SAFE_PATH the binary it
+# drives, and VAULT_VERSIONS the space-separated Vault versions to run
+# against. CI overrides all three; the defaults run the in-tree suite
+# against a freshly built binary over the suite's own default versions.
+TEST_PATH ?= ci/scripts/tests
+SAFE_PATH ?= ./$(BINARY_NAME)
+VAULT_VERSIONS ?=
+
 ##@ General
 
 .PHONY: help
@@ -76,6 +84,21 @@ test: ## Run all tests with race detector
 	@echo "$(GREEN)Running tests...$(RESET)"
 	@go test -race -v $(shell go list ./... | grep -v vendor)
 	@echo "$(GREEN)✓ Tests complete$(RESET)"
+
+.PHONY: test-integration
+test-integration: ## Run the end-to-end suite against real Vault servers
+	@echo "$(GREEN)Running integration suite...$(RESET)"
+	@test -x "$(TEST_PATH)" || { echo "$(YELLOW)No suite at $(TEST_PATH)$(RESET)"; exit 2; }
+# Rebuild when driving the in-tree binary so the suite never runs against a
+# stale build. An overridden SAFE_PATH is taken as-is: CI supplies the
+# release artifact it means to test.
+ifeq ($(SAFE_PATH),./$(BINARY_NAME))
+	@$(MAKE) --no-print-directory build
+else
+	@test -x "$(SAFE_PATH)" || { echo "$(YELLOW)No safe binary at $(SAFE_PATH)$(RESET)"; exit 2; }
+endif
+	@$(TEST_PATH) $(SAFE_PATH) $(VAULT_VERSIONS)
+	@echo "$(GREEN)✓ Integration suite complete$(RESET)"
 
 .PHONY: test-short
 test-short: ## Run tests in short mode (no race detector)

--- a/ci/scripts/test
+++ b/ci/scripts/test
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Gate for the pull-request job. No Vault server is available here, so this
+# runs the hermetic checks only: fmt, vet, staticcheck, and the unit tests.
+# The end-to-end suite runs in the test-vault-* jobs, which have a server.
+
+set -eu
+
+export GOPATH="${PWD}/gopath"
+export PATH="${PATH}:${GOPATH}/bin"
+
+test -n "${MODULE:-}" || {
+  echo >&2 "MODULE must be set to the Go module path.  Did you misconfigure Concourse?"
+  exit 2
+}
+
+cd "${GOPATH}/src/${MODULE}"
+
+go version
+echo
+
+make check

--- a/ci/scripts/test-release-against-vault
+++ b/ci/scripts/test-release-against-vault
@@ -21,7 +21,7 @@ bail() {
 	exit 2
 }
 test -n "${PROJECT:-}"        || bail "PROJECT must be set to the name of this package."
-test -n "${VAULT_VERSION:-}"  || bail "VAULT_VERSION must be set to the version of HashiCorp Vault to test against."
+test -n "${VAULT_VERSIONS:-}" || bail "VAULT_VERSIONS must be set to the version(s) of HashiCorp Vault to test against."
 
 test -f "${VERSION_FROM}"     || bail "Version file (${VERSION_FROM}) not found."
 VERSION=$(cat "${VERSION_FROM}")
@@ -33,10 +33,10 @@ ARCH=$(uname -m | sed -e 's/^x86_/amd/')
 [[ -e "$BUILD_ROOT/$PROJECT-$VERSION-$OS-$ARCH" ]] || \
   bail "Cannot find safe executable for v$VERSION on $OS/$ARCH"
 
-header "Testing $PROJECT v$VERSION ($OS/$ARCH) against Vault $VAULT_VERSION"
+header "Testing $PROJECT v$VERSION ($OS/$ARCH) against Vault $VAULT_VERSIONS"
 
 cd "$REPO_ROOT"
-make test \
+make test-integration \
   TEST_PATH="../$CI_ROOT/ci/scripts/tests" \
   SAFE_PATH="../$BUILD_ROOT/$PROJECT-$VERSION-$OS-$ARCH" \
   VAULT_VERSIONS="$VAULT_VERSIONS"


### PR DESCRIPTION
The 3400-line end-to-end suite in `ci/scripts/tests` has not run in CI, and
both CI entry points fail before reaching it. Three independent breakages,
one consequence.

## What broke

**The suite stopped being invoked.** `72188a2` (2023) wired the pipeline to
`make test` with a suite-runner target:

```make
test: $(if $(wildcard $(SAFE_PATH)),use,build)
	$(TEST_PATH) $(SAFE_PATH) ${VAULT_VERSIONS}
```

`test` was later modernized to `go test -race`. `ci/scripts/test-release-against-vault`
still passes `TEST_PATH`, `SAFE_PATH`, and `VAULT_VERSIONS`, but make accepts
unknown variables silently, so all three were ignored and only unit tests ran.

**Every `test-vault-*` job bailed at startup.** The script guarded on
`VAULT_VERSION`; all five jobs pass `VAULT_VERSIONS`. Under `set -u` the guard
fired every time with *"VAULT_VERSION must be set … Did you misconfigure
Concourse?"*

**Every pull-request build failed.** `test-pr` runs `ci/scripts/test`, deleted
in that same 2023 commit while the job kept referencing it.

## What this does

- adds `test-integration`, which passes `TEST_PATH`/`SAFE_PATH`/`VAULT_VERSIONS`
  through to the suite — kept separate from `test` so `check` stays hermetic
- guards and reports `VAULT_VERSIONS`, and calls the target that runs the suite
- restores `ci/scripts/test`, running `make check` only, since the PR job has
  no Vault server

`test-integration` rebuilds first when driving the in-tree binary. I hit the
alternative during development: a stale `./safe` sitting in the tree produced
a red run that had nothing to do with the code under test. An explicitly
overridden `SAFE_PATH` is still used as given, since CI supplies the release
artifact it means to test.

## Verification

- `make check` green; `make test-integration VAULT_VERSIONS=1.13.2` →
  **1725 passing, 0 failing, exit 0**
- the vault job script was run against a simulated Concourse resource layout:
  it bails with `VAULT_VERSIONS` unset, and with it set invokes
  `make test-integration TEST_PATH=../git-ci/ci/scripts/tests SAFE_PATH=../build/safe-1.2.3-darwin-arm64 VAULT_VERSIONS=…`,
  confirmed argument-by-argument so a multi-version value stays one argument
  rather than becoming extra make goals
- the PR script was run from a simulated `GOPATH` layout: it bails without
  `MODULE` and reaches a green `make check` with it

**Not verified:** none of this ran on Concourse — I have no access to the
pipeline. The scripts and the make target are verified locally against
simulated resource layouts, which covers the wiring but not Concourse's own
`load_var`, image, or resource behavior. The first real pipeline run is still
the proof.
