### PR TITLE
Fix backslash paths breaking export and tree walks

### DIFF
--- a/internal/cli/backslash_path_test.go
+++ b/internal/cli/backslash_path_test.go
@@ -1,0 +1,111 @@
+package cli
+
+// A Vault path is an arbitrary string, so any client can store a secret whose
+// name ends in a backslash. safe has to walk past one: the tree walk re-parses
+// the paths it builds, so a name it cannot encode and parse back takes out the
+// whole subtree rather than the one secret.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// seedBackslashTree stores two ordinary secrets and one whose name ends in a
+// backslash, all under the same root.
+func seedBackslashTree(t *testing.T) *cliFakeVault {
+	t.Helper()
+	fv := newCLIFake(t)
+	fv.set("secret/good/one", map[string]string{"k": "v"})
+	fv.set("secret/good/two", map[string]string{"k": "v"})
+	fv.set(`secret/good/bad\`, map[string]string{"k": "v"})
+	return fv
+}
+
+func TestCmdExportWalksPastBackslashPath(t *testing.T) {
+	isolateHome(t)
+	seedBackslashTree(t)
+
+	c := newTestCLI(t)
+	var err error
+	out := captureStdout(t, func() { err = c.cmdExport("export", "secret/good") })
+	if err != nil {
+		t.Fatalf("cmdExport: %v", err)
+	}
+
+	var doc map[string]map[string]any
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("export output is not JSON (%v):\n%s", err, out)
+	}
+
+	// The healthy siblings are the point: one unencodable name used to make
+	// the entire subtree unexportable.
+	for _, want := range []string{"secret/good/one", "secret/good/two"} {
+		if _, ok := doc[want]; !ok {
+			t.Errorf("export omitted %q; got keys %v", want, mapKeys(doc))
+		}
+	}
+
+	entry, ok := doc[`secret/good/bad\`]
+	if !ok {
+		t.Fatalf("export omitted the backslash-suffixed secret; got keys %v", mapKeys(doc))
+	}
+	if _, ok := entry["k"]; !ok {
+		t.Errorf("the backslash-suffixed secret lost its key name; got %v", entry)
+	}
+}
+
+func TestCmdPathsKeysWalksPastBackslashPath(t *testing.T) {
+	isolateHome(t)
+	seedBackslashTree(t)
+
+	c := newTestCLI(t)
+	c.opt.Paths.ShowKeys = true
+	var err error
+	out := captureStdout(t, func() { err = c.cmdPaths("paths", "secret/good") })
+	if err != nil {
+		t.Fatalf("cmdPaths: %v", err)
+	}
+
+	for _, want := range []string{"secret/good/one:k", "secret/good/two:k"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("paths --keys omitted %q, got:\n%s", want, out)
+		}
+	}
+	// The encoded form doubles the backslash so the joining colon cannot be
+	// read as escaped when the path is parsed again.
+	if !strings.Contains(out, `secret/good/bad\\:k`) {
+		t.Errorf("paths --keys should print the escaped backslash path with its key, got:\n%s", out)
+	}
+}
+
+func TestCmdTreeKeysWalksPastBackslashPath(t *testing.T) {
+	isolateHome(t)
+	seedBackslashTree(t)
+
+	c := newTestCLI(t)
+	c.opt.Tree.ShowKeys = true
+	var err error
+	out := captureStdout(t, func() { err = c.cmdTree("tree", "secret/good") })
+	if err != nil {
+		t.Fatalf("cmdTree: %v", err)
+	}
+
+	if !strings.Contains(out, "one") || !strings.Contains(out, "two") {
+		t.Errorf("tree --keys omitted the healthy siblings, got:\n%s", out)
+	}
+	// Every secret in the tree has exactly one key, named "k". An empty key
+	// name means the path and key were joined without escaping the path.
+	if strings.Contains(out, ":\n") || strings.HasSuffix(strings.TrimRight(out, "\n"), ":") {
+		t.Errorf("tree --keys printed an empty key name, got:\n%s", out)
+	}
+}
+
+// mapKeys is a test-only helper for readable failure messages.
+func mapKeys(m map[string]map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/vault/backslash_path_test.go
+++ b/pkg/vault/backslash_path_test.go
@@ -1,0 +1,135 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+)
+
+// A Vault path is an arbitrary string, and any client can create one that ends
+// in a backslash. safe's own path syntax has to survive those, because the
+// tree walk re-parses paths it built itself: a name that cannot be encoded and
+// parsed back breaks every command that walks a subtree, not just the one
+// secret.
+
+func TestEscapePathSegmentEscapesBackslash(t *testing.T) {
+	cases := []struct {
+		segment string
+		want    string
+	}{
+		{`plain`, `plain`},
+		{`trailing\`, `trailing\\`},
+		{`mid\dle`, `mid\\dle`},
+		{`two\\`, `two\\\\`},
+		{`colon:`, `colon\:`},
+		{`caret^`, `caret\^`},
+		{`both\:`, `both\\\:`},
+	}
+
+	for _, c := range cases {
+		if got := EscapePathSegment(c.segment); got != c.want {
+			t.Errorf("EscapePathSegment(%q) = %q, want %q", c.segment, got, c.want)
+		}
+	}
+}
+
+func TestParsePathSplitsAfterEscapedBackslash(t *testing.T) {
+	cases := []struct {
+		in      string
+		secret  string
+		key     string
+		version uint64
+	}{
+		// The encoded form of a path ending in a backslash. Before the escape
+		// alphabet included the backslash itself, the caret here looked
+		// escaped, and the whole string was read as one literal path.
+		{`secret/bad\\^1`, `secret/bad\`, ``, 1},
+		{`secret/bad\\:key`, `secret/bad\`, `key`, 0},
+		{`secret/bad\\:key^2`, `secret/bad\`, `key`, 2},
+		// A key ending in a backslash, with a version after it.
+		{`secret/a:key\\^3`, `secret/a`, `key\`, 3},
+		// A genuinely escaped separator still belongs to the segment.
+		{`secret/a\:b`, `secret/a:b`, ``, 0},
+		{`secret/a\^b`, `secret/a^b`, ``, 0},
+		{`secret/a\:b:key`, `secret/a:b`, `key`, 0},
+		// A lone trailing backslash has nothing to escape, so it is literal.
+		// This is what a user gets by typing the raw Vault path.
+		{`secret/bad\`, `secret/bad\`, ``, 0},
+		// A backslash before an ordinary character is not an escape, and both
+		// characters survive.
+		{`secret/a\b`, `secret/a\b`, ``, 0},
+	}
+
+	for _, c := range cases {
+		secret, key, version := ParsePath(c.in)
+		if secret != c.secret || key != c.key || version != c.version {
+			t.Errorf("ParsePath(%q) = (%q, %q, %d), want (%q, %q, %d)",
+				c.in, secret, key, version, c.secret, c.key, c.version)
+		}
+	}
+}
+
+// TestEncodeParseRoundTrip sweeps every short combination of the characters
+// that matter, so that no encoded path parses back as something else. The
+// alphabet is deliberately small and nasty: the separators, the escape
+// character, and one ordinary rune.
+func TestEncodeParseRoundTrip(t *testing.T) {
+	alphabet := []string{`a`, `\`, `:`, `^`}
+
+	var segments []string
+	for _, one := range alphabet {
+		segments = append(segments, one)
+		for _, two := range alphabet {
+			segments = append(segments, one+two)
+			for _, three := range alphabet {
+				segments = append(segments, one+two+three)
+			}
+		}
+	}
+
+	versions := []uint64{0, 1, 42}
+	checked := 0
+
+	for _, path := range segments {
+		for _, key := range append([]string{""}, segments...) {
+			for _, version := range versions {
+				encoded := EncodePath(path, key, version)
+				gotPath, gotKey, gotVersion := ParsePath(encoded)
+				checked++
+
+				// EncodePath canonicalizes on the way back out, so compare
+				// against the canonical form of what went in.
+				wantPath := Canonicalize(path)
+				if gotPath != wantPath || gotKey != key || gotVersion != version {
+					t.Errorf("round trip of (%q, %q, %d) encoded to %q, parsed back as (%q, %q, %d)",
+						path, key, version, encoded, gotPath, gotKey, gotVersion)
+				}
+			}
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("round trip sweep checked nothing")
+	}
+	t.Logf("checked %d round trips", checked)
+}
+
+// TestEncodedVersionAlwaysParses pins the specific shape the tree walk builds:
+// a literal Vault path plus a version. This is the exact call at tree.go's
+// version fetch, and the one that used to fail for backslash-suffixed names.
+func TestEncodedVersionAlwaysParses(t *testing.T) {
+	for _, name := range []string{`bad\`, `ok`, `two\\`, `mid\dle`, `co:lon`, `car^et`} {
+		path := "secret/good/" + name
+		encoded := EncodePath(path, "", 1)
+		gotPath, gotKey, gotVersion := ParsePath(encoded)
+
+		if gotPath != path || gotKey != "" || gotVersion != 1 {
+			t.Errorf("EncodePath(%q, \"\", 1) = %q, parsed back as (%q, %q, %d)",
+				path, encoded, gotPath, gotKey, gotVersion)
+		}
+	}
+}
+
+func ExampleEscapePathSegment() {
+	fmt.Println(EncodePath(`secret/ends-in\`, "password", 2))
+	// Output: secret/ends-in\\:password^2
+}

--- a/pkg/vault/path_helpers_test.go
+++ b/pkg/vault/path_helpers_test.go
@@ -18,7 +18,11 @@ func TestEscapePathSegment(t *testing.T) {
 		{name: "caret", input: "foo^bar", want: `foo\^bar`},
 		{name: "both", input: "a:b^c", want: `a\:b\^c`},
 		{name: "empty", input: "", want: ""},
-		{name: "already escaped colon", input: `a\:b`, want: `a\\:b`},
+		//The input is a raw segment holding a backslash and a colon, not an
+		// escaped one: both characters have to be escaped, or the result
+		// parses back with the colon separating a key.
+		{name: "backslash and colon", input: `a\:b`, want: `a\\\:b`},
+		{name: "trailing backslash", input: `a\`, want: `a\\`},
 		{name: "multiple colons", input: "a:b:c", want: `a\:b\:c`},
 		{name: "multiple carets", input: "a^b^c", want: `a\^b\^c`},
 	}
@@ -77,6 +81,9 @@ func TestEncodePathRoundTrip(t *testing.T) {
 		{"secret/f:oo", "b^ar", 2},
 		{"a:b", "c^d", 1},
 		{"plain", "simple", 0},
+		{`secret/ends-in\`, "bar", 0},
+		{`secret/ends-in\`, "bar", 4},
+		{"secret/foo", `key-ends-in\`, 6},
 	}
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%s:%s^%d", tc.path, tc.key, tc.version), func(t *testing.T) {

--- a/pkg/vault/tree.go
+++ b/pkg/vault/tree.go
@@ -867,10 +867,13 @@ func (w *treeWorker) workGet(t secretTree) ([]secretTree, error) {
 
 	ret := []secretTree{}
 	for _, key := range s.Keys() {
-		//Escape the key so a literal ':' or '^' in it survives the joined
-		// node name; Basename recovers the key with ParsePath.
+		//Encode both halves so a literal ':', '^' or '\' in either survives
+		// the joined node name; Basename recovers the key with ParsePath.
+		// Escaping only the key is not enough: a path ending in a backslash
+		// would make the joining colon itself look escaped, and the key
+		// would come back empty.
 		ret = append(ret, secretTree{
-			Name:    path + ":" + EscapePathSegment(key),
+			Name:    EncodePath(path, key, 0),
 			Type:    treeTypeKey,
 			Value:   string(s.data[key]),
 			Version: version,

--- a/pkg/vault/utils.go
+++ b/pkg/vault/utils.go
@@ -6,41 +6,73 @@ import (
 	"strings"
 )
 
-var keyColonRegexp = regexp.MustCompile(`[^\\](:)`)
-var versionCaretRegexp = regexp.MustCompile(`[^\\](\^)`)
 var canonicalizeSlashRe = regexp.MustCompile("//+")
+
+// lastUnescapedIndex returns the index of the last unescaped occurrence of sep
+// in s, or -1 if there is none. It scans left to right, skipping the character
+// after every backslash, so that a backslash which is itself escaped is not
+// mistaken for one that escapes sep. Index 0 never counts: a separator needs
+// something in front of it to separate.
+func lastUnescapedIndex(s string, sep byte) int {
+	last := -1
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			i++ //whatever follows is escaped, and cannot be a separator
+		case sep:
+			if i > 0 {
+				last = i
+			}
+		}
+	}
+	return last
+}
+
+// unescapePathSegment reverses EscapePathSegment. Only the characters that
+// EscapePathSegment escapes are unescaped; a backslash in front of anything
+// else was never an escape, so both characters are kept. A trailing backslash
+// has nothing to escape and is likewise literal, which is what a user gets by
+// typing a raw Vault path that ends in one.
+func unescapePathSegment(segment string) string {
+	if !strings.Contains(segment, `\`) {
+		return segment
+	}
+
+	var out strings.Builder
+	out.Grow(len(segment))
+	for i := 0; i < len(segment); i++ {
+		if segment[i] == '\\' && i+1 < len(segment) {
+			switch segment[i+1] {
+			case '\\', ':', '^':
+				i++
+			}
+		}
+		out.WriteByte(segment[i])
+	}
+
+	return out.String()
+}
 
 // ParsePath splits the given path string into its respective secret path
 // and contained key parts
 func ParsePath(path string) (secret, key string, version uint64) {
 	secret = path
-	var err error
 
-	matches := versionCaretRegexp.FindAllStringSubmatchIndex(path, -1)
-	if len(matches) > 0 { //if there exists a version caret
-		caretIdx := matches[len(matches)-1]
-		caretStart, caretEnd := caretIdx[len(caretIdx)-2], caretIdx[len(caretIdx)-1]
-		versionString := path[caretEnd:]
-		version, err = strconv.ParseUint(versionString, 10, 64)
-		if err == nil {
-			path = path[:caretStart]
+	if caret := lastUnescapedIndex(path, '^'); caret >= 0 {
+		if v, err := strconv.ParseUint(path[caret+1:], 10, 64); err == nil {
+			version = v
+			path = path[:caret]
 			secret = path
 		}
 	}
 
-	matches = keyColonRegexp.FindAllStringSubmatchIndex(path, -1)
-	if len(matches) > 0 { //if there exists a path colon
-		colonIdx := matches[len(matches)-1]
-		colonStart, colonEnd := colonIdx[len(colonIdx)-2], colonIdx[len(colonIdx)-1]
-		key = path[colonEnd:]
-		secret = path[:colonStart]
+	if colon := lastUnescapedIndex(path, ':'); colon >= 0 {
+		key = path[colon+1:]
+		secret = path[:colon]
 	}
 
-	//unescape escaped characters
-	secret = strings.ReplaceAll(secret, `\:`, ":")
-	secret = strings.ReplaceAll(secret, `\^`, "^")
-	key = strings.ReplaceAll(key, `\:`, ":")
-	key = strings.ReplaceAll(key, `\^`, "^")
+	secret = unescapePathSegment(secret)
+	key = unescapePathSegment(key)
 
 	secret = Canonicalize(secret)
 	return
@@ -49,7 +81,12 @@ func ParsePath(path string) (secret, key string, version uint64) {
 // EscapePathSegment is the reverse of ParsePath for an output secret or key
 // segment; whereas that function unescapes colons and carets, this function
 // reescapes them so that they can be run through that function again.
+//
+// The backslash is escaped first, and for the same reason: a Vault path is an
+// arbitrary string, so a name may end in one, and leaving it bare would make
+// the separator appended after it look escaped.
 func EscapePathSegment(segment string) string {
+	segment = strings.ReplaceAll(segment, `\`, `\\`)
 	segment = strings.ReplaceAll(segment, ":", `\:`)
 	segment = strings.ReplaceAll(segment, "^", `\^`)
 	return segment


### PR DESCRIPTION
A secret whose Vault path ends in a backslash makes `safe export` fail for
its entire subtree. The healthy secrets alongside it cannot be backed up.

```
$ safe export secret/good
!! no secret exists at path `secret/good/bad^1`
$ echo $?
1
```

`secret/good/one` and `secret/good/two` are ordinary, readable secrets. The
only thing wrong with the subtree is a sibling named `secret/good/bad\`,
which I created through the plain Vault HTTP API — `safe` was never involved,
so this is reachable by any client that can write a secret, not only by
someone typing safe's own path syntax.

`safe values`, `safe tree --keys`, and `safe paths --keys` fail the same way,
for the same reason. `safe get`, `safe tree`, and `safe paths` are unaffected.

## Why

safe's path mini-language escapes `:` and `^` but not the backslash that does
the escaping. The tree walk re-parses paths it built itself: to fetch a
version it encodes `secret/good/bad\` plus version 1, producing

```
secret/good/bad\^1
```

and `ParsePath` decided whether a separator was escaped by looking at the one
character in front of it (`[^\\](\^)`). One character cannot distinguish a
backslash that escapes the caret from a backslash that is itself part of the
name, so the caret was read as escaped, the whole string was taken as a
literal path, and the lookup failed. One unencodable name took out the walk.

## The change

**Escape the backslash too**, and replace the lookbehind with a left-to-right
scan, which is what makes an escaped backslash distinguishable from an
escaping one. A backslash in front of anything else was never an escape, so
both characters are kept and a raw Vault path typed as-is still resolves.

**Encode both halves of a key node's name.** The join escaped the key but not
the path, so a path ending in a backslash made the joining colon look escaped
and `Basename` recovered an empty key — every key of that secret was printed
and exported under a blank name, silently losing which key held which value.
This is only reachable once the first commit lets the walk get that far.

## Verification

Against a live `vault server -dev`, with the offending secrets written through
the raw HTTP API rather than through `safe`:

| Command | Before | After |
|---------|--------|-------|
| `safe export secret/good` | rc=1, nothing exported | rc=0, all four secrets |
| `safe tree --keys secret/good` | rc=1 | rc=0 |
| `safe paths --keys secret/good` | rc=1 | rc=0 |
| `safe values -p secret/good v` | rc=1 | rc=0 |

Backup and restore round-trip byte-identical through `safe export | safe
import` for names containing a trailing backslash, a colon, and a caret, and
for a key containing a colon — compared by reading both trees back through
the raw Vault API.

**No behaviour change for paths without a backslash.** I ran 31 command
results (get/exists/tree/paths/ls/export/versions/values/copy/move/delete,
including the `^0`, `^99`, `^abc`, and rejected-key error cases) against both
the old and new binaries on identical Vault state: the output is identical.

`make check` passes. The new `pkg/vault` sweep checks 21,420 encode/parse
round trips over the alphabet `{a, \, :, ^}`; 7,980 of them fail before this
change and none after.

## Compatibility

An encoded path containing a backslash now renders that backslash doubled, so
`safe paths` prints `secret/good/bad\\` where it used to print
`secret/good/bad\`. That is what makes the output paste back correctly, which
it did not before. Anyone who had literally typed a doubled backslash to mean
two backslashes will now get one — that population is a subset of the people
for whom these commands were already failing.

One existing test case changed. `EscapePathSegment(`a\:b`)` expected
`a\\:b`; it now yields `a\\\:b`. The old expectation no longer round-trips —
parsing `a\\:b` correctly finds an unescaped colon and splits off a key — so
the expectation was itself the bug.
