### PR TITLE
Resolve ls paths in safe's own syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,24 @@ public: |
   -----END RSA PRIVATE KEY-----
 ```
 
+### ls \[-1|-q\] \[path ...\]
+
+List what sits directly under a path, one level deep: secrets plain,
+folders with a trailing slash.  With no path, the mounts are listed
+instead.  `-1` prints one entry per line, and `-q` skips checking
+whether each secret on a version 2 mount can still be read, which is
+quicker but shows secrets whose newest version has been deleted.
+
+```
+safe ls secret/dc1
+admin  concourse/
+
+safe ls -1 secret/dc1/concourse/pipeline-the-first
+aws
+dockerhub
+github
+```
+
 ### tree path \[path ...\]
 
 Provide a tree hierarchy listing of all reachable keys in the

--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ cannot honour a key or a version say so rather than ignoring it:
   - Commands that write a whole secret — `set`, `ask`, `paste`, `ssh`,
     `rsa`, and `dhparam` — take a path only.
 
-  - Commands that walk a subtree — `tree`, `paths`, `values`, and
-    `export` — take a path only, since a key or a version cannot
-    scope a recursive walk.
+  - Commands that list what is under a path — `ls`, `tree`, `paths`,
+    `values`, and `export` — take a path only, since a key or a
+    version cannot scope a listing.
 
   - `gen` and `uuid` take `path:key`, which is how you name the key
     they are about to create.
@@ -215,13 +215,24 @@ safe get 'secret/dc1/we\\ird:password'
 ```
 
 `safe` prints paths in this same escaped form, so anything from `safe
-paths`, `safe paths --keys`, or `safe tree --keys` can be pasted
-straight back into another command:
+paths`, `safe paths --keys`, `safe tree --keys`, or `safe ls` can be
+pasted straight back into another command:
 
 ```
 safe paths --keys secret/dc1/admin
 secret/dc1/admin:password
 secret/dc1/admin:user\:name
