### PR TITLE
Act on the Vault named by -T for seal state

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -115,6 +115,21 @@ func connect(auth bool) *vault.Vault {
 	return nil
 }
 
+// usesStrongbox reports whether a command should look for Strongbox alongside
+// the Vault it is acting on. A nil target means no Vault is configured and the
+// address came from the environment, where there is no flag to consult.
+func usesStrongbox(target *rc.Vault) bool {
+	return target != nil && !target.NoStrongbox
+}
+
+// targetAddress is the address the client returned by connect is talking to.
+// rc.Apply sets it from the target the command named, so it holds for -T and
+// for an environment-only configuration alike, where the config has no
+// address to offer.
+func targetAddress() string {
+	return os.Getenv("VAULT_ADDR")
+}
+
 type Options struct {
 	Insecure     bool `cli:"-k, --insecure"`
 	Version      bool `cli:"-v, --version"`

--- a/internal/cli/seal_fake_test.go
+++ b/internal/cli/seal_fake_test.go
@@ -1,0 +1,124 @@
+package cli
+
+// A fake Vault that answers the seal-state endpoints: health, seal-status,
+// seal, and unseal. The KV fake in vault_fake_test.go serves secrets only,
+// and the commands that report or change seal state never read a secret.
+//
+// Tests that involve more than one target write their own ~/.saferc, so the
+// helper hands back the server URL rather than setting VAULT_ADDR itself.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+type fakeSealVault struct {
+	mu     sync.Mutex
+	sealed bool
+	//seals and unseals count the requests that changed the seal state, so a
+	// test can tell which of two Vaults a command acted on.
+	seals   int
+	unseals int
+	url     string
+}
+
+// newSealFake starts a fake Vault in the given seal state.
+func newSealFake(t *testing.T, sealed bool) *fakeSealVault {
+	t.Helper()
+	f := &fakeSealVault{sealed: sealed}
+	srv := httptest.NewServer(f)
+	t.Cleanup(srv.Close)
+	f.url = srv.URL
+	return f
+}
+
+// isSealed reports the current seal state.
+func (f *fakeSealVault) isSealed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.sealed
+}
+
+func (f *fakeSealVault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	w.Header().Set("Content-Type", "application/json")
+
+	// A sealed Vault answers health with 503, which is how Sealed() tells the
+	// two states apart.
+	state := map[string]any{
+		"type":        "shamir",
+		"sealed":      f.sealed,
+		"t":           1,
+		"n":           1,
+		"progress":    0,
+		"nonce":       "",
+		"version":     "1.0.0",
+		"initialized": true,
+	}
+
+	switch {
+	case r.URL.Path == "/v1/sys/health":
+		if f.sealed {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+		_, _ = w.Write([]byte(`{}`))
+
+	case r.URL.Path == "/v1/sys/seal-status":
+		_ = json.NewEncoder(w).Encode(state)
+
+	case r.URL.Path == "/v1/sys/seal" && r.Method == http.MethodPut:
+		f.sealed = true
+		f.seals++
+		w.WriteHeader(http.StatusNoContent)
+
+	case r.URL.Path == "/v1/sys/unseal" && r.Method == http.MethodPut:
+		var body struct {
+			Key   string `json:"key"`
+			Reset bool   `json:"reset"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if !body.Reset {
+			f.sealed = false
+			f.unseals++
+		}
+		state["sealed"] = f.sealed
+		_ = json.NewEncoder(w).Encode(state)
+
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":[]}`))
+	}
+}
+
+// writeSaferc writes a ~/.saferc under the isolated home.
+func writeSaferc(t *testing.T, body string) {
+	t.Helper()
+	path := filepath.Join(os.Getenv("HOME"), ".saferc")
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// twoTargets renders a config naming both Vaults, with alpha current. Neither
+// uses Strongbox, so the commands take the single-address branch; the
+// Strongbox flag is exercised on its own in the tests that care about it.
+func twoTargets(alpha, beta *fakeSealVault) string {
+	return `version: 1
+current: alpha
+vaults:
+  alpha:
+    url: ` + alpha.url + `
+    token: token-alpha
+    no_strongbox: true
+  beta:
+    url: ` + beta.url + `
+    token: token-beta
+    no_strongbox: true
+`
+}

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -470,10 +470,14 @@ func (c *CLI) cmdUnseal(command string, args ...string) error {
 	if err != nil {
 		return err
 	}
+	tgt, err := cfg.Vault(opt.UseTarget)
+	if err != nil {
+		return err
+	}
 	v := connect(false)
 
 	var addrs []string
-	if cfg.HasStrongbox() {
+	if usesStrongbox(tgt) {
 		st, err := v.Strongbox()
 		if err != nil {
 			return fmt.Errorf("%w; are you targeting a `safe' installation?", err)
@@ -485,16 +489,13 @@ func (c *CLI) cmdUnseal(command string, args ...string) error {
 			}
 		}
 	} else {
-		if err := v.SetURL(cfg.URL()); err != nil {
-			return err
-		}
 		isSealed, err := v.Sealed()
 		if err != nil {
 			return err
 		}
 
 		if isSealed {
-			addrs = append(addrs, cfg.URL())
+			addrs = append(addrs, targetAddress())
 		}
 	}
 
@@ -539,10 +540,14 @@ func (c *CLI) cmdSeal(command string, args ...string) error {
 	if err != nil {
 		return err
 	}
+	tgt, err := cfg.Vault(opt.UseTarget)
+	if err != nil {
+		return err
+	}
 	v := connect(true)
 
 	var toSeal []string
-	if cfg.HasStrongbox() {
+	if usesStrongbox(tgt) {
 		st, err := v.Strongbox()
 		if err != nil {
 			return fmt.Errorf("%w; are you targeting a `safe' installation?", err)
@@ -554,15 +559,12 @@ func (c *CLI) cmdSeal(command string, args ...string) error {
 			}
 		}
 	} else {
-		if err := v.SetURL(cfg.URL()); err != nil {
-			return err
-		}
 		isSealed, err := v.Sealed()
 		if err != nil {
 			return err
 		}
 		if !isSealed {
-			toSeal = append(toSeal, cfg.URL())
+			toSeal = append(toSeal, targetAddress())
 		}
 	}
 

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -300,6 +300,10 @@ func (c *CLI) cmdStatus(command string, args ...string) error {
 	if err != nil {
 		return err
 	}
+	tgt, err := cfg.Vault(opt.UseTarget)
+	if err != nil {
+		return err
+	}
 	v := connect(false)
 
 	type status struct {
@@ -309,7 +313,7 @@ func (c *CLI) cmdStatus(command string, args ...string) error {
 
 	var statuses []status
 
-	if cfg.HasStrongbox() {
+	if usesStrongbox(tgt) {
 		st, err := v.Strongbox()
 		if err != nil {
 			return fmt.Errorf("%w; are you targeting a `safe' installation?", err)
@@ -319,15 +323,12 @@ func (c *CLI) cmdStatus(command string, args ...string) error {
 			statuses = append(statuses, status{addr, state == "sealed"})
 		}
 	} else {
-		if err := v.SetURL(cfg.URL()); err != nil {
-			return err
-		}
 		isSealed, err := v.Sealed()
 		if err != nil {
 			return err
 		}
 
-		statuses = append(statuses, status{cfg.URL(), isSealed})
+		statuses = append(statuses, status{targetAddress(), isSealed})
 	}
 
 	var hasSealed bool

--- a/internal/cli/target_flag_test.go
+++ b/internal/cli/target_flag_test.go
@@ -1,0 +1,138 @@
+package cli
+
+// -T names the Vault a single command should act on. rc.Apply points the
+// environment at that Vault but leaves the current target alone, so a command
+// that asks the config for an address or a Strongbox flag gets the answer for
+// whichever Vault happens to be current. For the seal-state commands that
+// means reporting on, unsealing, or sealing the wrong Vault.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/prompt"
+)
+
+func TestCmdStatusReportsTheTargetNamedByDashT(t *testing.T) {
+	isolateHome(t)
+	alpha := newSealFake(t, false)
+	beta := newSealFake(t, true)
+	writeSaferc(t, twoTargets(alpha, beta))
+
+	c := newTestCLI(t)
+	c.opt.UseTarget = "beta"
+
+	out := captureStdout(t, func() {
+		if err := c.cmdStatus("status"); err != nil {
+			t.Fatalf("cmdStatus: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, beta.url+" is sealed") {
+		t.Errorf("status did not report the sealed target named by -T:\n%s", out)
+	}
+	if strings.Contains(out, alpha.url) {
+		t.Errorf("status reported the current target instead of the one named by -T:\n%s", out)
+	}
+}
+
+func TestCmdStatusReadsTheStrongboxFlagOfTheDashTTarget(t *testing.T) {
+	isolateHome(t)
+	alpha := newSealFake(t, false)
+	beta := newSealFake(t, true)
+	//alpha uses Strongbox, beta does not. Asking alpha's flag sends the
+	// command down the Strongbox branch, which beta cannot answer.
+	writeSaferc(t, `version: 1
+current: alpha
+vaults:
+  alpha:
+    url: `+alpha.url+`
+    token: token-alpha
+  beta:
+    url: `+beta.url+`
+    token: token-beta
+    no_strongbox: true
+`)
+
+	c := newTestCLI(t)
+	c.opt.UseTarget = "beta"
+
+	out := captureStdout(t, func() {
+		if err := c.cmdStatus("status"); err != nil {
+			t.Fatalf("cmdStatus: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, beta.url+" is sealed") {
+		t.Errorf("status did not report the target named by -T:\n%s", out)
+	}
+}
+
+func TestCmdStatusUsesTheEnvironmentAddressWithNoTarget(t *testing.T) {
+	isolateHome(t)
+	//No ~/.saferc at all: the address and token come from the environment,
+	// which is how safe is driven in a pipeline.
+	f := newSealFake(t, false)
+	t.Setenv("VAULT_ADDR", f.url)
+	t.Setenv("VAULT_TOKEN", "test-token")
+
+	c := newTestCLI(t)
+
+	out := captureStdout(t, func() {
+		if err := c.cmdStatus("status"); err != nil {
+			t.Fatalf("cmdStatus: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, f.url+" is unsealed") {
+		t.Errorf("status did not report the Vault named by VAULT_ADDR:\n%s", out)
+	}
+}
+
+func TestCmdSealSealsTheTargetNamedByDashT(t *testing.T) {
+	isolateHome(t)
+	alpha := newSealFake(t, false)
+	beta := newSealFake(t, false)
+	writeSaferc(t, twoTargets(alpha, beta))
+
+	c := newTestCLI(t)
+	c.opt.UseTarget = "beta"
+
+	_ = captureStdout(t, func() {
+		if err := c.cmdSeal("seal"); err != nil {
+			t.Fatalf("cmdSeal: %v", err)
+		}
+	})
+
+	if !beta.isSealed() {
+		t.Error("seal left the target named by -T unsealed")
+	}
+	if alpha.isSealed() {
+		t.Error("seal sealed the current target instead of the one named by -T")
+	}
+}
+
+func TestCmdUnsealUnsealsTheTargetNamedByDashT(t *testing.T) {
+	isolateHome(t)
+	//The current target is already unsealed, so a command that looks at it
+	// concludes there is nothing to do.
+	alpha := newSealFake(t, false)
+	beta := newSealFake(t, true)
+	writeSaferc(t, twoTargets(alpha, beta))
+
+	prompt.SetReader(strings.NewReader("unseal-key\n"))
+	t.Cleanup(func() { prompt.SetReader(nil) })
+
+	c := newTestCLI(t)
+	c.opt.UseTarget = "beta"
+
+	_ = captureStdout(t, func() {
+		if err := c.cmdUnseal("unseal"); err != nil {
+			t.Fatalf("cmdUnseal: %v", err)
+		}
+	})
+
+	if beta.isSealed() {
+		t.Error("unseal left the target named by -T sealed")
+	}
+}


### PR DESCRIPTION
`-T` names the Vault a single command should act on, and `$SAFE_TARGET` sets
it for a whole shell. `rc.Apply` points the environment at that Vault but
leaves the current target where it is, so any command that then asks the
config for an address or a Strongbox flag gets the answer for whichever
target happens to be current. `status`, `seal`, and `unseal` all do.

## What that cost

Two Vaults on a real Vault 1.13.2 pair: `alpha` on :8410, current and
unsealed; `beta` on :8411, sealed. Neither uses Strongbox.

Before:

```
$ safe status
http://127.0.0.1:8410 is unsealed

$ safe -T beta status
http://127.0.0.1:8410 is unsealed      # <- beta is sealed
rc=0
```

Exit 0, no warning, wrong Vault. `seal` is the same shape, and it writes:

```
$ safe -T beta seal                    # both Vaults unsealed to start
sealed http://127.0.0.1:8412...        # <- that is alpha

before: :8412 sealed=false  :8413 sealed=false
after:  :8412 sealed=true   :8413 sealed=false
```

That transcript needs the two aliases to accept the same token, which is
the ordinary case for two names for one HA cluster. When the tokens differ
the request still goes to the wrong Vault and comes back 403, because the
address came from one target and the token from the other.

After:

```
$ safe -T beta status
http://127.0.0.1:8411 is sealed

$ safe -T beta seal
sealed http://127.0.0.1:8413...
before: :8412 sealed=false  :8413 sealed=false
after:  :8412 sealed=false  :8413 sealed=true
```

## The change

The address now comes from the environment the client was built from, which
`rc.Apply` has already pointed at the named target, so the config address is
not consulted at all. The Strongbox flag comes from that same target rather
than from the current one.

Dropping the config address also fixes `safe status` with no `~/.saferc`,
where `cfg.URL()` was empty and the health check went to `//:80`:

```
$ VAULT_ADDR=http://127.0.0.1:8414 safe status
!! Transport Error: Get "//:80/v1/sys/health?...": unsupported protocol scheme ""
```

That is every environment-only invocation — a pipeline, a container, a CI
job — none of which could ask `safe` for seal state before this.

## Tests

`internal/cli/target_flag_test.go`, five tests over a pair of fake Vaults
whose seal state and recorded seal calls tell them apart: status names the
`-T` target, status reads the `-T` target's Strongbox flag, status works
from the environment alone, seal seals the `-T` target and leaves the
current one alone, unseal unseals the `-T` target the current one would
have reported as already unsealed.

Mutation-tested on each axis, against a clean tree:

| Reverted | Tests that fail |
|---|---|
| target resolution (`cfg.Vault(opt.UseTarget)` back to the current target) | 1 — the Strongbox test; the rest pin the address, which is a separate axis |
| address source (back to `cfg.URL()` and `SetURL`) | 5 — all of them |

`make check` and `go test -race ./...` green. Every transcript above is from
a live Vault, not the fake.

## Not changed

`target`, `targets`, and `env` already say `-T` makes no sense for them and
ignore it. `renew`, and every secret command, drive off the environment
`rc.Apply` sets, which was right all along.
