### PR TITLE
Refuse a version on gen and uuid paths

### DIFF
--- a/internal/cli/keygen.go
+++ b/internal/cli/keygen.go
@@ -36,6 +36,11 @@ func (c *CLI) cmdGen(command string, args ...string) error {
 	v := connect(true)
 
 	for len(args) > 0 {
+		//Checked before the password is generated, so a refused path costs
+		// nothing, and per path, since each one is named separately.
+		if err := assertWritableKeyPath(args[0]); err != nil {
+			return err
+		}
 		var path, key string
 		if vault.PathHasKey(args[0]) {
 			path, key, _ = vault.ParsePath(args[0])
@@ -88,6 +93,10 @@ func (c *CLI) cmdUuid(command string, args ...string) error {
 
 	if len(args) != 1 {
 		return r.Usage("uuid")
+	}
+
+	if err := assertWritableKeyPath(args[0]); err != nil {
+		return err
 	}
 
 	u := uuid.NewRandom()

--- a/internal/cli/keygen_version_test.go
+++ b/internal/cli/keygen_version_test.go
@@ -1,0 +1,152 @@
+package cli
+
+// Coverage for gen and uuid refusing a version in the path they write to.
+//
+// Both commands accept path:key -- the key names what they are about to
+// create -- so they cannot use assertWritablePath, which refuses a key as
+// well. A version is a different matter: it names a revision that already
+// exists, and neither command can write one, so naming one has to be an
+// error rather than something quietly dropped.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pborman/uuid"
+)
+
+// assertVersionRefused fails unless err complains about the version notation.
+func assertVersionRefused(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error naming the version notation, got nil")
+	}
+	if !strings.Contains(err.Error(), "/path^version") {
+		t.Fatalf("error = %q, want it to name the /path^version notation", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// gen
+// ---------------------------------------------------------------------------
+
+// The path:key form carries the version on the key, where gen splits the
+// argument itself and used to discard it.
+func TestCmdGenRefusesAVersionOnTheKey(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	c.opt.Gen.Policy = defaultGenPolicy
+	assertVersionRefused(t, c.cmdGen("gen", `secret/g:pw^7`))
+
+	if kv := fv.get("secret/g"); len(kv) != 0 {
+		t.Errorf("secret/g = %v, want nothing written", kv)
+	}
+}
+
+// The separate-key form carries the version on the path. This already
+// failed, but only once Write was reached, after the password had been
+// generated.
+func TestCmdGenRefusesAVersionOnThePath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	c.opt.Gen.Policy = defaultGenPolicy
+	assertVersionRefused(t, c.cmdGen("gen", `secret/g^7`, "pw"))
+
+	if kv := fv.get("secret/g"); len(kv) != 0 {
+		t.Errorf("secret/g = %v, want nothing written", kv)
+	}
+}
+
+// An escaped caret is part of the name, not a version, so it still writes.
+// This is what separates a check on the path syntax from one on the byte.
+func TestCmdGenAcceptsAnEscapedCaret(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	c.opt.Gen.Policy = defaultGenPolicy
+	if err := c.cmdGen("gen", `secret/g\^7:pw`); err != nil {
+		t.Fatalf("cmdGen: %v", err)
+	}
+	if kv := fv.get(`secret/g^7`); len(kv["pw"]) != 64 {
+		t.Errorf("secret/g^7[pw] has length %d, want 64 (keys: %v)", len(kv["pw"]), kv)
+	}
+}
+
+// Version 0 means the latest, which is what gen writes anyway.
+func TestCmdGenAcceptsVersionZero(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	c.opt.Gen.Policy = defaultGenPolicy
+	if err := c.cmdGen("gen", `secret/g:pw^0`); err != nil {
+		t.Fatalf("cmdGen: %v", err)
+	}
+	if kv := fv.get("secret/g"); len(kv["pw"]) != 64 {
+		t.Errorf("secret/g[pw] has length %d, want 64 (keys: %v)", len(kv["pw"]), kv)
+	}
+}
+
+// A later path is refused too, and the refusal names it rather than the one
+// that came before.
+func TestCmdGenRefusesAVersionOnALaterPath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	c.opt.Gen.Policy = defaultGenPolicy
+	err := c.cmdGen("gen", "secret/first:pw", `secret/second:pw^7`)
+	assertVersionRefused(t, err)
+	if !strings.Contains(err.Error(), "secret/second") {
+		t.Errorf("error = %q, want it to name secret/second", err)
+	}
+	if kv := fv.get("secret/second"); len(kv) != 0 {
+		t.Errorf("secret/second = %v, want nothing written", kv)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// uuid
+// ---------------------------------------------------------------------------
+
+func TestCmdUuidRefusesAVersionOnTheKey(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	assertVersionRefused(t, c.cmdUuid("uuid", `secret/u:id^7`))
+
+	if kv := fv.get("secret/u"); len(kv) != 0 {
+		t.Errorf("secret/u = %v, want nothing written", kv)
+	}
+}
+
+func TestCmdUuidRefusesAVersionOnThePath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	assertVersionRefused(t, c.cmdUuid("uuid", `secret/u^7`))
+
+	if kv := fv.get("secret/u"); len(kv) != 0 {
+		t.Errorf("secret/u = %v, want nothing written", kv)
+	}
+}
+
+func TestCmdUuidAcceptsAnEscapedCaret(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	if err := c.cmdUuid("uuid", `secret/u\^7:id`); err != nil {
+		t.Fatalf("cmdUuid: %v", err)
+	}
+	if kv := fv.get(`secret/u^7`); uuid.Parse(kv["id"]) == nil {
+		t.Errorf("secret/u^7[id] = %q, want a UUID (keys: %v)", kv["id"], kv)
+	}
+}

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -92,6 +92,15 @@ func assertWritablePath(path string) error {
 	if vault.PathHasKey(path) {
 		return fmt.Errorf("cannot write to paths in /path:key notation (%s)", path)
 	}
+	return assertWritableKeyPath(path)
+}
+
+// assertWritableKeyPath refuses a path naming a version, for the commands that
+// do accept a key. gen and uuid take one because it names the key they are
+// about to create, but a version names a revision that already exists, and
+// there is no writing to that, so naming one is a mistake rather than
+// something to drop on the floor.
+func assertWritableKeyPath(path string) error {
 	if vault.PathHasVersion(path) {
 		return fmt.Errorf("cannot write to paths in /path^version notation (%s)", path)
 	}


### PR DESCRIPTION
`safe gen secret/a:pw^7` generates a password, writes it, and exits zero.
The `^7` is discarded without a word. Same for `safe uuid secret/a:id^7`.

```
$ safe gen secret/g3:pw^7
$ echo $?
0
```

The secret it wrote is at version 1. Nothing asked for version 7 was
honoured, and nothing said so.

This is the case the README already claims does not happen: *"Not every
command understands all three parts, and the ones that cannot honour a key
or a version say so rather than ignoring it."* That sentence was true of
every command except these two.

## Why

Both commands split the `path:key` argument themselves:

```go
path, key, _ = vault.ParsePath(args[0])
```

The version goes into `_`. `assertWritablePath` would have caught it, but
they cannot call it — it refuses a key as well, and a key is exactly what
these two commands legitimately take, since it names what they are about
to create.

The same version written on the path instead of the key
(`safe gen secret/g4^7 pw`) did fail, because `Write` rejects it — but only
after the password had been generated and thrown away.

## The change

Split the version half of `assertWritablePath` into `assertWritableKeyPath`
and call it from both commands before any key material is generated.
`assertWritablePath` now delegates to it, so the two checks cannot drift
apart.

## Verification

Against a live `vault server -dev`:

| Command | Before | After |
|---------|--------|-------|
| `safe gen 'secret/a:pw^7'` | rc=0, version ignored | rc=1, names the argument |
| `safe uuid 'secret/a:id^7'` | rc=0, version ignored | rc=1, names the argument |
| `safe gen 'secret/a^7' pw` | rc=1, after generating | rc=1, before generating |
| `safe uuid 'secret/a^7'` | rc=1, after generating | rc=1, before generating |

Still accepted, unchanged: `gen path key`, `gen path:key`, `uuid path:key`,
`gen 12 path key`, and `^0`, which the README defines as the latest version
and so means what these commands do anyway.

The check reads the path syntax rather than looking for a `^`, so an
escaped caret is still part of the name: `safe gen 'secret/ok3\^7:pw'`
writes to `secret/ok3^7`. Replacing `PathHasVersion` with
`strings.Contains(path, "^")` fails that case and the `^0` case, which is
what those two tests are there to pin.

`make check` and `go test -race ./...` pass.