+```
+
+`safe ls` prints one name per entry rather than a whole path, and
+escapes each name the same way, so joining a name to the path you
+listed gives a path `safe` accepts:
+
+```
+safe ls secret/dc1
+admin  we\:ird/
+safe ls 'secret/dc1/we\:ird'
+haproxy
 ```
 
 Quote these arguments, or your shell will eat the backslashes before

--- a/internal/cli/ls_paths_test.go
+++ b/internal/cli/ls_paths_test.go
@@ -1,0 +1,186 @@
+package cli
+
+// `safe ls` reads and writes the same escaped path syntax as the commands that
+// walk a subtree, so its own output can be pasted back into it. These tests use
+// the fake Vault's verbatim path storage to hold a folder whose literal name
+// contains a colon, which is the only character that makes the two forms
+// differ.
+
+import (
+	"strings"
+	"testing"
+)
+
+// entriesOf splits a default (non -1) ls listing into its names. The listing is
+// one line of double-space separated entries.
+func entriesOf(out string) []string {
+	return strings.Fields(strings.TrimSpace(out))
+}
+
+// seedColonFolder stores a secret under a literal colon-bearing folder, beside
+// an ordinary one, on whichever mount version the caller started.
+func seedColonFolder(t *testing.T, fv *cliFakeVault) {
+	t.Helper()
+	if fv.v2 {
+		fv.setV2("secret/od:d/inner", map[string]string{"k": "v"})
+		fv.setV2("secret/plain/inner", map[string]string{"k": "v"})
+		return
+	}
+	fv.set("secret/od:d/inner", map[string]string{"k": "v"})
+	fv.set("secret/plain/inner", map[string]string{"k": "v"})
+}
+
+// The listing safe prints is the listing safe accepts. Before the root was
+// resolved, this errored with "no secret exists" on a path safe had printed.
+func TestCmdLsAcceptsAnEscapedRoot(t *testing.T) {
+	isolateHome(t)
+	seedColonFolder(t, newCLIFakeV2(t))
+
+	c := newTestCLI(t)
+	var err error
+	out := captureStdout(t, func() { err = c.cmdLs("ls", `secret/od\:d`) })
+	if err != nil {
+		t.Fatalf("cmdLs: %v", err)
+	}
+	if got := entriesOf(out); len(got) != 1 || got[0] != "inner" {
+		t.Errorf("ls %q = %q, want [inner]", `secret/od\:d`, got)
+	}
+}
+
+// The liveness check on a version 2 mount re-parses the path it is given, so an
+// unescaped colon in the folder name made it look up a key on a shorter path,
+// miss, and drop the secret from the listing -- an empty listing at exit 0.
+func TestCmdLsDoesNotDropAColonFolderQuietly(t *testing.T) {
+	isolateHome(t)
+	seedColonFolder(t, newCLIFakeV2(t))
+
+	c := newTestCLI(t)
+	var slow, quick string
+	var err error
+	slow = captureStdout(t, func() { err = c.cmdLs("ls", `secret/od\:d`) })
+	if err != nil {
+		t.Fatalf("cmdLs: %v", err)
+	}
+	c.opt.List.Quick = true
+	quick = captureStdout(t, func() { err = c.cmdLs("ls", `secret/od\:d`) })
+	if err != nil {
+		t.Fatalf("cmdLs --quick: %v", err)
+	}
+	if strings.TrimSpace(slow) != strings.TrimSpace(quick) {
+		t.Errorf("checking liveness changed the listing:\n  without -q: %q\n  with -q:    %q", slow, quick)
+	}
+}
+
+// A version 1 mount never runs the liveness check, so this pins the root
+// resolution on its own.
+func TestCmdLsAcceptsAnEscapedRootOnAVersion1Mount(t *testing.T) {
+	isolateHome(t)
+	seedColonFolder(t, newCLIFake(t))
+
+	c := newTestCLI(t)
+	var err error
+	out := captureStdout(t, func() { err = c.cmdLs("ls", `secret/od\:d`) })
+	if err != nil {
+		t.Fatalf("cmdLs: %v", err)
+	}
+	if got := entriesOf(out); len(got) != 1 || got[0] != "inner" {
+		t.Errorf("ls %q = %q, want [inner]", `secret/od\:d`, got)
+	}
+}
+
+func TestCmdLsEscapesTheNamesItPrints(t *testing.T) {
+	isolateHome(t)
+	seedColonFolder(t, newCLIFakeV2(t))
+
+	c := newTestCLI(t)
+	var err error
+	out := captureStdout(t, func() { err = c.cmdLs("ls", "secret") })
+	if err != nil {
+		t.Fatalf("cmdLs: %v", err)
+	}
+	got := entriesOf(out)
+	want := []string{`od\:d/`, "plain/"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("ls secret = %q, want %q", got, want)
+	}
+}
+
+// What safe prints is what safe accepts: feed each entry back in.
+func TestCmdLsOutputRoundTrips(t *testing.T) {
+	isolateHome(t)
+	seedColonFolder(t, newCLIFakeV2(t))
+
+	c := newTestCLI(t)
+	var err error
+	first := captureStdout(t, func() { err = c.cmdLs("ls", "secret") })
+	if err != nil {
+		t.Fatalf("cmdLs: %v", err)
+	}
+	for _, entry := range entriesOf(first) {
+		arg := "secret/" + strings.TrimSuffix(entry, "/")
+		out := captureStdout(t, func() { err = c.cmdLs("ls", arg) })
+		if err != nil {
+			t.Fatalf("cmdLs(%q) rejected safe's own output: %v", arg, err)
+		}
+		if got := entriesOf(out); len(got) != 1 || got[0] != "inner" {
+			t.Errorf("ls %q = %q, want [inner]", arg, got)
+		}
+	}
+}
+
+// An ordinary listing is unchanged: nothing in these names needs escaping.
+func TestCmdLsLeavesPlainNamesAlone(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	fv.set("secret/app/db", map[string]string{"k": "v"})
+	fv.set("secret/app/web/tls", map[string]string{"k": "v"})
+
+	c := newTestCLI(t)
+	var err error
+	out := captureStdout(t, func() { err = c.cmdLs("ls", "secret/app") })
+	if err != nil {
+		t.Fatalf("cmdLs: %v", err)
+	}
+	if strings.TrimRight(out, " \n") != "db  web/" {
+		t.Errorf("ls secret/app = %q, want %q", out, "db  web/  \n")
+	}
+
+	c.opt.List.Single = true
+	out = captureStdout(t, func() { err = c.cmdLs("ls", "secret/app") })
+	if err != nil {
+		t.Fatalf("cmdLs -1: %v", err)
+	}
+	if out != "db\nweb/\n" {
+		t.Errorf("ls -1 secret/app = %q, want %q", out, "db\nweb/\n")
+	}
+}
+
+// A key or a version cannot scope a listing, so naming one is refused rather
+// than looked up as part of the path and reported as missing.
+func TestCmdLsRefusesAKeyOrAVersion(t *testing.T) {
+	isolateHome(t)
+	seedColonFolder(t, newCLIFake(t))
+
+	cases := []struct {
+		arg  string
+		want string
+	}{
+		{arg: "secret/plain:inner", want: "specific key"},
+		{arg: "secret/plain^2", want: "specific version"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.arg, func(t *testing.T) {
+			c := newTestCLI(t)
+			err := c.cmdLs("ls", tc.arg)
+			if err == nil {
+				t.Fatalf("ls %q should have been refused", tc.arg)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q should mention %q", err, tc.want)
+			}
+			if !strings.Contains(err.Error(), "ls") {
+				t.Errorf("error %q should name the command", err)
+			}
+		})
+	}
+}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -333,22 +333,23 @@ func (c *CLI) cmdLs(command string, args ...string) error {
 	}
 	v := connect(true)
 	display := func(paths []string) {
+		end := "  "
 		if opt.List.Single {
-			for _, s := range paths {
-				if strings.HasSuffix(s, "/") {
-					_, _ = fmt.Printf("@B{%s}\n", s)
-				} else {
-					_, _ = fmt.Printf("@G{%s}\n", s)
-				}
+			end = "\n"
+		}
+		for _, s := range paths {
+			//Printed in safe's own syntax, so a name holding a colon or a
+			// caret can be pasted back. The trailing slash marks a folder
+			// and is not part of the name.
+			name, folder := strings.CutSuffix(s, "/")
+			name = vault.EscapePathSegment(name)
+			if folder {
+				_, _ = fmt.Printf("@B{%s/}%s", name, end)
+			} else {
+				_, _ = fmt.Printf("@G{%s}%s", name, end)
 			}
-		} else {
-			for _, s := range paths {
-				if strings.HasSuffix(s, "/") {
-					_, _ = fmt.Printf("@B{%s}  ", s)
-				} else {
-					_, _ = fmt.Printf("@G{%s}  ", s)
-				}
-			}
+		}
+		if !opt.List.Single {
 			_, _ = fmt.Printf("\n")
 		}
 	}
@@ -357,9 +358,16 @@ func (c *CLI) cmdLs(command string, args ...string) error {
 		args = []string{"/"}
 	}
 
-	for _, path := range args {
+	for _, arg := range args {
+		//Vault lists literal paths, so a root pasted back from safe's own
+		// output has to be unescaped first.
+		root, err := walkRoot("ls", arg)
+		if err != nil {
+			return err
+		}
+
 		var paths []string
-		if path == "" || path == "/" {
+		if root == "" {
 			generics, err := v.Mounts("generic")
 			if err != nil {
 				return err
@@ -371,8 +379,7 @@ func (c *CLI) cmdLs(command string, args ...string) error {
 
 			paths = append(generics, kvs...)
 		} else {
-			var err error
-			paths, err = v.List(path)
+			paths, err = v.List(root)
 			if err != nil {
 				return err
 			}
@@ -382,14 +389,17 @@ func (c *CLI) cmdLs(command string, args ...string) error {
 		if !opt.List.Quick {
 			for i := range paths {
 				if !strings.HasSuffix(paths[i], "/") {
-					fullpath := path + "/" + vault.EscapePathSegment(paths[i])
-					mountVersion, err := v.MountVersion(fullpath)
+					child := root + "/" + paths[i]
+					mountVersion, err := v.MountVersion(child)
 					if err != nil {
 						return err
 					}
 
 					if mountVersion == 2 {
-						_, err := v.Read(fullpath)
+						//Read parses the mini-language, so it takes the
+						// escaped form: a colon anywhere in the path would
+						// otherwise be read as a key separator.
+						_, err := v.Read(vault.EncodePath(child, "", 0))
 						if err != nil {
 							if vault.IsNotFound(err) {
 								continue
@@ -408,7 +418,7 @@ func (c *CLI) cmdLs(command string, args ...string) error {
 		sort.Strings(filteredPaths)
 
 		if len(args) != 1 {
-			_, _ = fmt.Printf("@C{%s}:\n", path)
+			_, _ = fmt.Printf("@C{%s}:\n", arg)
 		}
 		display(filteredPaths)
 		if len(args) != 1 {


### PR DESCRIPTION
`safe ls` was the last listing command that did not speak safe's own path
syntax. It passed its argument straight to the list call, which talks to Vault
in literal paths, and joined that raw argument to each child before reading it
back.

## What that cost

Fixture: one secret at the literal path `secret/od:d/inner`, on the KV v2
`secret/` mount of a real Vault 1.13.2 dev server.

```
$ safe paths secret
secret/od\:d/inner
secret/plain/inner
```

Before:

```
$ safe ls 'secret/od\:d'          # safe's own output, pasted back
!! no secret exists at path `secret/od\:d`
rc=1

