### PR TITLE
Test the version commands against a KV v2 mount

### DIFF
--- a/internal/cli/vault_fake_test.go
+++ b/internal/cli/vault_fake_test.go
@@ -9,30 +9,71 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
-// cliFakeVault serves a minimal KV v1 API: mount discovery plus GET, PUT,
-// DELETE and LIST under /v1/secret/. Paths are stored verbatim, so a secret
-// name containing a colon round-trips unchanged.
+// cliFakeVault serves a minimal KV API: mount discovery plus GET, PUT, DELETE
+// and LIST under /v1/secret/. Paths are stored verbatim, so a secret name
+// containing a colon round-trips unchanged.
+//
+// It speaks either KV version. newCLIFake gives a version 1 mount, which is
+// what most tests want; newCLIFakeV2 gives a version 2 mount, which keeps a
+// version history per path and is the only way to reach the code behind
+// versions, undelete, revert, and a versioned get. Real Vault defaults to
+// version 2, so behaviour that only exists there was previously untestable.
 type cliFakeVault struct {
-	mu   sync.Mutex
+	mu sync.Mutex
+	//data is the version 1 store: path to key/value pairs.
 	data map[string]map[string]string
+	//versions is the version 2 store: path to its version history, oldest
+	// first. Version N is at index N-1; entries are never removed, since a
+	// destroyed version still occupies its number.
+	versions map[string][]*fakeVersion
+	v2       bool
+}
+
+// fakeVersion is one version of a version 2 secret. A version is alive until
+// it is deleted, which is reversible, or destroyed, which is not.
+type fakeVersion struct {
+	data      map[string]string
+	createdAt time.Time
+	deletedAt *time.Time
+	destroyed bool
+}
+
+func (f *cliFakeVault) kvVersion() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.v2 {
+		return 2
+	}
+	return 1
 }
 
 func (f *cliFakeVault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if strings.HasPrefix(r.URL.Path, "/v1/sys/internal/ui/mounts") {
-		_, _ = w.Write([]byte(`{"data":{"secret/":{"type":"kv","options":{"version":"1"}}}}`))
+		//The client looks for the mount under data.secret; anything else
+		// decodes to an empty map and is reported as version 1 by default.
+		_, _ = fmt.Fprintf(w,
+			`{"data":{"secret":{"secret/":{"type":"kv","options":{"version":"%d"}}}}}`,
+			f.kvVersion())
 		return
 	}
 	if !strings.HasPrefix(r.URL.Path, "/v1/secret/") {
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte(`{"errors":[]}`))
+		return
+	}
+
+	if f.kvVersion() == 2 {
+		f.serveV2(w, r)
 		return
 	}
 

