### PR TITLE
Fix segfault on writes to a path naming a key

### DIFF
--- a/internal/cli/keygen.go
+++ b/internal/cli/keygen.go
@@ -154,6 +154,12 @@ func (c *CLI) cmdSsh(command string, args ...string) error {
 		return r.Usage("ssh")
 	}
 
+	for _, path := range args {
+		if err := assertWritablePath(path); err != nil {
+			return err
+		}
+	}
+
 	v := connect(true)
 	for _, path := range args {
 		s, err := v.Read(path)
@@ -194,6 +200,12 @@ func (c *CLI) cmdRsa(command string, args ...string) error {
 
 	if len(args) < 1 {
 		return r.Usage("rsa")
+	}
+
+	for _, path := range args {
+		if err := assertWritablePath(path); err != nil {
+			return err
+		}
 	}
 
 	v := connect(true)
@@ -240,6 +252,9 @@ func (c *CLI) cmdDhparam(command string, args ...string) error {
 	}
 
 	path := args[0]
+	if err := assertWritablePath(path); err != nil {
+		return err
+	}
 	v := connect(true)
 	s, err := v.Read(path)
 	if err != nil && !vault.IsNotFound(err) {

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -30,8 +30,11 @@ func (c *CLI) writeHelper(prompt bool, insecure bool, command string, args ...st
 	if len(args) < 2 {
 		return r.Usage(command)
 	}
-	v := connect(true)
 	path, args := args[0], args[1:]
+	if err := assertWritablePath(path); err != nil {
+		return err
+	}
+	v := connect(true)
 	s, err := v.Read(path)
 	if err != nil && !vault.IsNotFound(err) {
 		return err

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -9,6 +9,7 @@ import (
 	"unicode"
 
 	"github.com/cloudfoundry-community/safe/pkg/prompt"
+	"github.com/cloudfoundry-community/safe/pkg/vault"
 	"github.com/jhunt/go-ansi"
 )
 
@@ -80,6 +81,21 @@ func expandValueArg(arg string) (string, error) {
 		return string(b), nil
 	}
 	return arg, nil
+}
+
+// assertWritablePath refuses a path naming a key or a version, using the same
+// wording Vault.Write does. The commands that write a whole secret cannot
+// honour either, and checking here rather than at the write means the
+// complaint arrives before a value is prompted for or key material is
+// generated, instead of after the work is thrown away.
+func assertWritablePath(path string) error {
+	if vault.PathHasKey(path) {
+		return fmt.Errorf("cannot write to paths in /path:key notation (%s)", path)
+	}
+	if vault.PathHasVersion(path) {
+		return fmt.Errorf("cannot write to paths in /path^version notation (%s)", path)
+	}
+	return nil
 }
 
 func pr(label string, confirm bool, secure bool) string {

--- a/internal/cli/write_path_guard_test.go
+++ b/internal/cli/write_path_guard_test.go
@@ -1,0 +1,122 @@
+package cli
+
+// The commands that write a whole secret reject a path naming a key or a
+// version before connecting, so the complaint arrives ahead of the prompt or
+// the key generation rather than after the work is discarded.
+//
+// These guards sit before connect(), so no Vault seam is needed; HOME is
+// isolated so rc.Apply returns an empty config without error.
+
+import (
+	"strings"
+	"testing"
+)
+
+// newWritePathCLI registers the commands whose guards are exercised here so
+// that r.Usage returns a properly-typed *UsageError when arg counts are short.
+func newWritePathCLI(t *testing.T) *CLI {
+	t.Helper()
+	r := NewRunner()
+	opt := &Options{}
+	c := &CLI{opt: opt, r: r}
+	for _, name := range []string{"set", "paste", "ask", "ssh", "rsa", "dhparam"} {
+		r.Dispatch(name, &Help{
+			Summary: name,
+			Usage:   "safe " + name + " ...",
+			Type:    DestructiveCommand,
+		}, func(cmd string, args ...string) error { return nil })
+	}
+	return c
+}
+
+func assertWritePathRejected(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), want)
+	}
+}
+
+func TestAssertWritablePath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"plain path", "secret/foo", ""},
+		{"key", "secret/foo:bar", "/path:key"},
+		{"version", "secret/foo^2", "/path^version"},
+		{"escaped colon is part of the path", `secret/we\:ird`, ""},
+		{"escaped caret is part of the path", `secret/ca\^ret`, ""},
+		{"escaped path with a real key", `secret/we\:ird:bar`, "/path:key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := assertWritablePath(tc.path)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("assertWritablePath(%q) = %v, want nil", tc.path, err)
+				}
+				return
+			}
+			assertWritePathRejected(t, err, tc.want)
+		})
+	}
+}
+
+// The remaining tests drive the command handlers, which is what pins the
+// guard to a position ahead of connect(): reaching Vault would fail on the
+// isolated HOME long before returning this error.
+
+func TestCmdSet_KeyInPath_RejectedBeforeConnect(t *testing.T) {
+	isolateHome(t)
+	c := newWritePathCLI(t)
+	assertWritePathRejected(t, c.cmdSet("set", "secret/foo:bar", "k=v"), "/path:key")
+}
+
+func TestCmdSet_VersionInPath_RejectedBeforeConnect(t *testing.T) {
+	isolateHome(t)
+	c := newWritePathCLI(t)
+	assertWritePathRejected(t, c.cmdSet("set", "secret/foo^2", "k=v"), "/path^version")
+}
+
+func TestCmdPaste_KeyInPath_RejectedBeforeConnect(t *testing.T) {
+	isolateHome(t)
+	c := newWritePathCLI(t)
+	assertWritePathRejected(t, c.cmdPaste("paste", "secret/foo:bar", "k=v"), "/path:key")
+}
+
+func TestCmdAsk_KeyInPath_RejectedBeforeConnect(t *testing.T) {
+	isolateHome(t)
+	c := newWritePathCLI(t)
+	assertWritePathRejected(t, c.cmdAsk("ask", "secret/foo:bar", "k=v"), "/path:key")
+}
+
+func TestCmdSsh_KeyInPath_RejectedBeforeConnect(t *testing.T) {
+	isolateHome(t)
+	c := newWritePathCLI(t)
+	assertWritePathRejected(t, c.cmdSsh("ssh", "secret/foo:private"), "/path:key")
+}
+
+// A later path in the list is checked too, so one bad argument cannot slip
+// through behind a good one.
+func TestCmdSsh_KeyInSecondPath_RejectedBeforeConnect(t *testing.T) {
+	isolateHome(t)
+	c := newWritePathCLI(t)
+	assertWritePathRejected(t, c.cmdSsh("ssh", "secret/ok", "secret/foo:private"), "/path:key")
+}
+
+func TestCmdRsa_KeyInPath_RejectedBeforeConnect(t *testing.T) {
+	isolateHome(t)
+	c := newWritePathCLI(t)
+	assertWritePathRejected(t, c.cmdRsa("rsa", "secret/foo:private"), "/path:key")
+}
+
+func TestCmdDhparam_KeyInPath_RejectedBeforeConnect(t *testing.T) {
+	isolateHome(t)
+	c := newWritePathCLI(t)
+	assertWritePathRejected(t, c.cmdDhparam("dhparam", "secret/foo:dhparam-pem"), "/path:key")
+}