$ safe ls 'secret/od:d'           # the literal name
                                  # <- nothing
rc=0

$ safe ls --quick 'secret/od:d'
inner
rc=0
```

The second one is the bad one. `inner` exists and is alive; the listing is
empty and the exit code is 0. The liveness check on a version 2 mount escapes
only the child before handing the path to `Read`, so `secret/od:d` + `/inner`
arrives as `secret/od:d/inner`, `Read` splits it at the colon into the path
`secret/od` and the key `d/inner`, misses, and `continue`s past the entry.
`--quick` skips that check, which is why it prints the secret the default
listing hides.

After:

```
$ safe ls 'secret/od\:d'
inner

$ safe ls 'secret/od:d'
!! ls does not take a specific key (secret/od:d)
rc=1

$ safe ls secret
od\:d/  plain/
```

## The change

Three parts, one behaviour:

- Resolve the root through `walkRoot`, the same helper `tree`, `paths`, and
  `values` have used since #15. A key or a version cannot scope a listing, so
  naming one is refused rather than looked up as part of the path.

- Escape the whole path, not just the child, before handing it to `Read`; the
  mount-version lookup keeps the literal form, which is what it wants.

- Escape the names `ls` prints, for the same reason `paths` and `tree` escape
  theirs. Without this the fix is only half a round trip: `ls secret` would
  print a name that `ls` itself now refuses.

Plain names are untouched — `EscapePathSegment` is the identity on anything
without a `\`, `:`, or `^`.

## Tests

`internal/cli/ls_paths_test.go`, seven tests over both mount versions:
escaped root accepted on v1 and v2, the quiet-drop regression (the default
listing must agree with `--quick`), printed names escaped, output fed back in,
plain listings byte-identical in both `-1` and default form, and key/version
refused.

Mutation-tested on each axis independently, against a clean tree:

| Reverted | Tests that fail |
|---|---|
| root resolution | 5 — everything but the plain-listing and printed-names tests |
| child escaping | 3 — the two v2 tests and the round trip; the v1 test survives, since a v1 mount never runs the liveness check |
| printed-name escaping | 2 — printed names and the round trip |

`make check` and `go test -race ./...` green. Every before/after pair above is
from a live Vault, not the fake.

## Docs

`ls` joins the path-only bullet in the Secret Paths rules, the escaping section
gains a short note on joining a printed name to the path you listed, and the
command reference gains an `### ls` section — it had none, though `ls` is one
of the first commands anybody reaches for. Both examples were run against the
live server before being written down.
