### PR TITLE
Accept safe's own escaped paths as input

### DIFF
--- a/internal/cli/export_escaped_test.go
+++ b/internal/cli/export_escaped_test.go
@@ -1,0 +1,49 @@
+package cli
+
+// export walks a subtree, so it takes a root in safe's escaped syntax and
+// has to hand the literal path to the walk.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCmdExportAcceptsEscapedRoot(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	fv.set("secret/od:d/leaf", map[string]string{"k": "v"})
+	fv.set("secret/od", map[string]string{"other": "untouched"})
+
+	c := newTestCLI(t)
+	var err error
+	out := captureStdout(t, func() { err = c.cmdExport("export", `secret/od\:d`) })
+	if err != nil {
+		t.Fatalf("cmdExport: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("export output is not JSON (%v):\n%s", err, out)
+	}
+	if !strings.Contains(out, "leaf") {
+		t.Errorf("export should contain the leaf secret, got:\n%s", out)
+	}
+	if strings.Contains(out, "untouched") {
+		t.Errorf("the name-prefix sibling should not be exported, got:\n%s", out)
+	}
+}
+
+func TestCmdExportRejectsKeyInRoot(t *testing.T) {
+	isolateHome(t)
+	newCLIFake(t)
+
+	c := newTestCLI(t)
+	err := c.cmdExport("export", `secret/od\:d:leaf`)
+	if err == nil {
+		t.Fatal("expected an error for a root naming a key, got nil")
+	}
+	if !strings.Contains(err.Error(), "key") {
+		t.Errorf("error %q should mention a key", err)
+	}
+}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -20,6 +20,22 @@ import (
 	"github.com/cloudfoundry-community/safe/pkg/vault"
 )
 