--- a/internal/cli/vault_fake_v2_test.go
+++ b/internal/cli/vault_fake_v2_test.go
@@ -1,0 +1,323 @@
+package cli
+
+// The version 2 half of cliFakeVault. Version 2 splits one logical secret into
+// several endpoints — data, metadata, delete, undelete, destroy — and keeps a
+// version history rather than a single value, which is what makes versions,
+// undelete, revert, and a versioned get reachable at all.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeEpoch is the creation time of the first version any test writes. Times
+// are derived from it by version number so that output is stable across runs.
+var fakeEpoch = time.Date(2020, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// newCLIFakeV2 starts a fake Vault whose secret/ mount is KV version 2, and
+// points VAULT_ADDR and VAULT_TOKEN at it. Call it after isolateHome.
+func newCLIFakeV2(t *testing.T) *cliFakeVault {
+	t.Helper()
+	fv := &cliFakeVault{
+		data:     map[string]map[string]string{},
+		versions: map[string][]*fakeVersion{},
+		v2:       true,
+	}
+	srv := httptest.NewServer(fv)
+	t.Cleanup(srv.Close)
+	t.Setenv("VAULT_ADDR", srv.URL)
+	t.Setenv("VAULT_TOKEN", "test-token")
+	return fv
+}
+
+// setV2 appends one version per map given, oldest first, at a literal Vault
+// path. Calling it twice on the same path keeps appending.
+func (f *cliFakeVault) setV2(path string, values ...map[string]string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, kv := range values {
+		f.appendVersionLocked(path, kv)
+	}
+}
+
+// appendVersionLocked adds a version. Callers hold f.mu.
+func (f *cliFakeVault) appendVersionLocked(path string, kv map[string]string) *fakeVersion {
+	n := len(f.versions[path]) + 1
+	v := &fakeVersion{
+		data:      kv,
+		createdAt: fakeEpoch.Add(time.Duration(n) * time.Minute),
+	}
+	f.versions[path] = append(f.versions[path], v)
+	return v
+}
+
+// deleteV2 marks versions deleted, which is reversible.
+func (f *cliFakeVault) deleteV2(path string, versions ...uint) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, n := range versions {
+		if v := f.versionLocked(path, n); v != nil {
+			at := fakeEpoch.Add(time.Duration(n) * time.Hour)
+			v.deletedAt = &at
+		}
+	}
+}
+
+// destroyV2 marks versions destroyed, which is not.
+func (f *cliFakeVault) destroyV2(path string, versions ...uint) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, n := range versions {
+		if v := f.versionLocked(path, n); v != nil {
+			v.destroyed = true
+		}
+	}
+}
+
+// versionStates reports each version of a path as one of "alive", "deleted"
+// or "destroyed", oldest first, for assertions.
+func (f *cliFakeVault) versionStates(path string) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for _, v := range f.versions[path] {
+		switch {
+		case v.destroyed:
+			out = append(out, "destroyed")
+		case v.deletedAt != nil:
+			out = append(out, "deleted")
+		default:
+			out = append(out, "alive")
+		}
+	}
+	return out
+}
+
+// versionLocked returns version n of a path, or nil. Callers hold f.mu.
+func (f *cliFakeVault) versionLocked(path string, n uint) *fakeVersion {
+	history := f.versions[path]
+	if n == 0 || int(n) > len(history) {
+		return nil
+	}
+	return history[n-1]
+}
+
+// latestLocked returns the highest-numbered version and its number, or nil.
+// Callers hold f.mu.
+func (f *cliFakeVault) latestLocked(path string) (*fakeVersion, uint) {
+	history := f.versions[path]
+	if len(history) == 0 {
+		return nil, 0
+	}
+	return history[len(history)-1], uint(len(history))
+}
+
+// serveV2 routes /v1/secret/<verb>/<path> to the version 2 handlers.
+func (f *cliFakeVault) serveV2(w http.ResponseWriter, r *http.Request) {
+	rest := strings.TrimPrefix(r.URL.Path, "/v1/secret/")
+	verb, subpath, found := strings.Cut(rest, "/")
+	if !found {
+		notFound(w)
+		return
+	}
+	path := "secret/" + subpath
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	switch verb {
+	case "data":
+		f.serveV2Data(w, r, path)
+	case "metadata":
+		f.serveV2Metadata(w, r, path)
+	case "delete":
+		f.applyVersions(w, r, path, func(v *fakeVersion, n uint) {
+			at := fakeEpoch.Add(time.Duration(n) * time.Hour)
+			v.deletedAt = &at
+		})
+	case "undelete":
+		f.applyVersions(w, r, path, func(v *fakeVersion, _ uint) {
+			//A destroyed version is gone for good and undelete cannot
+			// resurrect it, which is what Vault does too.
+			if !v.destroyed {
+				v.deletedAt = nil
+			}
+		})
+	case "destroy":
+		f.applyVersions(w, r, path, func(v *fakeVersion, _ uint) {
+			v.destroyed = true
+		})
+	default:
+		notFound(w)
+	}
+}
+
+func (f *cliFakeVault) serveV2Data(w http.ResponseWriter, r *http.Request, path string) {
+	switch r.Method {
+	case http.MethodPut, http.MethodPost:
+		var body struct {
+			Data map[string]string `json:"data"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"errors":["malformed body"]}`))
+			return
+		}
+		v := f.appendVersionLocked(path, body.Data)
+		writeJSON(w, map[string]any{"data": versionJSON(v, uint(len(f.versions[path])))})
+
+	case http.MethodDelete:
+		//No version given deletes the latest.
+		if v, n := f.latestLocked(path); v != nil {
+			at := fakeEpoch.Add(time.Duration(n) * time.Hour)
+			v.deletedAt = &at
+		}
+		w.WriteHeader(http.StatusNoContent)
+
+	default:
+		number := uint(0)
+		if q := r.URL.Query().Get("version"); q != "" {
+			parsed, err := strconv.ParseUint(q, 10, 64)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"errors":["invalid version"]}`))
+				return
+			}
+			number = uint(parsed)
+		}
+
+		v := (*fakeVersion)(nil)
+		if number == 0 {
+			v, number = f.latestLocked(path)
+		} else {
+			v = f.versionLocked(path, number)
+		}
+		if v == nil {
+			notFound(w)
+			return
+		}
+		//A deleted or destroyed version still has metadata, but its data is
+		// gone; Vault answers 404 with the metadata attached.
+		if v.destroyed || v.deletedAt != nil {
+			w.WriteHeader(http.StatusNotFound)
+			writeJSON(w, map[string]any{"data": map[string]any{
+				"data":     nil,
+				"metadata": versionJSON(v, number),
+			}})
+			return
+		}
+		writeJSON(w, map[string]any{"data": map[string]any{
+			"data":     v.data,
+			"metadata": versionJSON(v, number),
+		}})
+	}
+}
+
+func (f *cliFakeVault) serveV2Metadata(w http.ResponseWriter, r *http.Request, path string) {
+	if r.URL.Query().Get("list") == "true" {
+		keys := f.childrenOfV2(path)
+		if len(keys) == 0 {
+			notFound(w)
+			return
+		}
+		writeJSON(w, map[string]any{"data": map[string]any{"keys": keys}})
+		return
+	}
+
+	if r.Method == http.MethodDelete {
+		delete(f.versions, path)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	history := f.versions[path]
+	if len(history) == 0 {
+		notFound(w)
+		return
+	}
+
+	versions := map[string]any{}
+	for i, v := range history {
+		versions[strconv.Itoa(i+1)] = versionJSON(v, uint(i+1))
+	}
+	writeJSON(w, map[string]any{"data": map[string]any{
+		"created_time":    history[0].createdAt.Format(time.RFC3339Nano),
+		"updated_time":    history[len(history)-1].createdAt.Format(time.RFC3339Nano),
+		"current_version": len(history),
+		"oldest_version":  1,
+		"max_versions":    0,
+		"versions":        versions,
+	}})
+}
+
+// applyVersions runs fn over every version named in the request body. An empty
+// list is a no-op rather than an error, matching Vault.
+func (f *cliFakeVault) applyVersions(w http.ResponseWriter, r *http.Request, path string, fn func(*fakeVersion, uint)) {
+	var body struct {
+		Versions []uint `json:"versions"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"errors":["malformed body"]}`))
+		return
+	}
+	for _, n := range body.Versions {
+		if v := f.versionLocked(path, n); v != nil {
+			fn(v, n)
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// childrenOfV2 returns the immediate children of a directory in the version 2
+// store, with a trailing slash on those that are themselves directories.
+// Callers hold f.mu.
+func (f *cliFakeVault) childrenOfV2(dir string) []string {
+	seen := map[string]bool{}
+	keys := []string{}
+	for stored := range f.versions {
+		rest, ok := strings.CutPrefix(stored, dir+"/")
+		if !ok {
+			continue
+		}
+		if i := strings.Index(rest, "/"); i >= 0 {
+			rest = rest[:i+1]
+		}
+		if !seen[rest] {
+			seen[rest] = true
+			keys = append(keys, rest)
+		}
+	}
+	//Vault does not promise an order, but a stable one keeps test output
+	// readable.
+	sort.Strings(keys)
+	return keys
+}
+
+func versionJSON(v *fakeVersion, number uint) map[string]any {
+	deletion := ""
+	if v.deletedAt != nil {
+		deletion = v.deletedAt.Format(time.RFC3339Nano)
+	}
+	return map[string]any{
+		"created_time":  v.createdAt.Format(time.RFC3339Nano),
+		"deletion_time": deletion,
+		"destroyed":     v.destroyed,
+		"version":       number,
+	}
+}
+
+func writeJSON(w http.ResponseWriter, body any) {
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func notFound(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNotFound)
+	_, _ = w.Write([]byte(`{"errors":[]}`))
+}

--- a/internal/cli/versioned_commands_test.go
+++ b/internal/cli/versioned_commands_test.go
@@ -1,0 +1,205 @@
+package cli
+
+// Version history only exists on a KV version 2 mount, so these paths were
+// unreachable while the fake spoke version 1 only. They cover the success
+// side of the version commands: that they act on the right versions, and that
+// they reach the right secret when the path arrives in safe's escaped syntax.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCmdVersionsListsEveryVersionAndState(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+		map[string]string{"password": "three"},
+	)
+	fv.deleteV2("secret/app", 2)
+	fv.destroyV2("secret/app", 1)
+
+	c := newTestCLI(t)
+	var err error
+	out := captureStdout(t, func() { err = c.cmdVersions("versions", "secret/app") })
+	if err != nil {
+		t.Fatalf("cmdVersions: %v", err)
+	}
+
+	for _, want := range []string{"destroyed", "deleted", "alive"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("versions output should report %q, got:\n%s", want, out)
+		}
+	}
+	for _, want := range []string{"1", "2", "3"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("versions output should list version %s, got:\n%s", want, out)
+		}
+	}
+}
+
+// A path pasted back from safe's own output arrives escaped, while the client
+// underneath takes literal Vault paths.
+func TestCmdVersionsAcceptsEscapedPath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/od:d", map[string]string{"k": "v"})
+
+	c := newTestCLI(t)
+	var err error
+	out := captureStdout(t, func() { err = c.cmdVersions("versions", `secret/od\:d`) })
+	if err != nil {
+		t.Fatalf("cmdVersions on an escaped path: %v", err)
+	}
+	if !strings.Contains(out, "alive") {
+		t.Errorf("expected the version to be listed, got:\n%s", out)
+	}
+}
+
+func TestCmdVersionsRejectsMissingSecret(t *testing.T) {
+	isolateHome(t)
+	newCLIFakeV2(t)
+
+	c := newTestCLI(t)
+	err := c.cmdVersions("versions", "secret/absent")
+	if err == nil {
+		t.Fatal("expected an error for a secret that does not exist, got nil")
+	}
+	if !strings.Contains(err.Error(), "secret/absent") {
+		t.Errorf("error %q should name the missing secret", err)
+	}
+}
+
+func TestCmdUndeleteAllRevivesEveryDeletedVersion(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+		map[string]string{"password": "three"},
+	)
+	fv.deleteV2("secret/app", 1, 3)
+
+	c := newTestCLI(t)
+	c.opt.Undelete.All = true
+	if err := c.cmdUndelete("undelete", "secret/app"); err != nil {
+		t.Fatalf("cmdUndelete --all: %v", err)
+	}
+
+	got := fv.versionStates("secret/app")
+	want := []string{"alive", "alive", "alive"}
+	if !equalStrings(got, want) {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+}
+
+// The regression this pins: --all looked the versions up under the parsed
+// path but undeleted under the escaped one, so nothing was revived and the
+// command still exited zero.
+func TestCmdUndeleteAllAcceptsEscapedPath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/od:d",
+		map[string]string{"k": "one"},
+		map[string]string{"k": "two"},
+	)
+	fv.deleteV2("secret/od:d", 1, 2)
+
+	c := newTestCLI(t)
+	c.opt.Undelete.All = true
+	if err := c.cmdUndelete("undelete", `secret/od\:d`); err != nil {
+		t.Fatalf("cmdUndelete --all on an escaped path: %v", err)
+	}
+
+	got := fv.versionStates("secret/od:d")
+	want := []string{"alive", "alive"}
+	if !equalStrings(got, want) {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+}
+
+func TestCmdUndeleteAllLeavesDestroyedVersionsAlone(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"k": "one"},
+		map[string]string{"k": "two"},
+	)
+	fv.deleteV2("secret/app", 1, 2)
+	fv.destroyV2("secret/app", 1)
+
+	c := newTestCLI(t)
+	c.opt.Undelete.All = true
+	if err := c.cmdUndelete("undelete", "secret/app"); err != nil {
+		t.Fatalf("cmdUndelete --all: %v", err)
+	}
+
+	got := fv.versionStates("secret/app")
+	want := []string{"destroyed", "alive"}
+	if !equalStrings(got, want) {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+}
+
+func TestCmdGetReadsTheRequestedVersion(t *testing.T) {
+	isolateHome(t)
+	newCLIFakeV2(t).setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+
+	c := newTestCLI(t)
+
+	cases := []struct {
+		arg  string
+		want string
+	}{
+		{"secret/app:password^1", "one"},
+		{"secret/app:password^2", "two"},
+		//No version means the latest, and so does version zero.
+		{"secret/app:password", "two"},
+		{"secret/app:password^0", "two"},
+	}
+
+	for _, tc := range cases {
+		var err error
+		out := captureStdout(t, func() { err = c.cmdGet("get", tc.arg) })
+		if err != nil {
+			t.Errorf("cmdGet(%q): %v", tc.arg, err)
+			continue
+		}
+		if strings.TrimSpace(out) != tc.want {
+			t.Errorf("cmdGet(%q) = %q, want %q", tc.arg, strings.TrimSpace(out), tc.want)
+		}
+	}
+}
+
+func TestCmdGetRejectsDeletedVersion(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+	fv.deleteV2("secret/app", 1)
+
+	c := newTestCLI(t)
+	err := c.cmdGet("get", "secret/app:password^1")
+	if err == nil {
+		t.Fatal("expected an error reading a deleted version, got nil")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/versioned_write_test.go
+++ b/internal/cli/versioned_write_test.go
@@ -1,0 +1,104 @@
+package cli
+
+// Writing to a version 2 mount creates a version rather than replacing a
+// value, and the client reads the new version number out of the write
+// response. These cover the write side, which the seeding helpers bypass.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCmdSetCreatesANewVersion(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app", map[string]string{"password": "one"})
+
+	c := newTestCLI(t)
+	captureStdout(t, func() {
+		if err := c.cmdSet("set", "secret/app", "password=two"); err != nil {
+			t.Fatalf("cmdSet: %v", err)
+		}
+	})
+
+	if got := fv.versionStates("secret/app"); len(got) != 2 {
+		t.Fatalf("expected a second version to be created, states = %v", got)
+	}
+
+	// The older version keeps its value; only the newest one changed.
+	for _, tc := range []struct{ arg, want string }{
+		{"secret/app:password^1", "one"},
+		{"secret/app:password^2", "two"},
+		{"secret/app:password", "two"},
+	} {
+		var err error
+		out := captureStdout(t, func() { err = c.cmdGet("get", tc.arg) })
+		if err != nil {
+			t.Errorf("cmdGet(%q): %v", tc.arg, err)
+			continue
+		}
+		if strings.TrimSpace(out) != tc.want {
+			t.Errorf("cmdGet(%q) = %q, want %q", tc.arg, strings.TrimSpace(out), tc.want)
+		}
+	}
+}
+
+// A write to a path with no history starts at version 1. The client decodes
+// the version number out of the write response body, so a write that answered
+// without one would report version zero here.
+func TestCmdSetOnANewPathStartsAtVersionOne(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+
+	c := newTestCLI(t)
+	captureStdout(t, func() {
+		if err := c.cmdSet("set", "secret/fresh", "k=v"); err != nil {
+			t.Fatalf("cmdSet: %v", err)
+		}
+	})
+
+	if got := fv.versionStates("secret/fresh"); len(got) != 1 || got[0] != "alive" {
+		t.Fatalf("version states = %v, want one alive version", got)
+	}
+
+	var err error
+	out := captureStdout(t, func() { err = c.cmdVersions("versions", "secret/fresh") })
+	if err != nil {
+		t.Fatalf("cmdVersions: %v", err)
+	}
+	if !strings.Contains(out, "1") || !strings.Contains(out, "alive") {
+		t.Errorf("versions should report version 1 alive, got:\n%s", out)
+	}
+}
+
+// revert rewrites an old version forward as a new one, which exercises a read
+// at a specific version followed by a write.
+func TestCmdRevertWritesTheOldValueForward(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+
+	c := newTestCLI(t)
+	captureStdout(t, func() {
+		if err := c.cmdRevert("revert", "secret/app", "1"); err != nil {
+			t.Fatalf("cmdRevert: %v", err)
+		}
+	})
+
+	states := fv.versionStates("secret/app")
+	if len(states) != 3 {
+		t.Fatalf("revert should have appended a version, states = %v", states)
+	}
+
+	var err error
+	out := captureStdout(t, func() { err = c.cmdGet("get", "secret/app:password") })
+	if err != nil {
+		t.Fatalf("cmdGet: %v", err)
+	}
+	if strings.TrimSpace(out) != "one" {
+		t.Errorf("latest value after revert = %q, want %q", strings.TrimSpace(out), "one")
+	}
+}


### PR DESCRIPTION
`safe versions`, `safe undelete --all`, and `safe get path^N` had no test of
their success paths — only of the arguments they reject. The reason is that the
`internal/cli` fake Vault spoke KV version 1, and version history only exists on
a version 2 mount. Real `vault server -dev` defaults to version 2, so the
commands most dependent on versions were the ones tests could not reach.

I flagged this gap in #15, where the two version-command fixes had to rest on
live runs rather than tests. This closes it.

## The fake

`newCLIFakeV2` gives a version 2 mount; `newCLIFake` is untouched and still
gives version 1. Version 2 splits a secret across `data`, `metadata`, `delete`,
`undelete`, and `destroy`, and keeps a per-path version list where a version can
be alive, deleted (reversible), or destroyed (not). Seeding helpers — `setV2`,
`deleteV2`, `destroyV2` — and a `versionStates` accessor for assertions.

The endpoint shapes are taken from the vaultkv client source rather than guessed,
including the detail that a deleted version returns 404 with its metadata still
attached.

**Mount discovery was also wrong**, and the second commit fixes it. The client
reads the mount out of `data.secret`; the fake served it one level up, so the
struct decoded to an empty map and the client reported version 1 by *falling
through the nil check* rather than by being told. The old behaviour was correct
by accident. All 17 existing `newCLIFake` callers still pass.

## The tests

Nine cases: every version and state listed by `versions`; `undelete --all`
reviving every deleted version while leaving destroyed ones alone; `get` reading
a specific version, with `^0` and a bare path both meaning latest; and a deleted
version refusing to be read.

Two of them pin #15 directly. **I verified they fail without it** by reverting
those two fixes and re-running:

```
cmdVersions on an escaped path: no secret exists at path `secret/od\:d`
version states = [deleted deleted], want [alive alive]
```

The second is the important one — that bug was a silent no-op that still exited
zero, which is exactly the kind that a test has to catch because a human running
the command will not.

I mutation-tested the rest too: making `Vault.Read` ignore the requested version
fails the `get` test with `= "two", want "one"`, so it is genuinely exercising
version selection rather than passing by construction.

`make check` and `go test -race ./internal/cli/` both pass.

## Scope

Tests only — no production code changes.

This covers the `internal/cli` fake. The `pkg/vault` fake is still version 1
only; extending it the same way would benefit the `tree`/`paths`/`get` unit
tests there, and is a reasonable follow-up rather than something to fold in here.