### PR TITLE
Store tokens against the target -T names

### DIFF
--- a/internal/cli/seal_fake_test.go
+++ b/internal/cli/seal_fake_test.go
@@ -25,12 +25,14 @@ type fakeSealVault struct {
 	seals   int
 	unseals int
 	url     string
+	//rootToken is what initializing this Vault hands back.
+	rootToken string
 }
 
 // newSealFake starts a fake Vault in the given seal state.
 func newSealFake(t *testing.T, sealed bool) *fakeSealVault {
 	t.Helper()
-	f := &fakeSealVault{sealed: sealed}
+	f := &fakeSealVault{sealed: sealed, rootToken: "root-token"}
 	srv := httptest.NewServer(f)
 	t.Cleanup(srv.Close)
 	f.url = srv.URL
@@ -76,6 +78,13 @@ func (f *fakeSealVault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		f.sealed = true
 		f.seals++
 		w.WriteHeader(http.StatusNoContent)
+
+	case r.URL.Path == "/v1/sys/init" && r.Method == http.MethodPut:
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys":        []string{"seal-key"},
+			"keys_base64": []string{"seal-key"},
+			"root_token":  f.rootToken,
+		})
 
 	case r.URL.Path == "/v1/sys/unseal" && r.Method == http.MethodPut:
 		var body struct {

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -280,6 +280,10 @@ func (c *CLI) cmdInit(command string, args ...string) error {
 	if err != nil {
 		return err
 	}
+	tgt, err := cfg.Vault(opt.UseTarget)
+	if err != nil {
+		return err
+	}
 	v := connect(false)
 
 	if opt.Init.NKeys == 0 {
@@ -309,7 +313,15 @@ func (c *CLI) cmdInit(command string, args ...string) error {
 	}
 
 	/* auth with the new root token, transparently */
-	_ = cfg.SetToken(token)
+	//The token belongs to the Vault that was just initialized, which -T may
+	// have named rather than the current target.
+	target := cfg.Current
+	if opt.UseTarget != "" {
+		target = opt.UseTarget
+	}
+	if err := cfg.SetTokenFor(target, token); err != nil {
+		return err
+	}
 	if err := cfg.Write(); err != nil {
 		return err
 	}
@@ -369,7 +381,7 @@ func (c *CLI) cmdInit(command string, args ...string) error {
 	if !opt.Init.Sealed {
 		addrs := []string{}
 		gotStrongbox := false
-		if cfg.HasStrongbox() {
+		if usesStrongbox(tgt) {
 			if st, err := v.Strongbox(); err == nil {
 				gotStrongbox = true
 				for addr := range st {

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -558,16 +558,20 @@ func (c *CLI) cmdLogout(command string, args ...string) error {
 	if err != nil {
 		return err
 	}
-	_ = cfg.SetToken("")
-	err = cfg.Write()
-	if err != nil {
-		return err
-	}
 
 	target := cfg.Current
 	if opt.UseTarget != "" {
 		target = opt.UseTarget
 	}
+	//Dropping the token of the target that was named, rather than of the
+	// current one, which is the only target SetToken can reach.
+	if err := cfg.SetTokenFor(target, ""); err != nil {
+		return err
+	}
+	if err := cfg.Write(); err != nil {
+		return err
+	}
+
 	_, _ = fmt.Fprintf(os.Stderr, "Successfully logged out of @C{%s}\n", target)
 	return nil
 }

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -539,15 +539,11 @@ func (c *CLI) cmdAuth(command string, args ...string) error {
 		return fmt.Errorf("Unrecognized authentication method '%s'", method)
 	}
 
-	//This handles saving the token to the correct target when using the -T
-	// flag to use a different target
-	currentTarget := cfg.Current
-	err = cfg.SetCurrent(target, false)
-	if err != nil {
-		return fmt.Errorf("Could not find target with name `%s'", target)
+	//The token belongs to the target that was authenticated against, which
+	// -T may have named, and storing it must not move the current target.
+	if err := cfg.SetTokenFor(target, token); err != nil {
+		return err
 	}
-	_ = cfg.SetToken(token)
-	_ = cfg.SetCurrent(currentTarget, false)
 	return cfg.Write()
 }
 

--- a/internal/cli/token_target_test.go
+++ b/internal/cli/token_target_test.go
@@ -1,0 +1,61 @@
+package cli
+
+// The commands that store a token in ~/.saferc write it against the current
+// target, because that is the only target Config.SetToken knows about. -T
+// names a different Vault for one command, so those commands put the token on
+// the wrong target — and, in the case of logout, clear a token the user did
+// not ask them to clear.
+
+import (
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/rc"
+)
+
+// readConfig parses ~/.saferc under the isolated home.
+func readConfig(t *testing.T) rc.Config {
+	t.Helper()
+	cfg, err := rc.Read()
+	if err != nil {
+		t.Fatalf("rc.Read: %v", err)
+	}
+	return cfg
+}
+
+func TestCmdLogoutClearsTheTokenOfTheTargetNamedByDashT(t *testing.T) {
+	isolateHome(t)
+	alpha := newSealFake(t, false)
+	beta := newSealFake(t, false)
+	writeSaferc(t, twoTargets(alpha, beta))
+
+	c := newTestCLI(t)
+	c.opt.UseTarget = "beta"
+
+	if err := c.cmdLogout("logout"); err != nil {
+		t.Fatalf("cmdLogout: %v", err)
+	}
+
+	cfg := readConfig(t)
+	if cfg.Vaults["beta"].Token != "" {
+		t.Errorf("beta kept its token %q after being logged out of", cfg.Vaults["beta"].Token)
+	}
+	if cfg.Vaults["alpha"].Token != "token-alpha" {
+		t.Errorf("alpha lost its token: %q", cfg.Vaults["alpha"].Token)
+	}
+	if cfg.Current != "alpha" {
+		t.Errorf("current target: got %q, want alpha", cfg.Current)
+	}
+}
+
+func TestCmdLogoutWithNothingTargetedReportsAnError(t *testing.T) {
+	isolateHome(t)
+	f := newSealFake(t, false)
+	t.Setenv("VAULT_ADDR", f.url)
+	t.Setenv("VAULT_TOKEN", "test-token")
+
+	c := newTestCLI(t)
+
+	if err := c.cmdLogout("logout"); err == nil {
+		t.Error("logging out with no target selected reported success")
+	}
+}

--- a/internal/cli/token_target_test.go
+++ b/internal/cli/token_target_test.go
@@ -7,8 +7,10 @@ package cli
 // not ask them to clear.
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/cloudfoundry-community/safe/pkg/prompt"
 	"github.com/cloudfoundry-community/safe/pkg/rc"
 )
 
@@ -57,5 +59,33 @@ func TestCmdLogoutWithNothingTargetedReportsAnError(t *testing.T) {
 
 	if err := c.cmdLogout("logout"); err == nil {
 		t.Error("logging out with no target selected reported success")
+	}
+}
+
+func TestCmdAuthStoresTheTokenOnTheTargetNamedByDashT(t *testing.T) {
+	isolateHome(t)
+	alpha := newSealFake(t, false)
+	beta := newSealFake(t, false)
+	writeSaferc(t, twoTargets(alpha, beta))
+
+	prompt.SetReader(strings.NewReader("beta-token\n"))
+	t.Cleanup(func() { prompt.SetReader(nil) })
+
+	c := newTestCLI(t)
+	c.opt.UseTarget = "beta"
+
+	if err := c.cmdAuth("auth", "token"); err != nil {
+		t.Fatalf("cmdAuth: %v", err)
+	}
+
+	cfg := readConfig(t)
+	if cfg.Vaults["beta"].Token != "beta-token" {
+		t.Errorf("beta token: got %q, want beta-token", cfg.Vaults["beta"].Token)
+	}
+	if cfg.Vaults["alpha"].Token != "token-alpha" {
+		t.Errorf("alpha token: got %q, want it untouched", cfg.Vaults["alpha"].Token)
+	}
+	if cfg.Current != "alpha" {
+		t.Errorf("current target: got %q, want alpha", cfg.Current)
 	}
 }

--- a/internal/cli/token_target_test.go
+++ b/internal/cli/token_target_test.go
@@ -89,3 +89,31 @@ func TestCmdAuthStoresTheTokenOnTheTargetNamedByDashT(t *testing.T) {
 		t.Errorf("current target: got %q, want alpha", cfg.Current)
 	}
 }
+
+func TestCmdInitStoresTheRootTokenOnTheTargetNamedByDashT(t *testing.T) {
+	isolateHome(t)
+	alpha := newSealFake(t, false)
+	beta := newSealFake(t, true)
+	beta.rootToken = "beta-root"
+	writeSaferc(t, twoTargets(alpha, beta))
+
+	c := newTestCLI(t)
+	c.opt.UseTarget = "beta"
+	//Leaving the Vault sealed keeps the test to the one thing it is about:
+	// where the root token that initializing produced ends up.
+	c.opt.Init.Sealed = true
+
+	_ = captureStdout(t, func() {
+		if err := c.cmdInit("init"); err != nil {
+			t.Fatalf("cmdInit: %v", err)
+		}
+	})
+
+	cfg := readConfig(t)
+	if cfg.Vaults["beta"].Token != "beta-root" {
+		t.Errorf("beta token: got %q, want beta-root", cfg.Vaults["beta"].Token)
+	}
+	if cfg.Vaults["alpha"].Token != "token-alpha" {
+		t.Errorf("alpha token: got %q, want it untouched", cfg.Vaults["alpha"].Token)
+	}
+}

--- a/pkg/rc/config.go
+++ b/pkg/rc/config.go
@@ -281,12 +281,20 @@ func (c *Config) SetTarget(alias string, config Vault) error {
 }
 
 func (c *Config) SetToken(token string) error {
-	if c.Current == "" {
+	return c.SetTokenFor(c.Current, token)
+}
+
+// SetTokenFor stores a token against a named target without making it the
+// current one. Commands that honour -T need that separation: -T names a Vault
+// for one command, and moving the current target would outlive the command,
+// since Write persists it.
+func (c *Config) SetTokenFor(alias, token string) error {
+	if alias == "" {
 		return fmt.Errorf("No target selected")
 	}
-	v, ok, _ := c.Find(c.Current)
+	v, ok, _ := c.Find(alias)
 	if !ok {
-		return fmt.Errorf("Unknown target '%s'", c.Current)
+		return fmt.Errorf("Unknown target '%s'", alias)
 	}
 	v.Token = token
 	return nil

--- a/pkg/rc/config_test.go
+++ b/pkg/rc/config_test.go
@@ -466,6 +466,34 @@ func TestConfigAccessors(t *testing.T) {
 		}
 	})
 
+	t.Run("SetTokenFor names its target and leaves the current one alone", func(t *testing.T) {
+		c := Config{
+			Current: "prod",
+			Vaults: map[string]*Vault{
+				"prod":  {URL: "https://prod:8200", Token: "prod-token"},
+				"stage": {URL: "https://stage:8200", Token: "stage-token"},
+			},
+		}
+		if err := c.SetTokenFor("stage", "new"); err != nil {
+			t.Fatalf("SetTokenFor: %s", err)
+		}
+		if c.Vaults["stage"].Token != "new" {
+			t.Errorf("stage token: got %q, want new", c.Vaults["stage"].Token)
+		}
+		if c.Vaults["prod"].Token != "prod-token" {
+			t.Errorf("prod token: got %q, want it untouched", c.Vaults["prod"].Token)
+		}
+		if c.Current != "prod" {
+			t.Errorf("current: got %q, want prod", c.Current)
+		}
+		if err := c.SetTokenFor("ghost", "x"); err == nil {
+			t.Error("expected error setting a token on an unknown target")
+		}
+		if err := c.SetTokenFor("", "x"); err == nil {
+			t.Error("expected error setting a token with no target named")
+		}
+	})
+
 	t.Run("SetCurrent validates the alias and can reskip", func(t *testing.T) {
 		c := Config{Vaults: map[string]*Vault{"prod": {URL: "u"}}}
 		if err := c.SetCurrent("ghost", false); err == nil {


### PR DESCRIPTION
**Stacked on #31**, which adds the helper this uses. Merge #31 first, then
**retarget this to `develop` before merging it** — `gh pr edit 32 --base
develop`. A stacked PR merged while its base still names a branch that has
already merged lands on that branch instead of on `develop`; that is how the
documentation in #29 was lost, and #30 puts it back.

## Why

`Config.SetToken` writes to the current target, because the current target
is the only one it knows about. Every command that stores a token calls it,
and `-T` names a different Vault without moving the current target. So the
token goes to the wrong entry in `~/.saferc`.

`logout` is the one that costs something. Two targets, both with tokens:

```
$ safe -T beta logout
Successfully logged out of beta

  alpha:  token: ""            # <- wiped, and nobody asked
  beta:   token: token-beta    # <- still logged in
```

It reports success against the Vault it did not log out of, leaves that
token live in the file, and signs the user out of a Vault they did not name.
Someone rotating a credential and then walking away has neither of the two
things they think they have.

`init` has the same shape without the second half: `safe -T beta init`
stores the root token of the Vault it just initialized against the current
target, leaving the initialized one with no token at all, and reads its
Strongbox flag from the current target too.

`auth` was already correct. It reached the right target by making it
current, setting the token, and switching back — a dance that only works
because `Write` happens to come after the restore. It now says what it
means.

## The change

`rc.Config` gains `SetTokenFor(alias, token)`: store a token against a named
target without making it current. `SetToken` becomes a call to it with the
current target, so the existing behaviour and its "No target selected"
error are unchanged.

`logout`, `auth`, and `init` name the target they mean. None of them moves
the current target, which matters because `Write` persists it, and `-T` is
supposed to last exactly one command.

Two errors that were being dropped now surface: logging out with nothing
targeted said "Successfully logged out of " and returned 0, and a token
stored against a target that had gone missing looked like a success.

## Tests

`pkg/rc`: `SetTokenFor` names its target, leaves the current one and its
token alone, and rejects both an unknown alias and an empty one.

`internal/cli/token_target_test.go`: logout clears the `-T` target's token
and only that one, with the current target unmoved; logout with nothing
targeted is an error; auth stores the token on the `-T` target (this one
passed before the change and guards the refactor); init stores the root
token on the `-T` target.

Verified live as well — `safe -T beta logout` against a Vault pair now
clears beta's token and leaves alpha's:

```
  alpha:  token: token-alpha
  beta:   token: ""
```

`make check` and `go test -race ./...` green.