--- a/pkg/vault/read_nonnil_test.go
+++ b/pkg/vault/read_nonnil_test.go
@@ -1,0 +1,62 @@
+// Read never hands back a nil *Secret. Callers that tolerate a not-found
+// error go on to use the value, and every Secret accessor dereferences the
+// receiver, so a nil here is a segfault one call later.
+package vault_test
+
+import (
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// TestReadNeverReturnsNilOnKeyNotFound pins the invariant for a missing key
+// within an existing secret, which is the case that used to return nil.
+func TestReadNeverReturnsNilOnKeyNotFound(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/myapp", map[string]string{"user": "admin"})
+
+	s, err := v.Read("secret/myapp:missing")
+	assertKeyNotFound(t, err)
+	if s == nil {
+		t.Fatal("Read returned a nil *Secret alongside KeyNotFound")
+	}
+	if !s.Empty() {
+		t.Errorf("secret should be empty, has keys %v", s.Keys())
+	}
+}
+
+// TestReadNeverReturnsNilOnSecretNotFound pins the same invariant for a
+// missing secret, so the two not-found branches stay consistent.
+func TestReadNeverReturnsNilOnSecretNotFound(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+
+	s, err := v.Read("secret/does-not-exist")
+	assertSecretNotFound(t, err)
+	if s == nil {
+		t.Fatal("Read returned a nil *Secret alongside SecretNotFound")
+	}
+	if !s.Empty() {
+		t.Errorf("secret should be empty, has keys %v", s.Keys())
+	}
+}
+
+// TestReadNilFreeSecretIsUsable walks the shape that crashed: tolerate the
+// not-found error, then keep using the secret.
+func TestReadNilFreeSecretIsUsable(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/myapp", map[string]string{"user": "admin"})
+
+	s, err := v.Read("secret/myapp:missing")
+	if err != nil && !vault.IsNotFound(err) {
+		t.Fatalf("Read: %v", err)
+	}
+	if s.Has("anything") {
+		t.Error("empty secret should not report a key")
+	}
+	if err := s.Set("added", "value", false); err != nil {
+		t.Fatalf("Set on the returned secret: %v", err)
+	}
+}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -136,8 +136,10 @@ func (v *Vault) Curl(method string, path string, body []byte) (*http.Response, e
 }
 
 // Read checks the Vault for a Secret at the specified path, and returns it.
-// If there is nothing at that path, a nil *Secret will be returned, with no
-// error.
+// The returned *Secret is never nil. A missing secret and a missing key are
+// both reported through err, as SecretNotFound and KeyNotFound respectively,
+// alongside an empty Secret; every Secret method dereferences its receiver,
+// so a caller that tolerates a not-found error can still use the value.
 func (v *Vault) Read(path string) (secret *Secret, err error) {
 	path, key, version := ParsePath(path)
 
@@ -155,7 +157,7 @@ func (v *Vault) Read(path string) (secret *Secret, err error) {
 	if key != "" {
 		val, found := raw[key]
 		if !found {
-			return nil, NewKeyNotFoundError(path, key)
+			return secret, NewKeyNotFoundError(path, key)
 		}
 		raw = map[string]any{key: val}
 	}


### PR DESCRIPTION
`safe set secret/foo:bar k=v` segfaults. So do `paste`, `ask`, `ssh`,
`rsa`, and `dhparam` when the path names a key that does not yet exist.

## Cause

`Vault.Read` returns a **nil** `*Secret` alongside `KeyNotFoundError`
(vault.go:158), while the missing-*secret* branch returns an empty one.
`IsNotFound` covers both (errors.go:29), so the caller shape

```go
s, err := v.Read(path)
if err != nil && !vault.IsNotFound(err) {
	return err
}
```

falls through holding nil, and every `Secret` accessor dereferences its
receiver.

```
panic: runtime error: invalid memory address or nil pointer dereference
vault.(*Secret).Has(...)          pkg/vault/secret.go:38
vault.(*Secret).Set(0x0, ...)     pkg/vault/secret.go:60
cli.(*CLI).writeHelper            internal/cli/secrets.go:57
```

The doc comment above `Read` claimed the opposite of what the code did —
"a nil `*Secret` will be returned, with no error" — on both clauses.

The tell is that the same command works when the key *does* exist: `Read`
succeeds, and `Write` rejects the syntax properly. The correct behavior
was already there; only the not-found path skipped it.

## Measured, Vault 1.13.2 KV v2

Seed `safe set secret/foo user=admin`, then:

| Command | Before | After |
|---------|--------|-------|
| `set secret/foo:bar k=v` | **SIGSEGV** | `cannot write to paths in /path:key notation`, rc=1 |
| `paste secret/foo:nope k=v` | **SIGSEGV** | same |
| `ssh secret/foo:private` | **SIGSEGV** | same |
| `rsa secret/foo:private` | **SIGSEGV** | same |
| `dhparam secret/foo:dhparam-pem` | **SIGSEGV**, after generating the params | same, before generating them |
| `set secret/foo:user k=v` (key exists) | clean error | unchanged |
| `gen` / `uuid` on `path:key` | rc=0 | unchanged — #12 already strips the key |

## What this does

**Commit 1** returns the already-allocated empty secret instead of nil, so
both not-found branches agree, and corrects the doc comment. This alone
removes all five crashes.

**Commit 2** is not a crash fix — it moves the complaint earlier. Without
it the error still arrives from `Write`, but only after the value has been
prompted for and the key material generated. `safe dhparam 4096` spun for
the full generation before failing; it now returns immediately. The guard
runs before `connect()`, so no Vault round-trip happens either.

Escaped colons and carets stay part of the path: `safe set 'secret/we\:ird'
user=admin` still writes, verified against a live server with the `vault`
CLI confirming the literal `we:ird` path.

## Verification

- `make check` green. Three new `pkg/vault` tests pin the never-nil
  invariant; one reproduces the production crash in-process and fails with
  the identical stack before the fix.
- Eight new `internal/cli` tests drive the real handlers, which is what
  pins the guard ahead of `connect()`.
- Integration suite, Vault 1.13.2: **1725 passing, 0 failing** — unchanged
  from `develop`.
- No caller anywhere depends on the nil return; nothing in the repo
  compares a `*Secret` against nil, and no test asserted it.

## Note for reviewers

`IsNotFound` deliberately keeps its umbrella meaning. Narrowing it would
change the `-f` delete paths (secrets.go:542,549) and the tree walks
(tree.go:411,427,798,905), which rely on it covering both cases.

`CreateSignedCertificate` (vault.go:1044) has the same hazardous shape and
is exported, but has no caller in the repo. Commit 1 makes it safe without
touching it.