+// walkRoot resolves a tree-walk root argument to the literal Vault path the
+// walk needs. safe prints paths in its own escaped syntax, so a root pasted
+// back from `safe paths` or `safe tree` arrives escaped, while the walk and
+// Secrets.Draw both work in literal paths. A key or a version cannot scope a
+// recursive walk, so naming one is refused rather than quietly dropped.
+func walkRoot(command, arg string) (string, error) {
+	raw, key, version := vault.ParsePath(arg)
+	if key != "" {
+		return "", fmt.Errorf("%s does not take a specific key (%s)", command, arg)
+	}
+	if version != 0 {
+		return "", fmt.Errorf("%s does not take a specific version (%s)", command, arg)
+	}
+	return raw, nil
+}
+
 func (c *CLI) writeHelper(prompt bool, insecure bool, command string, args ...string) error {
 	opt := c.opt
 	r := c.r
@@ -410,7 +426,11 @@ func (c *CLI) cmdTree(command string, args ...string) error {
 	r2, _ := regexp.Compile("^└")
 	v := connect(true)
 	for i, path := range args {
-		secrets, err := v.ConstructSecrets(path, vault.TreeOpts{
+		root, err := walkRoot("tree", path)
+		if err != nil {
+			return err
+		}
+		secrets, err := v.ConstructSecrets(root, vault.TreeOpts{
 			FetchKeys:           opt.Tree.ShowKeys,
 			AllowDeletedSecrets: opt.Tree.Quick,
 		})
@@ -418,7 +438,7 @@ func (c *CLI) cmdTree(command string, args ...string) error {
 		if err != nil {
 			return err
 		}
-		lines := strings.Split(secrets.Draw(path, fmt.CanColorize(os.Stdout), !opt.Tree.HideLeaves), "\n")
+		lines := strings.Split(secrets.Draw(root, fmt.CanColorize(os.Stdout), !opt.Tree.HideLeaves), "\n")
 		if i > 0 {
 			lines = lines[1:] // Drop root '.' from subsequent paths
 		}
@@ -446,7 +466,11 @@ func (c *CLI) cmdPaths(command string, args ...string) error {
 	}
 	v := connect(true)
 	for _, path := range args {
-		secrets, err := v.ConstructSecrets(path, vault.TreeOpts{
+		root, err := walkRoot("paths", path)
+		if err != nil {
+			return err
+		}
+		secrets, err := v.ConstructSecrets(root, vault.TreeOpts{
 			FetchKeys:           opt.Paths.ShowKeys,
 			AllowDeletedSecrets: opt.Paths.Quick,
 			SkipVersionInfo:     !opt.Paths.ShowKeys,
@@ -491,7 +515,11 @@ func (c *CLI) cmdValues(command string, args ...string) error {
 		paths = []string{"secret"}
 	}
 	for i := range paths {
-		paths[i] = vault.Canonicalize(paths[i])
+		root, err := walkRoot("values", paths[i])
+		if err != nil {
+			return err
+		}
+		paths[i] = root
 	}
 	paths = dedupeExportPaths(paths)
 

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -621,7 +621,9 @@ func (c *CLI) cmdUndelete(command string, args ...string) error {
 				versions = append(versions, v.Version)
 			}
 
-			if err = v.Client().Undelete(path, versions); err != nil {
+			//The version list was looked up under the parsed path; the
+			// client takes literal paths, so the undelete uses it too.
+			if err = v.Client().Undelete(secret, versions); err != nil {
 				return err
 			}
 		} else {

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -264,11 +264,16 @@ func (c *CLI) cmdVersions(command string, args ...string) error {
 	}
 
 	for i := range args {
-		_, _, version := vault.ParsePath(args[i])
+		secret, key, version := vault.ParsePath(args[i])
 		if version > 0 {
 			return fmt.Errorf("Specifying version to versions is not supported")
 		}
-		versions, err := v.Client().Versions(args[i])
+		if key != "" {
+			return fmt.Errorf("Specifying key to versions is not supported")
+		}
+		//The client takes literal Vault paths, so it gets what ParsePath
+		// returned rather than the escaped syntax the argument arrived in.
+		versions, err := v.Client().Versions(secret)
 		if vaultkv.IsNotFound(err) {
 			err = vault.NewSecretNotFoundError(args[i])
 		}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -743,8 +743,7 @@ func (c *CLI) cmdExport(command string, args ...string) error {
 
 	//Standardize and validate paths
 	for i := range args {
-		args[i] = vault.Canonicalize(args[i])
-		_, key, version := vault.ParsePath(args[i])
+		raw, key, version := vault.ParsePath(args[i])
 		if key != "" {
 			return fmt.Errorf("Cannot export path with key (%s)", args[i])
 		}
@@ -752,6 +751,9 @@ func (c *CLI) cmdExport(command string, args ...string) error {
 		if version > 0 {
 			return fmt.Errorf("Cannot export path with version (%s)", args[i])
 		}
+		//ParsePath already canonicalized, and the walk wants the literal
+		// path rather than the escaped syntax the argument arrived in.
+		args[i] = raw
 	}
 
 	//Deduplicate the input paths

--- a/internal/cli/versions_guard_test.go
+++ b/internal/cli/versions_guard_test.go
@@ -1,0 +1,44 @@
+package cli
+
+// versions takes a secret path. A version was already refused; a key was not,
+// and used to reach Vault as part of the path and come back as a misleading
+// "no secret exists".
+//
+// The successful lookup needs a KV v2 mount, which the CLI fake does not
+// serve, so only the guards are covered here.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCmdVersionsRejectsKey(t *testing.T) {
+	isolateHome(t)
+	newCLIFake(t)
+
+	c := newTestCLI(t)
+	err := c.cmdVersions("versions", "secret/foo:mykey")
+	if err == nil {
+		t.Fatal("expected an error for a path naming a key, got nil")
+	}
+	if !strings.Contains(err.Error(), "key") {
+		t.Errorf("error %q should mention a key", err)
+	}
+	if strings.Contains(err.Error(), "no secret exists") {
+		t.Errorf("error %q should not report a missing secret", err)
+	}
+}
+
+func TestCmdVersionsRejectsVersion(t *testing.T) {
+	isolateHome(t)
+	newCLIFake(t)
+
+	c := newTestCLI(t)
+	err := c.cmdVersions("versions", "secret/foo^2")
+	if err == nil {
+		t.Fatal("expected an error for a path naming a version, got nil")
+	}
+	if !strings.Contains(err.Error(), "version") {
+		t.Errorf("error %q should mention a version", err)
+	}
+}

--- a/internal/cli/walk_root_test.go
+++ b/internal/cli/walk_root_test.go
@@ -1,0 +1,141 @@
+package cli
+
+// safe prints paths in its own escaped syntax, so its output has to be usable
+// as its own input. These tests pin the round trip for the commands that walk
+// a subtree, using the fake Vault's verbatim path storage to hold a secret
+// whose literal name contains a colon.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWalkRoot(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		arg     string
+		want    string
+		wantErr string
+	}{
+		{name: "plain path", arg: "secret/foo", want: "secret/foo"},
+		{name: "escaped colon is unescaped", arg: `secret/we\:ird`, want: "secret/we:ird"},
+		{name: "escaped caret is unescaped", arg: `secret/ca\^ret`, want: "secret/ca^ret"},
+		{name: "canonicalized", arg: "/secret//foo/", want: "secret/foo"},
+		{name: "key refused", arg: "secret/foo:bar", wantErr: "specific key"},
+		{name: "version refused", arg: "secret/foo^2", wantErr: "specific version"},
+		{name: "key on an escaped path refused", arg: `secret/we\:ird:bar`, wantErr: "specific key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := walkRoot("tree", tc.arg)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("walkRoot(%q) = %q, want an error", tc.arg, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error %q should mention %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("walkRoot(%q): %v", tc.arg, err)
+			}
+			if got != tc.want {
+				t.Errorf("walkRoot(%q) = %q, want %q", tc.arg, got, tc.want)
+			}
+		})
+	}
+}
+
+// seedColonTree stores a secret under a literal colon-bearing folder, plus a
+// name-prefix sibling that must not be swept in by the walk.
+func seedColonTree(t *testing.T) *cliFakeVault {
+	t.Helper()
+	fv := newCLIFake(t)
+	fv.set("secret/od:d/leaf", map[string]string{"k": "v"})
+	fv.set("secret/od", map[string]string{"other": "untouched"})
+	return fv
+}
+
+func TestCmdTreeAcceptsEscapedRoot(t *testing.T) {
+	isolateHome(t)
+	seedColonTree(t)
+
+	c := newTestCLI(t)
+	var err error
+	out := captureStdout(t, func() { err = c.cmdTree("tree", `secret/od\:d`) })
+	if err != nil {
+		t.Fatalf("cmdTree: %v", err)
+	}
+	if !strings.Contains(out, "leaf") {
+		t.Errorf("tree output should list the leaf, got:\n%s", out)
+	}
+	// The root is escaped once for display, never twice.
+	if strings.Contains(out, `od\\:d`) {
+		t.Errorf("tree output double-escaped the root, got:\n%s", out)
+	}
+	if !strings.Contains(out, `od\:d`) {
+		t.Errorf("tree output should show the escaped root, got:\n%s", out)
+	}
+}
+
+func TestCmdPathsAcceptsEscapedRoot(t *testing.T) {
+	isolateHome(t)
+	seedColonTree(t)
+
+	c := newTestCLI(t)
+	var err error
+	out := captureStdout(t, func() { err = c.cmdPaths("paths", `secret/od\:d`) })
+	if err != nil {
+		t.Fatalf("cmdPaths: %v", err)
+	}
+	if !strings.Contains(out, `secret/od\:d/leaf`) {
+		t.Errorf("paths output should list the escaped leaf, got:\n%s", out)
+	}
+	if strings.Contains(out, "untouched") || strings.Contains(out, "secret/od\n") {
+		t.Errorf("the name-prefix sibling should not appear, got:\n%s", out)
+	}
+}
+
+// What safe prints is what safe accepts: feed the output of `paths` back in.
+func TestCmdPathsOutputRoundTrips(t *testing.T) {
+	isolateHome(t)
+	seedColonTree(t)
+
+	c := newTestCLI(t)
+	var err error
+	first := captureStdout(t, func() { err = c.cmdPaths("paths", `secret/od\:d`) })
+	if err != nil {
+		t.Fatalf("cmdPaths: %v", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(first), "\n") {
+		if line == "" {
+			continue
+		}
+		if _, err := walkRoot("paths", line); err != nil {
+			t.Fatalf("walkRoot rejected safe's own output %q: %v", line, err)
+		}
+		out := captureStdout(t, func() { err = c.cmdPaths("paths", line) })
+		if err != nil {
+			t.Fatalf("cmdPaths(%q) rejected safe's own output: %v", line, err)
+		}
+		if strings.TrimSpace(out) != line {
+			t.Errorf("cmdPaths(%q) = %q, want it to echo the same path", line, strings.TrimSpace(out))
+		}
+	}
+}
+
+func TestCmdTreeRejectsKeyInRoot(t *testing.T) {
+	isolateHome(t)
+	seedColonTree(t)
+
+	c := newTestCLI(t)
+	err := c.cmdTree("tree", `secret/od\:d:leaf`)
+	if err == nil {
+		t.Fatal("expected an error for a root naming a key, got nil")
+	}
+	if !strings.Contains(err.Error(), "specific key") {
+		t.Errorf("error %q should mention a specific key", err)
+	}
+}


### PR DESCRIPTION
safe prints paths in its own escaped syntax, so its output should be
usable as its own input. It is not:

```
$ safe paths secret
secret/od\:d/leaf

$ safe tree 'secret/od\:d'
!! no secret exists at path `secret/od\:d`
```

## Cause

#10 and #12 established the vocabulary split — `Read`, `Write`, and
`deleteEntireSecret` take the escaped mini-language because they call
`ParsePath`; `Versions`, `client.*`, and `ConstructSecrets` take literal
Vault paths — and fixed the handoffs inside `pkg/vault`. The CLI layer
was never converted. Six call sites still pass raw argv to a consumer
that wants a literal path.

## Measured, Vault 1.13.2 KV v2

Fixture is one secret at the literal Vault path `secret/od:d`, which the
mini-language writes as `secret/od\:d`, plus a `secret/od` sibling that
must not be swept in.

| Command | Before | After |
|---------|--------|-------|
| `tree 'secret/od\:d'` | `no secret exists`, rc=1 | walks it |
| `paths 'secret/od\:d'` | `no secret exists`, rc=1 | lists it |
| `export 'secret/od\:d'` | `no secret exists`, rc=1 | exports it |
| `values -p 'secret/od\:d' v` | `no secret exists`, rc=1 | searches it |
| `versions 'secret/od\:d'` | `no secret exists`, rc=1 | rc=0 |
| `undelete --all 'secret/od\:d'` | **rc=0, restored nothing** | restores it |
| `versions 'secret/foo:mykey'` | misleading `no secret exists` | `Specifying key to versions is not supported` |

`undelete --all` is the one to look at. It resolved the version list
correctly against the parsed path, then issued the undelete against the
original argument, so it reported success and exit 0 while every version
stayed deleted. Verified against a live server by reading the KV metadata
directly, with a colon-free control undeleting correctly in the same run:

```
COLON     after delete   : v1 deleted=true
COLON     after undelete : v1 deleted=true      <- before
CONTROL   after delete   : v1 deleted=true
CONTROL   after undelete : v1 deleted=false
```

## Two things worth reviewer attention

**`Secrets.Draw` wants a literal path, not an escaped one.** It compares
its root against walked paths and applies `EscapePathSegment` only when
printing, so passing the already-escaped argument escaped it twice
(`od\\:d`). Today that is masked because the walk errors out first; it
would have become visible the moment the walk was fixed. Passing the
resolved root to both fixes them together.

**A key or version in a walk root is now refused, not dropped.** `safe
tree 'secret/od\:d:leaf'` previously would have silently walked the whole
subtree, ignoring the key. It now errors, matching what `DeleteTree` does
for the same reason. `export` already refused both; `versions` refused a
version but not a key, and now refuses both.

## Verification

- `make check` green. Nine new `internal/cli` tests drive the real command
  handlers against the fake Vault, which stores paths verbatim. All of
  them fail with the fix neutered and pass with it — including a test
  that feeds `safe paths` output back into `safe paths`.
- Integration suite, Vault 1.13.2: **1725 passing, 0 failing** —
  unchanged from `develop`.
- Every case above re-run against a live Vault paired with a colon-free
  control, so the fix is specific and does not disturb ordinary paths.

## Not covered by a test

`versions` and `undelete --all` need a KV v2 mount to reach their
success paths, and the CLI fake serves v1 only. Their guards are unit
tested; the success paths are covered by the live v2 run above. Extending
the fake to v2 is worth doing separately — it would also benefit
`tree`, `paths`, and `get`.
