### PR TITLE
Document escaping a literal backslash

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,18 @@ safe set secret/dc1/admin 'user:name=root'
 safe get 'secret/dc1/admin:user\:name'
 ```
 
+Only the arguments `safe` parses need escaping.  The key named on a
+`set` is taken as written, which is why the same key goes in plain
+and comes back escaped.
+
+The backslash escapes itself as well, so a path or key holding a
+literal backslash takes two:
+
+```
+safe set 'secret/dc1/we\\ird' password=s3cr3t
+safe get 'secret/dc1/we\\ird:password'
+```
+
 `safe` prints paths in this same escaped form, so anything from `safe
 paths`, `safe paths --keys`, or `safe tree --keys` can be pasted
 straight back into another command:


### PR DESCRIPTION
Follow-up to #16 and #17, held until both were in so neither carried a
merge-order dependency on the other.

#16 made the backslash escape itself, so `\\` in a path or key now means
one literal backslash. #17 wrote the escaping section but could only
describe `:` and `^`, since the backslash rule was still unmerged. This
adds the missing case.

It also names the asymmetry the section demonstrated without explaining:
the key on a `set` is taken as written, so the same key goes in as
`user:name` and comes back as `user\:name`. A reader comparing the two
example lines had no way to tell that was deliberate.

## Verification

Every command in the section, run verbatim against a live
`vault server -dev`:

| Command | Result |
|---------|--------|
| `safe set secret/dc1/admin 'user:name=root'` | rc=0 |
| `safe get 'secret/dc1/admin:user\:name'` | rc=0, `root` |
| `safe set 'secret/dc1/we\\ird' password=s3cr3t` | rc=0 |
| `safe get 'secret/dc1/we\\ird:password'` | rc=0, `s3cr3t` |
| `safe paths --keys secret/dc1/admin` | matches the block already in the section |

The third command creates a secret whose Vault path is literally
`secret/dc1/we\ird`, confirmed by reading the mount back through the raw
HTTP API. Documentation only; no code changes.