### PR TITLE
Unify wording for an unreadable version

### DIFF
--- a/internal/cli/error_wording_test.go
+++ b/internal/cli/error_wording_test.go
@@ -1,0 +1,250 @@
+package cli
+
+// safe says "that version cannot be read" from three places — a read, a
+// revert, and an undelete — and each phrased it differently, down to the
+// capitalisation and which quote character closed the secret name. A reader
+// who hits two of them has no way to tell they were told the same thing.
+//
+// These pin the one sentence, and pin the fact that sharing the sentence did
+// not also share the error kind: an undelete failure travels into the tree
+// walk, whose callers drop not-found errors on the floor.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// versionedFake serves a v2 mount holding secret/s with three versions, the
+// first destroyed and the second deleted, which is every state a version can
+// be in at once.
+func versionedFake(t *testing.T) *cliFakeVault {
+	t.Helper()
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/s",
+		map[string]string{"a": "1"},
+		map[string]string{"a": "2"},
+		map[string]string{"a": "3"})
+	fv.destroyV2("secret/s", 1)
+	fv.deleteV2("secret/s", 2)
+	return fv
+}
+
+// errText fails unless err is non-nil, and returns its message.
+func errText(t *testing.T, err error, what string) string {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s = nil, want an error", what)
+	}
+	return err.Error()
+}
+
+// All three commands describe the same destroyed version the same way.
+func TestDestroyedVersionReadsTheSameEverywhere(t *testing.T) {
+	const want = "version 1 of secret `secret/s` has been destroyed"
+
+	isolateHome(t)
+	versionedFake(t)
+	c := newTestCLI(t)
+
+	for _, tc := range []struct {
+		command string
+		err     error
+	}{
+		{"get", c.cmdGet("get", "secret/s^1")},
+		{"revert", c.cmdRevert("revert", "secret/s", "1")},
+		{"undelete", c.cmdUndelete("undelete", "secret/s^1")},
+	} {
+		if got := errText(t, tc.err, tc.command); got != want {
+			t.Errorf("%s = %q, want %q", tc.command, got, want)
+		}
+	}
+}
+
+// And the same for a version number that was never issued.
+func TestMissingVersionReadsTheSameEverywhere(t *testing.T) {
+	const want = "no version 9 of secret `secret/s` exists"
+
+	isolateHome(t)
+	versionedFake(t)
+	c := newTestCLI(t)
+
+	for _, tc := range []struct {
+		command string
+		err     error
+	}{
+		{"get", c.cmdGet("get", "secret/s^9")},
+		{"revert", c.cmdRevert("revert", "secret/s", "9")},
+		{"undelete", c.cmdUndelete("undelete", "secret/s^9")},
+	} {
+		if got := errText(t, tc.err, tc.command); got != want {
+			t.Errorf("%s = %q, want %q", tc.command, got, want)
+		}
+	}
+}
+
+// revert can be told to go ahead anyway, so it appends the flag that would do
+// it. What it appends the flag to is the sentence a read gives.
+func TestRevertOnADeletedVersionLeadsWithTheSharedSentence(t *testing.T) {
+	const shared = "version 2 of secret `secret/s` has been deleted"
+
+	isolateHome(t)
+	versionedFake(t)
+	c := newTestCLI(t)
+
+	got := errText(t, c.cmdRevert("revert", "secret/s", "2"), "revert")
+	if !strings.HasPrefix(got, shared) {
+		t.Errorf("revert = %q, want it to open with %q", got, shared)
+	}
+	if !strings.Contains(got, "--deleted") {
+		t.Errorf("revert = %q, want it to name --deleted", got)
+	}
+	if reader := errText(t, c.cmdGet("get", "secret/s^2"), "get"); reader != shared {
+		t.Errorf("get = %q, want %q", reader, shared)
+	}
+}
+
+// A secret that is not there at all is reported as such by both commands that
+// look up its history, rather than as a version problem.
+func TestMissingSecretReadsTheSameEverywhere(t *testing.T) {
+	const want = "no secret exists at path `secret/nope`"
+
+	isolateHome(t)
+	versionedFake(t)
+	c := newTestCLI(t)
+
+	for _, tc := range []struct {
+		command string
+		err     error
+	}{
+		{"get", c.cmdGet("get", "secret/nope^3")},
+		{"revert", c.cmdRevert("revert", "secret/nope", "1")},
+	} {
+		if got := errText(t, tc.err, tc.command); got != want {
+			t.Errorf("%s = %q, want %q", tc.command, got, want)
+		}
+	}
+}
+
+// copy checks the state of the version before it moves anything, and had its
+// own way of describing what it found — one that echoed the path with its
+// version glued on rather than naming the version.
+func TestCopyOnAnUnreadableVersionUsesTheSharedSentence(t *testing.T) {
+	isolateHome(t)
+	versionedFake(t)
+	c := newTestCLI(t)
+
+	for _, tc := range []struct{ path, want string }{
+		{"secret/s^1", "version 1 of secret `secret/s` has been destroyed"},
+		{"secret/s^2", "version 2 of secret `secret/s` has been deleted"},
+		{"secret/s^9", "no version 9 of secret `secret/s` exists"},
+	} {
+		got := errText(t, c.cmdCopy("copy", tc.path, "secret/dst"), "copy "+tc.path)
+		if got != tc.want {
+			t.Errorf("copy %s = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+// With no version named, the number is the part the caller does not already
+// know, so it is what the message leads with.
+func TestCopyNamesTheVersionItLandedOn(t *testing.T) {
+	const want = "version 2 of secret `secret/d` has been deleted"
+
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/d",
+		map[string]string{"a": "1"},
+		map[string]string{"a": "2"})
+	fv.deleteV2("secret/d", 2)
+
+	c := newTestCLI(t)
+	if got := errText(t, c.cmdCopy("copy", "secret/d", "secret/dst"), "copy"); got != want {
+		t.Errorf("copy = %q, want %q", got, want)
+	}
+}
+
+// A secret with nothing left to operate on is about the secret, not any one
+// version, so it keeps its own sentence — in the same voice as the rest.
+func TestDeleteAllOnASecretWithNothingAliveNamesTheSecret(t *testing.T) {
+	const want = "no living version of secret `secret/d` exists"
+
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/d", map[string]string{"a": "1"})
+	fv.deleteV2("secret/d", 1)
+
+	c := newTestCLI(t)
+	c.opt.Delete.All = true
+	if got := errText(t, c.cmdDelete("delete", "secret/d"), "delete -a"); got != want {
+		t.Errorf("delete -a = %q, want %q", got, want)
+	}
+}
+
+// The same for a destroy, which will settle for a deleted version and so says
+// so when there is not one of those either.
+func TestDestroyAllOnAFullyDestroyedSecretNamesTheSecret(t *testing.T) {
+	const want = "no living or deleted version of secret `secret/d` exists"
+
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/d", map[string]string{"a": "1"})
+	fv.destroyV2("secret/d", 1)
+
+	c := newTestCLI(t)
+	c.opt.Delete.All = true
+	c.opt.Delete.Destroy = true
+	if got := errText(t, c.cmdDelete("delete", "secret/d"), "delete -a --destroy"); got != want {
+		t.Errorf("delete -a --destroy = %q, want %q", got, want)
+	}
+}
+
+// safe rm -f is meant to shrug at anything that is not there, and it decides
+// what counts by asking IsNotFound. These have always been that kind, so
+// naming the version must not change what -f does with them.
+func TestForcedDeleteStillShrugsAtAnUnreadableVersion(t *testing.T) {
+	isolateHome(t)
+	versionedFake(t)
+	c := newTestCLI(t)
+	c.opt.Delete.Force = true
+
+	for _, path := range []string{"secret/s^1", "secret/s^2", "secret/s^9"} {
+		if err := c.cmdDelete("delete", path); err != nil {
+			t.Errorf("delete -f %s = %v, want nil", path, err)
+		}
+	}
+}
+
+// Sharing the wording must not share the kind. Undelete's error reaches the
+// tree walk, and a walk error that answers to IsNotFound is discarded by
+// MoveCopyTree's skip-if-exists check, so a destroyed version reported as a
+// not-found would go missing rather than stop the copy.
+func TestUndeleteFailureIsNotANotFound(t *testing.T) {
+	isolateHome(t)
+	versionedFake(t)
+	c := newTestCLI(t)
+
+	err := c.cmdUndelete("undelete", "secret/s^1")
+	if err == nil {
+		t.Fatal("cmdUndelete on a destroyed version = nil, want an error")
+	}
+	if vault.IsNotFound(err) {
+		t.Errorf("undelete error %q answers to IsNotFound; a tree walk would swallow it", err)
+	}
+}
+
+// The same for revert, which reports the condition without reading it either.
+func TestRevertFailureIsNotANotFound(t *testing.T) {
+	isolateHome(t)
+	versionedFake(t)
+	c := newTestCLI(t)
+
+	err := c.cmdRevert("revert", "secret/s", "1")
+	if err == nil {
+		t.Fatal("cmdRevert onto a destroyed version = nil, want an error")
+	}
+	if vault.IsNotFound(err) {
+		t.Errorf("revert error %q answers to IsNotFound, but nothing was missing", err)
+	}
+}

--- a/internal/cli/revert_test.go
+++ b/internal/cli/revert_test.go
@@ -41,7 +41,7 @@ func TestCmdRevertColonBearingPathMissingVersion(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error reverting to a version that does not exist")
 	}
-	if !strings.Contains(err.Error(), "Version 2") {
+	if !strings.Contains(err.Error(), "no version 2 of secret `secret/we:ird` exists") {
 		t.Errorf("error %q should report version 2 as missing", err)
 	}
 }

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -679,16 +679,19 @@ func (c *CLI) cmdRevert(command string, args ...string) error {
 		return err
 	}
 	if len(allVersions) == 0 {
-		return fmt.Errorf("no versions found for %s", secret)
+		return errors.New(vault.SecretNotFoundMessage(secret))
 	}
 
-	destroyedErr := fmt.Errorf("Version %d of secret `%s' is destroyed", targetVersion, secret)
+	//Said the way a read says it, but left plain: revert reports these by
+	// reading version metadata, not by failing a read, so nothing downstream
+	// should mistake one for a missing path.
+	destroyedErr := errors.New(vault.VersionNotFoundMessage(secret, targetVersion, "destroyed"))
 	if targetVersion < uint64(allVersions[0].Version) {
 		return destroyedErr
 	}
 
 	if targetVersion > uint64(allVersions[len(allVersions)-1].Version) {
-		return fmt.Errorf("Version %d of secret `%s' does not exist", targetVersion, secret)
+		return errors.New(vault.VersionNotFoundMessage(secret, targetVersion, ""))
 	}
 
 	versionObject := allVersions[targetVersion-uint64(allVersions[0].Version)]
@@ -698,7 +701,8 @@ func (c *CLI) cmdRevert(command string, args ...string) error {
 
 	if versionObject.Deleted {
 		if !opt.Revert.Deleted {
-			return fmt.Errorf("Version %d of secret `%s' is deleted. To force a read, specify --deleted", targetVersion, secret)
+			return fmt.Errorf("%s; pass --deleted to undelete it, revert to it, and delete it again",
+				vault.VersionNotFoundMessage(secret, targetVersion, "deleted"))
 		}
 
 		err = v.Undelete(vault.EncodePath(secret, "", targetVersion))

--- a/pkg/vault/error_wording_test.go
+++ b/pkg/vault/error_wording_test.go
@@ -1,0 +1,47 @@
+package vault
+
+// The sentences safe uses for "cannot read that" live here, so that the
+// commands which walk version history themselves — revert and undelete — can
+// say what a read would say without having to return what a read returns.
+//
+// The split matters: those commands' errors travel into the tree walk, and a
+// walk error answering to IsNotFound is discarded by the skip-if-exists check
+// in MoveCopyTree. Sharing wording is safe; sharing the kind is not.
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSecretNotFoundMessage(t *testing.T) {
+	const want = "no secret exists at path `secret/a`"
+
+	if got := SecretNotFoundMessage("secret/a"); got != want {
+		t.Errorf("SecretNotFoundMessage = %q, want %q", got, want)
+	}
+	if got := NewSecretNotFoundError("secret/a").Error(); got != want {
+		t.Errorf("NewSecretNotFoundError = %q, want %q", got, want)
+	}
+}
+
+func TestVersionNotFoundMessageMatchesItsConstructor(t *testing.T) {
+	for _, state := range []string{"", "deleted", "destroyed"} {
+		want := VersionNotFoundMessage("secret/a", 2, state)
+		if got := NewVersionNotFoundError("secret/a", 2, state).Error(); got != want {
+			t.Errorf("state %q: constructor = %q, message = %q", state, got, want)
+		}
+	}
+}
+
+// A message on its own is just a message. Wrapping one in errors.New must not
+// produce something IsNotFound answers for.
+func TestSharedMessagesCarryNoKind(t *testing.T) {
+	for _, err := range []error{
+		errors.New(SecretNotFoundMessage("secret/a")),
+		errors.New(VersionNotFoundMessage("secret/a", 2, "destroyed")),
+	} {
+		if IsNotFound(err) {
+			t.Errorf("IsNotFound(%q) = true, want false", err)
+		}
+	}
+}

--- a/pkg/vault/errors.go
+++ b/pkg/vault/errors.go
@@ -29,27 +29,42 @@ func IsNotFound(err error) bool {
 	return IsSecretNotFound(err) || IsKeyNotFound(err)
 }
 
-// NewSecretNotFoundError returns an error with a message descibing the path
-// which could not be found in the secret backend.
-func NewSecretNotFoundError(path string) error {
-	return secretNotFound{message: fmt.Sprintf("no secret exists at path `%s`", path)}
+// SecretNotFoundMessage returns the sentence safe uses for a secret it could
+// not read. See VersionNotFoundMessage for why the wording is available apart
+// from the error that usually carries it.
+func SecretNotFoundMessage(path string) string {
+	return fmt.Sprintf("no secret exists at path `%s`", path)
 }
 
-// NewVersionNotFoundError returns an error describing a version that could not
-// be read from a secret which does itself exist. state names why, in the
+// VersionNotFoundMessage returns the sentence safe uses for a version it could
+// not read from a secret that does itself exist. state names why, in the
 // vocabulary `safe versions` prints — "deleted" or "destroyed" — or is empty
 // if the version was simply never created.
 //
-// The result is the same kind of error as NewSecretNotFoundError, since the
-// secret is still what could not be read; only the wording narrows. Callers
-// testing IsSecretNotFound or IsNotFound are unaffected.
-func NewVersionNotFoundError(path string, version uint64, state string) error {
-	if state != "" {
-		return secretNotFound{message: fmt.Sprintf(
-			"version %d of secret `%s` has been %s", version, path, state)}
+// revert and undelete report these same conditions, but they find them by
+// walking version metadata rather than by failing a read, and their errors
+// reach the tree walk, where anything answering to IsNotFound is discarded by
+// the skip-if-exists check in MoveCopyTree. They take the wording from here
+// and keep their own error kind.
+func VersionNotFoundMessage(path string, version uint64, state string) string {
+	if state == "" {
+		return fmt.Sprintf("no version %d of secret `%s` exists", version, path)
 	}
-	return secretNotFound{message: fmt.Sprintf(
-		"no version %d of secret `%s` exists", version, path)}
+	return fmt.Sprintf("version %d of secret `%s` has been %s", version, path, state)
+}
+
+// NewSecretNotFoundError returns an error with a message descibing the path
+// which could not be found in the secret backend.
+func NewSecretNotFoundError(path string) error {
+	return secretNotFound{message: SecretNotFoundMessage(path)}
+}
+
+// NewVersionNotFoundError returns VersionNotFoundMessage as an error of the
+// same kind as NewSecretNotFoundError, since the secret is still what could
+// not be read; only the wording narrows. Callers testing IsSecretNotFound or
+// IsNotFound are unaffected.
+func NewVersionNotFoundError(path string, version uint64, state string) error {
+	return secretNotFound{message: VersionNotFoundMessage(path, version, state)}
 }
 
 // IsSecretNotFound returns true if the given error was created with

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -287,9 +288,6 @@ func (v *Vault) verifySecretState(path string, opts verifyOpts) error {
 		return err
 	}
 
-	var deletedErr = secretNotFound{fmt.Sprintf("`%s' is deleted", path)}
-	var destroyedErr = secretNotFound{fmt.Sprintf("`%s' is destroyed", path)}
-
 	switch mountV {
 	case 1:
 		return v.verifySecretExists(path)
@@ -317,23 +315,27 @@ func (v *Vault) verifySecretState(path string, opts verifyOpts) error {
 			if version == 0 {
 				v = versions[len(versions)-1]
 			} else {
+				//Older than anything Vault still lists, which only happens
+				// once a version has been destroyed and pruned.
 				if uint64(versions[0].Version) > version {
-					return destroyedErr
+					return NewVersionNotFoundError(secret, version, "destroyed")
 				}
 
 				if version > uint64(versions[len(versions)-1].Version) {
-					return secretNotFound{fmt.Sprintf("`%s' references a version that does not yet exist", path)}
+					return NewVersionNotFoundError(secret, version, "")
 				}
 
 				idx := version - uint64(versions[0].Version)
 				v = versions[idx]
 			}
 
+			//Named by number even when the caller asked for the latest, since
+			// which version that was is the part they do not know.
 			if v.Destroyed {
-				return destroyedErr
+				return NewVersionNotFoundError(secret, uint64(v.Version), "destroyed")
 			}
 			if opts.State == verifyStateAlive && v.Deleted {
-				return deletedErr
+				return NewVersionNotFoundError(secret, uint64(v.Version), "deleted")
 			}
 		} else {
 			for i := range versions {
@@ -344,10 +346,9 @@ func (v *Vault) verifySecretState(path string, opts verifyOpts) error {
 
 			//If we got this far, we couldn't find a version that satisfied our constraints
 			if opts.State == verifyStateAlive {
-				return secretNotFound{fmt.Sprintf("No living versions for `%s'", path)}
-			} else {
-				return secretNotFound{fmt.Sprintf("No living or deleted versions for `%s'", path)}
+				return secretNotFound{fmt.Sprintf("no living version of secret `%s` exists", secret)}
 			}
+			return secretNotFound{fmt.Sprintf("no living or deleted version of secret `%s` exists", secret)}
 		}
 
 	default:
@@ -589,7 +590,9 @@ func (v *Vault) Undelete(path string) error {
 		version = uint64(respVersions[len(respVersions)-1].Version)
 	}
 
-	destroyedErr := fmt.Errorf("`%s' version: %d is destroyed", secret, version)
+	//Said the way a read says it, but left a plain error: this one reaches the
+	// tree walk, and MoveCopyTree drops walk errors that answer to IsNotFound.
+	destroyedErr := errors.New(VersionNotFoundMessage(secret, version, "destroyed"))
 	firstVersion := respVersions[0].Version
 	if version < uint64(firstVersion) {
 		return destroyedErr
@@ -602,7 +605,7 @@ func (v *Vault) Undelete(path string) error {
 	}
 	idx := int(diff)
 	if idx >= len(respVersions) {
-		return fmt.Errorf("version %d of `%s' does not yet exist", version, secret)
+		return errors.New(VersionNotFoundMessage(secret, version, ""))
 	}
 
 	if respVersions[idx].Destroyed {


### PR DESCRIPTION
`safe` has five commands that can tell you a version cannot be read, and
until now each said it its own way. This is the consolidation I flagged on
#21 rather than smuggling into it.

## What it looked like

Against one secret with version 1 destroyed, 2 deleted, 3 alive:

| command | before |
|---|---|
| `get secret/s^1` | ``version 1 of secret `secret/s` has been destroyed`` |
| `revert secret/s 1` | ``Version 1 of secret `secret/s' is destroyed`` |
| `undelete secret/s^1` | ``` `secret/s' version: 1 is destroyed ``` |
| `copy secret/s^1 x` | ``` `secret/s^1' is destroyed ``` |
| `delete secret/s^1` | ``` `secret/s^1' is destroyed ``` |

Seven sentences for three conditions. They disagreed on capitalisation, on
whether the secret name closed with a backtick or an apostrophe, and on
whether the version was named at all — `undelete` reported a missing version
as "does not yet exist", which reads as a prediction rather than a fact.

## After

Every one of them now says what `get` says:

```
version 1 of secret `secret/s` has been destroyed
version 2 of secret `secret/s` has been deleted
no version 9 of secret `secret/s` exists
```

`get`'s output is byte-for-byte unchanged; it was already the one to copy.
`revert` keeps its hint, appended to the shared sentence:

```
version 2 of secret `secret/s` has been deleted; pass --deleted to
undelete it, revert to it, and delete it again
```

Two sentences are about a secret rather than a version, and keep their own
wording in the same voice — `no living version of secret `x` exists` and
`no living or deleted version of secret `x` exists`.

Naming the version is a real gain where the caller did not name one. A
`copy secret/d` onto a secret whose latest version is deleted used to say
``` `secret/d' is deleted ```; it now says ``version 2 of secret `secret/d`
has been deleted``, and which version that was is exactly the part the
caller did not know.

## Error kinds are untouched

This is the part I did not want to rush, and it is why the wording lives in
two exported message functions rather than in one constructor everything
calls.

- `verifySecretState`'s errors (delete, copy, move) were already
  `secretNotFound`, so they move onto `NewVersionNotFoundError` directly.
  `safe delete -f` decides what to shrug at by asking `IsNotFound`, and it
  still shrugs at exactly what it did before.
- `revert` and `undelete` find these conditions by reading version metadata,
  not by failing a read, and their errors are plain. `Undelete`'s reaches the
  tree walk, where `MoveCopyTree`'s skip-if-exists check discards any walk
  error answering to `IsNotFound`. Those two take the wording and keep their
  kind.

Exit codes were compared before and after on a live Vault across
`delete -f`, `copy -f`, `delete`, `exists`, `revert` and `undelete`, on
destroyed, deleted, missing and alive versions. All identical.

## Verification

- `make check` and `go test -race ./...` clean.
- Live differential against `vault server -dev` on both a KV v2 and a KV v1
  mount, covering all five commands; the table above is from that run.
- Success paths re-checked live: `undelete` restores a deleted version,
  `revert` writes a new version with the old value, `revert -d` works
  through a deleted one, and `copy` of an alive version still copies.
- Mutation testing on two independent axes. Reverting any site to its old
  phrasing fails the wording tests and leaves the kind tests passing;
  "simplifying" the two plain sites onto `NewVersionNotFoundError` fails
  the kind tests and leaves the wording tests passing.

## Not covered here

The empty-history branch in `revert` is reworded for consistency, but I
could not reach it on either mount version — `Versions` returns an error for
a missing secret before the length check runs — so it is untested.
