### PR TITLE
Name the version a failed read asked for

### DIFF
--- a/internal/cli/version_not_found_test.go
+++ b/internal/cli/version_not_found_test.go
@@ -1,0 +1,135 @@
+package cli
+
+// Coverage for what a read says when the version it was given is not the
+// reason a secret could not be read, or is.
+//
+// Every one of these used to print "no secret exists at path X" — true only
+// in the last case, and actively misleading in the rest, since the secret is
+// sitting right there and `safe versions` will list it.
+
+import (
+	"strings"
+	"testing"
+)
+
+// readErr runs get and returns the error it produced, failing if there was
+// none.
+func readErr(t *testing.T, c *CLI, args ...string) string {
+	t.Helper()
+	err := c.cmdGet("get", args...)
+	if err == nil {
+		t.Fatalf("cmdGet(%v) = nil, want an error", args)
+	}
+	return err.Error()
+}
+
+// A version that was never created names itself, rather than accusing the
+// secret of being absent.
+func TestGetNamesAVersionThatNeverExisted(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/a",
+		map[string]string{"k": "one"},
+		map[string]string{"k": "two"})
+
+	c := newTestCLI(t)
+	got := readErr(t, c, "secret/a:k^99")
+	if !strings.Contains(got, "no version 99 of secret `secret/a` exists") {
+		t.Errorf("error = %q, want it to name version 99 of secret/a", got)
+	}
+}
+
+// The same, with no key on the path: the version is still the problem.
+func TestGetNamesAVersionThatNeverExistedWithoutAKey(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/a", map[string]string{"k": "one"})
+
+	c := newTestCLI(t)
+	got := readErr(t, c, "secret/a^99")
+	if !strings.Contains(got, "no version 99 of secret `secret/a` exists") {
+		t.Errorf("error = %q, want it to name version 99 of secret/a", got)
+	}
+}
+
+// A deleted version is recoverable, so saying so points at safe undelete
+// instead of at a secret the reader will not find anything wrong with.
+func TestGetReportsADeletedVersionAsDeleted(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/del",
+		map[string]string{"k": "one"},
+		map[string]string{"k": "two"})
+	fv.deleteV2("secret/del", 2)
+
+	c := newTestCLI(t)
+	got := readErr(t, c, "secret/del:k^2")
+	if !strings.Contains(got, "version 2 of secret `secret/del` has been deleted") {
+		t.Errorf("error = %q, want it to report version 2 as deleted", got)
+	}
+}
+
+// A destroyed version is not recoverable, and the two words are worth
+// keeping apart for someone deciding whether to go looking for a backup.
+func TestGetReportsADestroyedVersionAsDestroyed(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/gone",
+		map[string]string{"k": "one"},
+		map[string]string{"k": "two"})
+	fv.destroyV2("secret/gone", 1)
+
+	c := newTestCLI(t)
+	got := readErr(t, c, "secret/gone:k^1")
+	if !strings.Contains(got, "version 1 of secret `secret/gone` has been destroyed") {
+		t.Errorf("error = %q, want it to report version 1 as destroyed", got)
+	}
+}
+
+// A secret that is genuinely absent keeps the message it always had, even
+// when a version was asked for: there is no history to narrow it down with.
+func TestGetStillReportsAMissingSecret(t *testing.T) {
+	isolateHome(t)
+	newCLIFakeV2(t)
+
+	c := newTestCLI(t)
+	for _, arg := range []string{"secret/nope:k", "secret/nope:k^99"} {
+		got := readErr(t, c, arg)
+		if !strings.Contains(got, "no secret exists at path `secret/nope`") {
+			t.Errorf("cmdGet(%q) error = %q, want the missing-secret message", arg, got)
+		}
+	}
+}
+
+// A missing key in a version that does exist is still a missing key.
+func TestGetStillReportsAMissingKey(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/a", map[string]string{"k": "one"})
+
+	c := newTestCLI(t)
+	got := readErr(t, c, "secret/a:nope^1")
+	if !strings.Contains(got, "no key `nope` exists in secret `secret/a`") {
+		t.Errorf("error = %q, want the missing-key message", got)
+	}
+}
+
+// A version that is there reads normally; the new branch must not intercept
+// a successful read.
+func TestGetStillReadsAnExistingVersion(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/a",
+		map[string]string{"k": "one"},
+		map[string]string{"k": "two"})
+
+	c := newTestCLI(t)
+	out := captureStdout(t, func() {
+		if err := c.cmdGet("get", "secret/a:k^1"); err != nil {
+			t.Fatalf("cmdGet: %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "one" {
+		t.Errorf("get secret/a:k^1 = %q, want %q", strings.TrimSpace(out), "one")
+	}
+}

--- a/pkg/vault/errors.go
+++ b/pkg/vault/errors.go
@@ -35,6 +35,23 @@ func NewSecretNotFoundError(path string) error {
 	return secretNotFound{message: fmt.Sprintf("no secret exists at path `%s`", path)}
 }
 
+// NewVersionNotFoundError returns an error describing a version that could not
+// be read from a secret which does itself exist. state names why, in the
+// vocabulary `safe versions` prints — "deleted" or "destroyed" — or is empty
+// if the version was simply never created.
+//
+// The result is the same kind of error as NewSecretNotFoundError, since the
+// secret is still what could not be read; only the wording narrows. Callers
+// testing IsSecretNotFound or IsNotFound are unaffected.
+func NewVersionNotFoundError(path string, version uint64, state string) error {
+	if state != "" {
+		return secretNotFound{message: fmt.Sprintf(
+			"version %d of secret `%s` has been %s", version, path, state)}
+	}
+	return secretNotFound{message: fmt.Sprintf(
+		"no version %d of secret `%s` exists", version, path)}
+}
+
 // IsSecretNotFound returns true if the given error was created with
 // NewSecretNotFoundError(), including when the error is wrapped with %w.
 // False otherwise.

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -149,7 +149,7 @@ func (v *Vault) Read(path string) (secret *Secret, err error) {
 	_, err = v.client.Get(path, &raw, &vaultkv.KVGetOpts{Version: uint(version)})
 	if err != nil {
 		if vaultkv.IsNotFound(err) {
-			err = NewSecretNotFoundError(path)
+			err = v.notFoundReading(path, version)
 		}
 		return
 	}
@@ -178,6 +178,44 @@ func (v *Vault) Read(path string) (secret *Secret, err error) {
 	}
 
 	return
+}
+
+// notFoundReading turns a 404 from a read into the most specific not-found
+// error it can. A versioned read fails either because the secret is not there
+// or because that one version is not, and the two send a reader looking in
+// different places: one to create the secret, the other to `safe versions`.
+//
+// Telling them apart costs a metadata request, so it is only paid when a
+// version was actually named. A plain read of a missing secret — what every
+// `safe gen` does on a path it is about to create — still costs the single
+// request it always did.
+func (v *Vault) notFoundReading(path string, version uint64) error {
+	if version == 0 {
+		return NewSecretNotFoundError(path)
+	}
+
+	versions, err := v.client.Versions(path)
+	if err != nil || len(versions) == 0 {
+		//No history to consult, so the secret itself is the better answer.
+		return NewSecretNotFoundError(path)
+	}
+
+	for _, v := range versions {
+		if uint64(v.Version) != version {
+			continue
+		}
+		switch {
+		case v.Destroyed:
+			return NewVersionNotFoundError(path, version, "destroyed")
+		case v.Deleted:
+			return NewVersionNotFoundError(path, version, "deleted")
+		}
+		//The version is there and alive, so the 404 was about something
+		// other than the version; do not claim otherwise.
+		return NewSecretNotFoundError(path)
+	}
+
+	return NewVersionNotFoundError(path, version, "")
 }
 
 // List returns the set of (relative) paths that are directly underneath

--- a/pkg/vault/version_not_found_test.go
+++ b/pkg/vault/version_not_found_test.go
@@ -1,0 +1,57 @@
+package vault
+
+// A version-not-found error narrows the wording of a secret-not-found error
+// without changing its kind. Callers branch on IsNotFound and IsSecretNotFound
+// to decide whether a path is absent — `exists` turns it into an exit code,
+// and gen, uuid, ssh, rsa and dhparam all treat it as "nothing here yet, carry
+// on and create it". If the narrowed error stopped answering to those, a
+// missing version would start looking like a hard failure.
+
+import "testing"
+
+func TestVersionNotFoundIsStillASecretNotFound(t *testing.T) {
+	for _, state := range []string{"", "deleted", "destroyed"} {
+		err := NewVersionNotFoundError("secret/a", 2, state)
+		if !IsSecretNotFound(err) {
+			t.Errorf("IsSecretNotFound(%q) = false, want true", err)
+		}
+		if !IsNotFound(err) {
+			t.Errorf("IsNotFound(%q) = false, want true", err)
+		}
+		if IsKeyNotFound(err) {
+			t.Errorf("IsKeyNotFound(%q) = true, want false", err)
+		}
+	}
+}
+
+func TestVersionNotFoundMessage(t *testing.T) {
+	cases := []struct {
+		name    string
+		state   string
+		message string
+	}{
+		{
+			name:    "never created",
+			state:   "",
+			message: "no version 2 of secret `secret/a` exists",
+		},
+		{
+			name:    "deleted",
+			state:   "deleted",
+			message: "version 2 of secret `secret/a` has been deleted",
+		},
+		{
+			name:    "destroyed",
+			state:   "destroyed",
+			message: "version 2 of secret `secret/a` has been destroyed",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewVersionNotFoundError("secret/a", 2, tc.state).Error()
+			if got != tc.message {
+				t.Errorf("Error() = %q, want %q", got, tc.message)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Asking for a version that is not there blames the secret:

```
$ safe get 'secret/a:k^99'
!! no secret exists at path `secret/a`
$ safe get 'secret/a:k'
two
```

The secret exists. `safe versions secret/a` lists it. Only version 99 was
missing, and the message sent the reader looking in the wrong place.

The same message covered three different situations, two of which are
recoverable and one of which is not:

| Situation | Before | After |
|-----------|--------|-------|
| version never created | ``no secret exists at path `secret/a` `` | ``no version 99 of secret `secret/a` exists`` |
| version deleted | ``no secret exists at path `secret/del` `` | ``version 2 of secret `secret/del` has been deleted`` |
| version destroyed | ``no secret exists at path `secret/a` `` | ``version 1 of secret `secret/a` has been destroyed`` |
| secret genuinely absent | ``no secret exists at path `secret/nope` `` | unchanged |

Deleted and destroyed are worth keeping apart: `safe undelete` brings one
back and nothing brings the other back, so the two should not read alike to
someone deciding whether to go looking for a backup.

## The change

A 404 from a versioned read consults the version history before choosing a
message. If there is no history, or the version is listed and alive, it
falls back to the message it always used rather than guessing.

## Cost

The history is fetched only when a version was named *and* the read failed.
That matters because `Read` is not only an error path: `gen`, `uuid`, `ssh`,
`rsa`, and `dhparam` all read a path they are about to create and expect the
miss. None of them name a version, so none of them pay.

Measured through a Vault file audit device, counting requests to the mount:

| Command | develop | this branch |
|---------|---------|-------------|
| `safe gen secret/new pw` | 2 (read, create) | 2 (read, create) |
| `safe ssh 1024 secret/new` | 2 (read, create) | 2 (read, create) |

## Compatibility

The narrowed error is still a `secretNotFound`, so `IsNotFound` and
`IsSecretNotFound` keep answering true. `safe exists 'secret/a:k^99'` still
exits 1 silently, and the generating commands still treat an absent path as
something to create. A test pins that, since a new error type here would
have quietly turned a missing version into a hard failure.

## Verification

Against a live `vault server -dev`, with a KV v1 mount alongside the default
v2 one. Every row above confirmed, plus unchanged behaviour for a missing
key, a live version, `kv1/b:k^1` on a v1 mount, and `kv1/b:k^99`, which
correctly reports the version rather than the secret.

Reverting the new branch fails the four tests that assert the narrowed
wording and leaves the three control tests passing.

`make check` and `go test -race ./...` pass.

## Not covered here

`safe get secret/del` — no version named — still says the secret does not
exist when what actually happened is that its latest version was deleted.
Narrowing that one means fetching history on *every* missed read, including
the `gen` hot path above, so it wants a different approach and its own
change.