### PR TITLE
Name a deleted latest version on a read

### DIFF
--- a/internal/cli/deleted_latest_test.go
+++ b/internal/cli/deleted_latest_test.go
@@ -1,0 +1,168 @@
+package cli
+
+// A secret whose newest version has been deleted reads as though the secret
+// were not there at all. It is: `safe versions` lists it, an older version
+// still reads, and `safe undelete` brings it back — but `safe get` said "no
+// secret exists at path", which sends the reader off to create one.
+//
+// Vault says which version it was and what happened to it, in the body of the
+// 404 itself, but the client discards non-2xx bodies. Recovering it costs one
+// metadata request, so it is paid here rather than in Read: a read with no
+// version named is exactly what gen, uuid, ssh, rsa and dhparam do to a path
+// they are about to create, and they would pay it on every run.
+
+import (
+	"strings"
+	"testing"
+)
+
+// deletedLatest serves a v2 mount holding secret/d, whose second and newest
+// version is deleted while the first is still alive.
+func deletedLatest(t *testing.T) *cliFakeVault {
+	t.Helper()
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/d",
+		map[string]string{"a": "one"},
+		map[string]string{"a": "two"})
+	fv.deleteV2("secret/d", 2)
+	return fv
+}
+
+func getErr(t *testing.T, c *CLI, args ...string) string {
+	t.Helper()
+	err := c.cmdGet("get", args...)
+	if err == nil {
+		t.Fatalf("cmdGet(%v) = nil, want an error", args)
+	}
+	return err.Error()
+}
+
+// The headline case: the secret is there, and the message says which version
+// went missing and how.
+func TestGetNamesADeletedLatestVersion(t *testing.T) {
+	const want = "version 2 of secret `secret/d` has been deleted"
+
+	isolateHome(t)
+	deletedLatest(t)
+	c := newTestCLI(t)
+
+	if got := getErr(t, c, "secret/d"); got != want {
+		t.Errorf("get secret/d = %q, want %q", got, want)
+	}
+}
+
+// Naming a key does not change what happened to the version.
+func TestGetNamesADeletedLatestVersionWithAKey(t *testing.T) {
+	const want = "version 2 of secret `secret/d` has been deleted"
+
+	isolateHome(t)
+	deletedLatest(t)
+	c := newTestCLI(t)
+
+	if got := getErr(t, c, "secret/d:a"); got != want {
+		t.Errorf("get secret/d:a = %q, want %q", got, want)
+	}
+}
+
+// A destroyed newest version is reported as destroyed, since undelete will not
+// bring that one back and the reader should not go looking for it.
+func TestGetNamesADestroyedLatestVersion(t *testing.T) {
+	const want = "version 2 of secret `secret/d` has been destroyed"
+
+	isolateHome(t)
+	fv := deletedLatest(t)
+	fv.destroyV2("secret/d", 2)
+	c := newTestCLI(t)
+
+	if got := getErr(t, c, "secret/d"); got != want {
+		t.Errorf("get secret/d = %q, want %q", got, want)
+	}
+}
+
+// A secret that really is absent still says so. This is the answer the old
+// message was right about, and the one gen and friends depend on.
+func TestGetStillReportsATrulyMissingSecret(t *testing.T) {
+	const want = "no secret exists at path `secret/absent`"
+
+	isolateHome(t)
+	deletedLatest(t)
+	c := newTestCLI(t)
+
+	if got := getErr(t, c, "secret/absent"); got != want {
+		t.Errorf("get secret/absent = %q, want %q", got, want)
+	}
+}
+
+// A key that is not in a perfectly readable secret is still a missing key, not
+// a version problem.
+func TestGetStillReportsAMissingKeyOnALiveSecret(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/live", map[string]string{"a": "one"})
+	c := newTestCLI(t)
+
+	got := getErr(t, c, "secret/live:nope")
+	if !strings.Contains(got, "no key `nope` exists in secret `secret/live`") {
+		t.Errorf("get secret/live:nope = %q, want it to name the missing key", got)
+	}
+}
+
+// A version named explicitly was already reported precisely, and must not be
+// re-described as the latest.
+func TestGetStillNamesTheVersionItWasGiven(t *testing.T) {
+	const want = "no version 9 of secret `secret/d` exists"
+
+	isolateHome(t)
+	deletedLatest(t)
+	c := newTestCLI(t)
+
+	if got := getErr(t, c, "secret/d^9"); got != want {
+		t.Errorf("get secret/d^9 = %q, want %q", got, want)
+	}
+}
+
+// An older version that is still alive reads normally; nothing here changes
+// what a successful get does.
+func TestGetStillReadsAnOlderLiveVersion(t *testing.T) {
+	isolateHome(t)
+	deletedLatest(t)
+	c := newTestCLI(t)
+
+	out := captureStdout(t, func() {
+		if err := c.cmdGet("get", "secret/d:a^1"); err != nil {
+			t.Fatalf("cmdGet: %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "one" {
+		t.Errorf("get secret/d:a^1 = %q, want %q", strings.TrimSpace(out), "one")
+	}
+}
+
+// The multi-path branch of get collects its errors separately, so it needs the
+// same treatment.
+func TestMultiPathGetNamesADeletedLatestVersion(t *testing.T) {
+	isolateHome(t)
+	fv := deletedLatest(t)
+	fv.setV2("secret/other", map[string]string{"b": "two"})
+	c := newTestCLI(t)
+
+	got := getErr(t, c, "secret/d", "secret/other")
+	if !strings.Contains(got, "version 2 of secret `secret/d` has been deleted") {
+		t.Errorf("get secret/d secret/other = %q, want it to name version 2", got)
+	}
+}
+
+// A version 1 mount has no version history to consult, and a missing secret
+// there is simply missing.
+func TestGetOnAVersion1MountStillReportsAMissingSecret(t *testing.T) {
+	const want = "no secret exists at path `secret/absent`"
+
+	isolateHome(t)
+	fv := newCLIFake(t)
+	fv.set("secret/live", map[string]string{"a": "one"})
+	c := newTestCLI(t)
+
+	if got := getErr(t, c, "secret/absent"); got != want {
+		t.Errorf("get secret/absent = %q, want %q", got, want)
+	}
+}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -145,7 +145,7 @@ func (c *CLI) cmdGet(command string, args ...string) error {
 	if len(args) == 1 && !opt.Get.Yaml {
 		s, err := v.Read(args[0])
 		if err != nil {
-			return err
+			return v.ExplainNotFound(args[0], err)
 		}
 
 		if opt.Get.KeysOnly {
@@ -175,7 +175,7 @@ func (c *CLI) cmdGet(command string, args ...string) error {
 
 		// Check if the desired path[:key] is found
 		if err != nil {
-			errs = append(errs, err)
+			errs = append(errs, v.ExplainNotFound(path, err))
 			if k != "" {
 				if _, ok := missingKeys[p]; !ok {
 					missingKeys[p] = make([]string, 0)

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -218,6 +218,49 @@ func (v *Vault) notFoundReading(path string, version uint64) error {
 	return NewVersionNotFoundError(path, version, "")
 }
 
+// ExplainNotFound narrows a not-found error from Read the way notFoundReading
+// narrows a versioned one: when the secret does exist and it is only its newest
+// version that cannot be read, it says which version and what became of it.
+// Anything else is returned untouched, including a missing key and a version
+// the caller named, which is already as specific as it gets.
+//
+// Read does not do this for itself. A read with no version named is what gen,
+// uuid, ssh, rsa and dhparam all do to a path they are about to create, and
+// they expect the miss; the metadata request this costs would land on every one
+// of those. Here it is paid only by a command that has already failed and is
+// about to put the message in front of somebody.
+//
+// Vault does say which version it was in the body of the 404, but vaultkv
+// discards the body of any non-2xx response, so the history has to be asked for
+// separately.
+func (v *Vault) ExplainNotFound(path string, err error) error {
+	if !IsSecretNotFound(err) {
+		return err
+	}
+
+	secret, _, version := ParsePath(path)
+	if version != 0 {
+		return err
+	}
+
+	versions, verr := v.client.Versions(secret)
+	if verr != nil || len(versions) == 0 {
+		//Nothing to consult, so the secret really is the best answer.
+		return err
+	}
+
+	//A read with no version named asks for the newest one, so that is the
+	// only version whose state can explain this particular miss.
+	latest := versions[len(versions)-1]
+	switch {
+	case latest.Destroyed:
+		return NewVersionNotFoundError(secret, uint64(latest.Version), "destroyed")
+	case latest.Deleted:
+		return NewVersionNotFoundError(secret, uint64(latest.Version), "deleted")
+	}
+	return err
+}
+
 // List returns the set of (relative) paths that are directly underneath
 // the given path.  Intermediate path nodes are suffixed with a single "/",
 // whereas leaf nodes (the secrets themselves) are not.


### PR DESCRIPTION
This is the case #21 explicitly left alone, saying it "wants a different
approach and its own change". Here is the different approach.

## The problem

A secret whose newest version has been deleted reads as though it were not
there at all:

```
$ safe versions secret/db
version  status   created at
1        alive    29 Jul 26 09:51 EDT
2        deleted  29 Jul 26 09:51 EDT

$ safe get secret/db
!! no secret exists at path `secret/db`
```

The secret is right there. An older version still reads, `safe undelete`
brings the newest one back, and `safe versions` will happily list it. The
message is not merely unhelpful — it points at the one recovery that
destroys data, which is to write a new secret over the top.

Naming a version already worked (#21), so `safe get secret/db^2` said
"has been deleted". It was only the common form, with no version named,
that lied.

## After

```
$ safe get secret/db
!! version 2 of secret `secret/db` has been deleted

$ safe undelete secret/db^2 && safe get secret/db:password
```

## Why it is not in Read

`Vault.Read` is not only an error path. `gen`, `uuid`, `ssh`, `rsa` and
`dhparam` all read a path they are about to create and expect the miss.
Refining inside `Read` would put a metadata request on every one of those,
on every run.

So the refinement is a separate `Vault.ExplainNotFound`, called from the two
places `cmdGet` reads. Measured against a live Vault with a file audit
device:

| command | before | after |
|---|---|---|
| `gen secret/new:pw` (fresh path) | 3 requests | 3 requests |
| `ssh secret/new` (fresh path) | 3 requests | 3 requests |
| `get` on a secret that is there | 2 requests | 2 requests |
| `get` on a deleted-latest secret | 2 requests | 3 requests |
| `get` on a genuinely absent secret | 2 requests | 3 requests |

The one command that pays is a `get` that has already failed and is about to
put a message in front of somebody. Scripts testing for presence should be
using `safe exists`, which is untouched and still costs what it did.

## Why the extra request is needed at all

Vault does say which version it was, in the body of the 404:

```json
{"data":{"data":null,"metadata":{"deletion_time":"2026-07-29T13:51:08Z",
                                 "destroyed":false,"version":2}}}
```

but `vaultkv`'s `doRequest` returns `parseError(resp)` for any non-2xx
without decoding the body, and `ErrNotFound` carries only a message string.
The answer is on the wire and thrown away one layer down. Recovering it
without a second request means changing `vaultkv`, which is a separate
dependency; asking for the history is what safe can do on its own today.

## What is deliberately left alone

`ExplainNotFound` returns the error untouched for a named version (already
precise), a missing key, a genuinely absent secret, and a v1 mount. Those
four are covered by tests that were passing before this change and still are.

## Verification

- `make check` and `go test -race ./...` clean.
- Nine new tests; four fail before the change, five are controls that pass
  both before and after.
- Live differential against `vault server -dev` on both a v2 and a v1 mount,
  including that the advice now works: `undelete` then `get` returns the
  value.
- Request counts above measured with a Vault file audit device.
- Mutation testing: dropping the named-version guard fails the
  named-version control; making `ExplainNotFound` a no-op fails all four
  headline tests; removing the call from the single-path branch fails the
  three single-path tests and leaves the multi-path one passing, so the two
  call sites are independently covered.
