### PR TITLE
Document the listing and export flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,13 +513,30 @@ expiry.
 Renews (re-signs) the certificate authority at `path`, without
 affecting the list of revoked certificates.
 
-### export path \[path ...\]
+### export \[-a|-d\] path \[path ...\]
 
 Export the given subtree(s) in a format suitable for migration
 (via a future `import` call), or long-term storage offline.
 Secrets will not be encrypted in this representation, so care
 should be taken in handling it.  Output will be printed to
 standard output.
+
+By default only the latest version of each secret is exported, which
+keeps the output readable by versions of `safe` before v1.0.0.  `-a`
+exports every version instead, in a newer format those versions cannot
+read.
+
+A secret is exported only if something in it can be read.  A plain
+export takes the latest version, so it skips a secret whose latest
+version has been deleted or destroyed; `-a` keeps any secret with at
+least one readable version, and records the unreadable ones in place
+as empty placeholders, so the versions around them keep their numbers.
+
+`-d` undeletes, reads, and re-deletes each deleted version so that it
+is exported with its value rather than as a placeholder, and it also
+brings in the secrets a plain export would have skipped entirely.  A
+destroyed version cannot be recovered and stays a placeholder either
+way.
 
 ### import <export.file
 

--- a/README.md
+++ b/README.md
@@ -299,9 +299,14 @@ public: |
 
 List what sits directly under a path, one level deep: secrets plain,
 folders with a trailing slash.  With no path, the mounts are listed
-instead.  `-1` prints one entry per line, and `-q` skips checking
-whether each secret on a version 2 mount can still be read, which is
-quicker but shows secrets whose newest version has been deleted.
+instead.  `-1` prints one entry per line.
+
+A secret is listed only if its newest version can still be read, so
+one whose newest version has been deleted or destroyed is left out —
+even when an older version of it is still live.  Finding that out
+costs a read per secret, and `-q` skips the check and lists those
+secrets too.  Only a version 2 mount keeps versions, so neither the
+check nor `-q` does anything on a version 1 mount.
 
 ```
 safe ls secret/dc1
@@ -313,10 +318,15 @@ dockerhub
 github
 ```
 
-### tree path \[path ...\]
+### tree \[-d|-q|--keys\] path \[path ...\]
 
 Provide a tree hierarchy listing of all reachable keys in the
 Vault.
+
+`-d` draws only the folders, which is a quicker way to get your
+bearings in an unfamiliar Vault.  `--keys` names the keys inside each
+secret beside it.  `-q` skips the liveness check, exactly as it does
+for `ls` above.
 
 ```
 safe tree secret/dc1
@@ -333,9 +343,13 @@ safe tree secret/dc1
             └── github
 ```
 
-### paths path \[path ... \]
+### paths \[-q|--keys\] path \[path ... \]
 
 Provide a flat listing of all reachable keys in the Vault.
+
+`--keys` prints a line per key, as `path:key`, rather than a line per
+secret.  `-q` skips the liveness check, exactly as it does for `ls`
+above.
 
 ```
 safe paths secret/dc1


### PR DESCRIPTION
Documentation only. **Stacked on #28** — it builds on the `### ls` section that
PR adds, so review that one first; GitHub will retarget this to `develop` once
#28 merges.

## Why

`ls`, `tree`, and `paths` all take flags the command reference never mentioned,
and one of them decides whether a secret is listed at all. A secret whose newest
version has been deleted or destroyed does not appear in a default listing —
not even when an older version of it is still perfectly readable — and nothing
in the README said so. The behaviour is defensible for a listing of what you can
read, and `-q` is right there, but a reader had no way to learn either fact.

`export`'s two flags were undocumented in the same way, and they change which
secrets come out, not just how many versions of each.

## Verified, not inferred

Every claim was measured against a live Vault 1.13.2 first. Fixture on the v2
`secret/` mount: `alive` (one live version), `gone` (v1 live, v2 deleted),
`dead` (its only version deleted), `blown` (its only version destroyed).

```
$ safe paths secret/d          $ safe paths -q secret/d
secret/d/alive                 secret/d/alive
                               secret/d/blown
                               secret/d/dead
                               secret/d/gone
```

`tree` and `ls` agree with `paths` on the same fixture, both with and without
`-q`.

```
$ safe export secret/d
{"secret/d/alive":{"a":"1"}}

$ safe export -a secret/d
... "secret/d/gone":{"versions":[{"value":{"a":"1"}},{"destroyed":true}]} ...

$ safe export -a -d secret/d
... "secret/d/gone":{"versions":[{"value":{"a":"1"}},{"deleted":true,"value":{"a":"2"}}]},
    "secret/d/dead":{"versions":[{"deleted":true,"value":{"a":"1"}}]},
    "secret/d/blown":{"versions":[{"destroyed":true}]} ...

$ safe export -d secret/d
{"secret/d/alive":{"a":"1"},"secret/d/blown":{},"secret/d/dead":{"a":"1"},"secret/d/gone":{"a":"2"}}
```

Which is where the wording comes from: `-a` keeps any secret with at least one
readable version and pads the rest as placeholders so the surrounding version
numbers stay right; `-d` recovers the deleted values *and* pulls in secrets a
plain export skips entirely; a destroyed version stays a placeholder either way.

## Not changed

The listing behaviour itself. Hiding a secret you cannot read is a reasonable
default for a listing, `-q` covers the other case, and unlike a backup it loses
nothing. This PR makes it discoverable rather than quietly true.
