### PR TITLE
Search superseded and deleted versions for a value

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ secret/dc1/concourse/pipeline-the-second/dockerhub
 secret/dc1/concourse/pipeline-the-second/github
 ```
 
-### values \[--keys\] \[-p path ...\] value \[value ...\]
+### values \[--keys\] \[-a\] \[-p path ...\] value \[value ...\]
 
 Find the secrets whose latest live version contains one of the given
 values, matched exactly and case-sensitively. Handy for auditing
@@ -372,6 +372,13 @@ read from a file (`@file`), standard input (`@-`), or a hidden prompt
 (no arguments). Subtrees the token cannot read are skipped with a
 warning on standard error.
 
+`-a` (`--all-versions`) searches the whole readable history rather than
+the value in use, which is what finds a credential that has already
+been rotated away. Each match is then reported as `path^version`, so a
+hit on a superseded version reads back exactly as printed. Deleted and
+destroyed versions are searched in neither mode, since reading one
+would mean undeleting it first.
+
 ```
 safe values -p secret/prod hunter2
 secret/prod/db
@@ -380,6 +387,11 @@ secret/prod/legacy/db
 safe values --keys hunter2
 secret/prod/db:password
 secret/prod/legacy/db:old-password
+
+safe values --all-versions --keys hunter2
+secret/prod/db:password^3
+secret/prod/legacy/db:old-password^1
+secret/prod/legacy/db:old-password^2
 ```
 
 ### delete path \[path ...\]

--- a/README.md
+++ b/README.md
@@ -375,9 +375,13 @@ warning on standard error.
 `-a` (`--all-versions`) searches the whole readable history rather than
 the value in use, which is what finds a credential that has already
 been rotated away. Each match is then reported as `path^version`, so a
-hit on a superseded version reads back exactly as printed. Deleted and
-destroyed versions are searched in neither mode, since reading one
-would mean undeleting it first.
+hit on a superseded version reads back exactly as printed.
+
+`-d` (`--deleted`) reaches deleted versions as well, by undeleting each
+one, reading it, and deleting it again — the same cycle `safe export
+-d` uses. It writes to the Vault to answer the question, and an
+interrupted search can leave a version undeleted. Destroyed versions
+are gone and are searched by neither flag.
 
 ```
 safe values -p secret/prod hunter2

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -227,6 +227,7 @@ type Options struct {
 	Values struct {
 		ShowKeys    bool     `cli:"--keys"`
 		AllVersions bool     `cli:"-a, --all-versions"`
+		Deleted     bool     `cli:"-d, --deleted"`
 		Paths       []string `cli:"-p, --path"`
 	} `cli:"values"`
 
@@ -775,7 +776,7 @@ vaults. This flag does nothing for kv v1 mounts.
 
 	r.Dispatch("values", &Help{
 		Summary: "Find secrets containing specified values",
-		Usage:   "safe values [--keys] [-a] [-p PATH ...] [VALUE ...]",
+		Usage:   "safe values [--keys] [-ad] [-p PATH ...] [VALUE ...]",
 		Type:    NonDestructiveCommand,
 		Description: `
 Searches the hierarchy of secrets for any whose stored values equal one of
@@ -788,10 +789,18 @@ deleted or destroyed are not searched.
 which is what an audit of a leaked value wants: a credential that was
 rotated away still sits in the history. Each match is then reported as
 path^version, so a hit on a superseded version can be told apart from one on
-the value in use and read back exactly as printed. Deleted and destroyed
-versions are still not searched, since reading one would mean undeleting it.
-On a kv v1 mount, where a secret has only the one version, this reports
-every match as version 1.
+the value in use and read back exactly as printed. Only the versions that can
+be read without writing are searched; add -d for the deleted ones. On a kv v1
+mount, where a secret has only the one version, this reports every match as
+version 1.
+
+-d (--deleted) searches deleted versions too, by undeleting each one, reading
+it, and deleting it again -- the same cycle safe export -d uses. It writes to
+the Vault to answer the question, and an interrupted search can leave a
+version undeleted, so reach for it when a leaked credential has to be tracked
+down wherever it landed. Destroyed versions are gone and are searched by
+neither flag. Matches carry their version number under -d as well, since a
+match may be sitting in a version that is no longer live.
 
 Search locations are given with -p (--path), which may be repeated to search
 several subtrees. The flag value must be a separate argument; the --path=x

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -225,8 +225,9 @@ type Options struct {
 	} `cli:"tree"`
 
 	Values struct {
-		ShowKeys bool     `cli:"--keys"`
-		Paths    []string `cli:"-p, --path"`
+		ShowKeys    bool     `cli:"--keys"`
+		AllVersions bool     `cli:"-a, --all-versions"`
+		Paths       []string `cli:"-p, --path"`
 	} `cli:"values"`
 
 	Target struct {
@@ -774,7 +775,7 @@ vaults. This flag does nothing for kv v1 mounts.
 
 	r.Dispatch("values", &Help{
 		Summary: "Find secrets containing specified values",
-		Usage:   "safe values [--keys] [-p PATH ...] [VALUE ...]",
+		Usage:   "safe values [--keys] [-a] [-p PATH ...] [VALUE ...]",
 		Type:    NonDestructiveCommand,
 		Description: `
 Searches the hierarchy of secrets for any whose stored values equal one of
@@ -782,6 +783,15 @@ the given values. Matching is exact, case-sensitive, and against whole
 values; no substring or pattern matching is performed. Only the latest live
 version of each secret is inspected -- secrets whose newest version has been
 deleted or destroyed are not searched.
+
+-a (--all-versions) searches every readable version of each secret instead,
+which is what an audit of a leaked value wants: a credential that was
+rotated away still sits in the history. Each match is then reported as
+path^version, so a hit on a superseded version can be told apart from one on
+the value in use and read back exactly as printed. Deleted and destroyed
+versions are still not searched, since reading one would mean undeleting it.
+On a kv v1 mount, where a secret has only the one version, this reports
+every match as version 1.
 
 Search locations are given with -p (--path), which may be repeated to search
 several subtrees. The flag value must be a separate argument; the --path=x

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -545,6 +545,7 @@ func (c *CLI) cmdValues(command string, args ...string) error {
 	results, skipped, err := v.FindValueMatches(paths, values, vault.ValueSearchOpts{
 		ShowKeys:    opt.Values.ShowKeys,
 		AllVersions: opt.Values.AllVersions,
+		Deleted:     opt.Values.Deleted,
 	})
 	//Partial results still print when some paths failed; err below makes
 	// main report the failure and exit non-zero.

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -543,7 +543,8 @@ func (c *CLI) cmdValues(command string, args ...string) error {
 
 	v := connect(true)
 	results, skipped, err := v.FindValueMatches(paths, values, vault.ValueSearchOpts{
-		ShowKeys: opt.Values.ShowKeys,
+		ShowKeys:    opt.Values.ShowKeys,
+		AllVersions: opt.Values.AllVersions,
 	})
 	//Partial results still print when some paths failed; err below makes
 	// main report the failure and exit non-zero.

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -542,7 +542,9 @@ func (c *CLI) cmdValues(command string, args ...string) error {
 	paths = dedupeExportPaths(paths)
 
 	v := connect(true)
-	results, skipped, err := v.FindValueMatches(paths, values, opt.Values.ShowKeys)
+	results, skipped, err := v.FindValueMatches(paths, values, vault.ValueSearchOpts{
+		ShowKeys: opt.Values.ShowKeys,
+	})
 	//Partial results still print when some paths failed; err below makes
 	// main report the failure and exit non-zero.
 	for _, result := range results {

--- a/internal/cli/values_all_versions_test.go
+++ b/internal/cli/values_all_versions_test.go
@@ -1,0 +1,122 @@
+package cli
+
+// `safe values` searches the value in use. A rotated credential is exactly the
+// one an operator goes looking for after a leak, and it lives in the history
+// rather than in the current version, so --all-versions searches the whole
+// readable history and names the version each match came from.
+
+import (
+	"strings"
+	"testing"
+)
+
+// rotated serves a v2 mount holding secret/v/db, whose password was rotated
+// once, plus a second secret that never changed.
+func rotated(t *testing.T) *cliFakeVault {
+	t.Helper()
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/v/db",
+		map[string]string{"password": "old-pass", "user": "dba"},
+		map[string]string{"password": "new-pass", "user": "dba"})
+	fv.setV2("secret/v/api",
+		map[string]string{"token": "static"})
+	return fv
+}
+
+// valueLines runs cmdValues and returns the paths it printed.
+func valueLines(t *testing.T, c *CLI, values ...string) []string {
+	t.Helper()
+	out := captureStdout(t, func() {
+		if err := c.cmdValues("values", values...); err != nil {
+			t.Fatalf("cmdValues(%v): %v", values, err)
+		}
+	})
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return nil
+	}
+	return strings.Split(out, "\n")
+}
+
+func TestValuesSearchesOnlyTheCurrentVersionByDefault(t *testing.T) {
+	isolateHome(t)
+	rotated(t)
+	c := newTestCLI(t)
+
+	if got := valueLines(t, c, "old-pass"); got != nil {
+		t.Errorf("a rotated-away value = %v, want no match without --all-versions", got)
+	}
+	if got, want := valueLines(t, c, "new-pass"), []string{"secret/v/db"}; !equalLines(got, want) {
+		t.Errorf("current value = %v, want %v", got, want)
+	}
+}
+
+func TestValuesAllVersionsFindsARotatedValue(t *testing.T) {
+	isolateHome(t)
+	rotated(t)
+	c := newTestCLI(t)
+	c.opt.Values.AllVersions = true
+
+	got, want := valueLines(t, c, "old-pass"), []string{"secret/v/db^1"}
+	if !equalLines(got, want) {
+		t.Errorf("values --all-versions old-pass = %v, want %v", got, want)
+	}
+}
+
+// The version belongs on the reported path in every output shape, so that
+// what is printed reads back as printed.
+func TestValuesAllVersionsNamesTheVersionWithKeys(t *testing.T) {
+	isolateHome(t)
+	rotated(t)
+	c := newTestCLI(t)
+	c.opt.Values.AllVersions = true
+	c.opt.Values.ShowKeys = true
+
+	got, want := valueLines(t, c, "old-pass"), []string{"secret/v/db:password^1"}
+	if !equalLines(got, want) {
+		t.Errorf("values --all-versions --keys = %v, want %v", got, want)
+	}
+}
+
+// A value that survived the rotation appears once per version that holds it,
+// oldest first.
+func TestValuesAllVersionsReportsEveryVersionHolding(t *testing.T) {
+	isolateHome(t)
+	rotated(t)
+	c := newTestCLI(t)
+	c.opt.Values.AllVersions = true
+
+	got, want := valueLines(t, c, "dba"), []string{"secret/v/db^1", "secret/v/db^2"}
+	if !equalLines(got, want) {
+		t.Errorf("values --all-versions dba = %v, want %v", got, want)
+	}
+}
+
+// Reading a deleted version means undeleting it first, which a search must not
+// do, so the history it reports stops at what it can read.
+func TestValuesAllVersionsSkipsADeletedVersion(t *testing.T) {
+	isolateHome(t)
+	fv := rotated(t)
+	fv.deleteV2("secret/v/db", 1)
+	c := newTestCLI(t)
+	c.opt.Values.AllVersions = true
+
+	if got := valueLines(t, c, "old-pass"); got != nil {
+		t.Errorf("deleted version = %v, want no match", got)
+	}
+	if got, want := valueLines(t, c, "new-pass"), []string{"secret/v/db^2"}; !equalLines(got, want) {
+		t.Errorf("alive version alongside a deleted one = %v, want %v", got, want)
+	}
+}
+
+func equalLines(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/values_deleted_test.go
+++ b/internal/cli/values_deleted_test.go
@@ -1,0 +1,97 @@
+package cli
+
+// `safe values -d` searches versions that have been deleted, which it can only
+// do by undeleting each one, reading it, and deleting it again -- the cycle
+// `safe export -d` already uses. What the tests here pin down is that the
+// search finds what is in those versions and puts every one of them back.
+
+import "testing"
+
+// deletedHistory serves a v2 mount holding secret/d/db with three versions:
+// version 1 deleted, version 2 destroyed, version 3 alive.
+func deletedHistory(t *testing.T) *cliFakeVault {
+	t.Helper()
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/d/db",
+		map[string]string{"password": "leaked"},
+		map[string]string{"password": "interim"},
+		map[string]string{"password": "current"})
+	fv.deleteV2("secret/d/db", 1)
+	fv.destroyV2("secret/d/db", 2)
+	return fv
+}
+
+func TestValuesWithoutDeletedCannotSeeADeletedVersion(t *testing.T) {
+	isolateHome(t)
+	deletedHistory(t)
+	c := newTestCLI(t)
+	c.opt.Values.AllVersions = true
+
+	if got := valueLines(t, c, "leaked"); got != nil {
+		t.Errorf("a deleted version = %v, want no match without -d", got)
+	}
+}
+
+func TestValuesDeletedFindsAValueInADeletedVersion(t *testing.T) {
+	isolateHome(t)
+	deletedHistory(t)
+	c := newTestCLI(t)
+	c.opt.Values.AllVersions = true
+	c.opt.Values.Deleted = true
+
+	got, want := valueLines(t, c, "leaked"), []string{"secret/d/db^1"}
+	if !equalLines(got, want) {
+		t.Errorf("values -a -d leaked = %v, want %v", got, want)
+	}
+}
+
+// The search must leave the Vault as it found it. An undelete that is not
+// followed by a delete turns a search into a restore.
+func TestValuesDeletedLeavesTheVersionDeleted(t *testing.T) {
+	isolateHome(t)
+	fv := deletedHistory(t)
+	c := newTestCLI(t)
+	c.opt.Values.AllVersions = true
+	c.opt.Values.Deleted = true
+
+	before := fv.versionStates("secret/d/db")
+	valueLines(t, c, "leaked")
+	after := fv.versionStates("secret/d/db")
+
+	if !equalLines(before, after) {
+		t.Errorf("version states after the search = %v, want %v as before", after, before)
+	}
+}
+
+// A destroyed version cannot be read back by anyone, so -d must not claim it
+// searched one.
+func TestValuesDeletedStillCannotSeeADestroyedVersion(t *testing.T) {
+	isolateHome(t)
+	deletedHistory(t)
+	c := newTestCLI(t)
+	c.opt.Values.AllVersions = true
+	c.opt.Values.Deleted = true
+
+	if got := valueLines(t, c, "interim"); got != nil {
+		t.Errorf("a destroyed version = %v, want no match", got)
+	}
+}
+
+// Without --all-versions, -d reaches the newest version even when that one is
+// the deleted one, which is the state a secret is left in by `safe delete`.
+func TestValuesDeletedReachesADeletedLatestVersion(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/d/gone", map[string]string{"password": "buried"})
+	fv.deleteV2("secret/d/gone", 1)
+	c := newTestCLI(t)
+	c.opt.Values.Deleted = true
+
+	got, want := valueLines(t, c, "buried"), []string{"secret/d/gone^1"}
+	if !equalLines(got, want) {
+		t.Errorf("values -d buried = %v, want %v", got, want)
+	}
+	if states := fv.versionStates("secret/d/gone"); !equalLines(states, []string{"deleted"}) {
+		t.Errorf("version states after the search = %v, want [deleted]", states)
+	}
+}

--- a/pkg/vault/find_value_matches_test.go
+++ b/pkg/vault/find_value_matches_test.go
@@ -36,7 +36,7 @@ func TestFindValueMatchesShowKeys(t *testing.T) {
 	v, fv := newTestVault(t)
 	seedValueTree(fv)
 
-	got, skipped, err := v.FindValueMatches([]string{"secret"}, []string{"secret123"}, true)
+	got, skipped, err := v.FindValueMatches([]string{"secret"}, []string{"secret123"}, vault.ValueSearchOpts{ShowKeys: true})
 	if err != nil {
 		t.Fatalf("FindValueMatches: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestFindValueMatchesPathsOnly(t *testing.T) {
 	v, fv := newTestVault(t)
 	seedValueTree(fv)
 
-	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"secret123"}, false)
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"secret123"}, vault.ValueSearchOpts{})
 	if err != nil {
 		t.Fatalf("FindValueMatches: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestFindValueMatchesDeduplicatesPaths(t *testing.T) {
 	v, fv := newTestVault(t)
 	seedValueTree(fv)
 
-	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"admin", "secret123"}, false)
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"admin", "secret123"}, vault.ValueSearchOpts{})
 	if err != nil {
 		t.Fatalf("FindValueMatches: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestFindValueMatchesMultipleValues(t *testing.T) {
 	v, fv := newTestVault(t)
 	seedValueTree(fv)
 
-	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"secret123", "abc123"}, true)
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"secret123", "abc123"}, vault.ValueSearchOpts{ShowKeys: true})
 	if err != nil {
 		t.Fatalf("FindValueMatches: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestFindValueMatchesMultiplePaths(t *testing.T) {
 	seedValueTree(fv)
 
 	got, _, err := v.FindValueMatches(
-		[]string{"secret/test1", "secret/test2"}, []string{"admin", "user"}, true)
+		[]string{"secret/test1", "secret/test2"}, []string{"admin", "user"}, vault.ValueSearchOpts{ShowKeys: true})
 	if err != nil {
 		t.Fatalf("FindValueMatches: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestFindValueMatchesNoMatches(t *testing.T) {
 	v, fv := newTestVault(t)
 	seedValueTree(fv)
 
-	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"nonexistent"}, true)
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"nonexistent"}, vault.ValueSearchOpts{ShowKeys: true})
 	if err != nil {
 		t.Fatalf("FindValueMatches: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestFindValueMatchesIsExactNotSubstring(t *testing.T) {
 	v, fv := newTestVault(t)
 	fv.set("secret/app", map[string]string{"password": "secret123456"})
 
-	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"secret123"}, true)
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"secret123"}, vault.ValueSearchOpts{ShowKeys: true})
 	if err != nil {
 		t.Fatalf("FindValueMatches: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestFindValueMatchesValueWithColon(t *testing.T) {
 	fv.set("secret/app", map[string]string{"url": "https://example.com:8443"})
 
 	got, _, err := v.FindValueMatches(
-		[]string{"secret"}, []string{"https://example.com:8443"}, true)
+		[]string{"secret"}, []string{"https://example.com:8443"}, vault.ValueSearchOpts{ShowKeys: true})
 	if err != nil {
 		t.Fatalf("FindValueMatches: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestFindValueMatchesNonexistentPathErrors(t *testing.T) {
 	v, _ := newTestVault(t)
 
 	if _, _, err := v.FindValueMatches(
-		[]string{"nonexistent/path"}, []string{"value"}, true); err == nil {
+		[]string{"nonexistent/path"}, []string{"value"}, vault.ValueSearchOpts{ShowKeys: true}); err == nil {
 		t.Error("FindValueMatches on a missing path should return an error")
 	}
 }
@@ -193,7 +193,7 @@ func TestFindValueMatchesEmptyTargets(t *testing.T) {
 	v, fv := newTestVault(t)
 	seedValueTree(fv)
 
-	got, _, err := v.FindValueMatches([]string{"secret"}, nil, false)
+	got, _, err := v.FindValueMatches([]string{"secret"}, nil, vault.ValueSearchOpts{})
 	if err != nil {
 		t.Fatalf("FindValueMatches: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestFindValueMatchesEmptyStringValue(t *testing.T) {
 	v, fv := newTestVault(t)
 	fv.set("secret/app", map[string]string{"blank": "", "other": "x"})
 
-	got, _, err := v.FindValueMatches([]string{"secret"}, []string{""}, true)
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{""}, vault.ValueSearchOpts{ShowKeys: true})
 	if err != nil {
 		t.Fatalf("FindValueMatches: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestFindValueMatchesPartialFailure(t *testing.T) {
 	seedValueTree(fv)
 
 	got, _, err := v.FindValueMatches(
-		[]string{"secret", "nonexistent/x"}, []string{"secret123"}, false)
+		[]string{"secret", "nonexistent/x"}, []string{"secret123"}, vault.ValueSearchOpts{})
 	if err == nil {
 		t.Fatal("expected an error for the unwalkable path, got nil")
 	}
@@ -251,7 +251,7 @@ func TestFindValueMatchesOverlappingPaths(t *testing.T) {
 	seedValueTree(fv)
 
 	got, _, err := v.FindValueMatches(
-		[]string{"secret", "secret/nested"}, []string{"secret123"}, true)
+		[]string{"secret", "secret/nested"}, []string{"secret123"}, vault.ValueSearchOpts{ShowKeys: true})
 	if err != nil {
 		t.Fatalf("FindValueMatches: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestFindValueMatchesSortsByPathLessThan(t *testing.T) {
 	fv.set("secret/a-b", map[string]string{"k": "match"})
 	fv.set("secret/a/x", map[string]string{"k": "match"})
 
-	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"match"}, false)
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"match"}, vault.ValueSearchOpts{})
 	if err != nil {
 		t.Fatalf("FindValueMatches: %v", err)
 	}
@@ -293,7 +293,7 @@ func TestFindValueMatchesEscapingMatchesPaths(t *testing.T) {
 	v, fv := newTestVault(t)
 	fv.set("secret/odd:colon", map[string]string{"od^d": "match"})
 
-	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"match"}, true)
+	got, _, err := v.FindValueMatches([]string{"secret"}, []string{"match"}, vault.ValueSearchOpts{ShowKeys: true})
 	if err != nil {
 		t.Fatalf("FindValueMatches(--keys): %v", err)
 	}
@@ -311,7 +311,7 @@ func TestFindValueMatchesEscapingMatchesPaths(t *testing.T) {
 		t.Errorf("Secrets.Paths() = %v, want %v (escaping must stay in lockstep)", paths, want)
 	}
 
-	got, _, err = v.FindValueMatches([]string{"secret"}, []string{"match"}, false)
+	got, _, err = v.FindValueMatches([]string{"secret"}, []string{"match"}, vault.ValueSearchOpts{})
 	if err != nil {
 		t.Fatalf("FindValueMatches(paths): %v", err)
 	}
@@ -328,7 +328,7 @@ func TestFindValueMatchesCountsForbiddenSkips(t *testing.T) {
 	fv.set("secret/hidden/deep", map[string]string{"k": "secret123"})
 	fv.forbid("secret/hidden")
 
-	got, skipped, err := v.FindValueMatches([]string{"secret"}, []string{"secret123"}, false)
+	got, skipped, err := v.FindValueMatches([]string{"secret"}, []string{"secret123"}, vault.ValueSearchOpts{})
 	if err != nil {
 		t.Fatalf("FindValueMatches: %v", err)
 	}
@@ -339,5 +339,37 @@ func TestFindValueMatchesCountsForbiddenSkips(t *testing.T) {
 	want := []string{"secret/nested/path", "secret/test1", "secret/test2"}
 	if !slices.Equal(got, want) {
 		t.Errorf("FindValueMatches(forbidden sibling) = %v, want %v", got, want)
+	}
+}
+
+// A kv v1 secret has exactly one version, numbered 1. Asking for every
+// version there still names it, so the output shape does not depend on which
+// kind of mount was searched.
+func TestFindValueMatchesAllVersionsOnV1NamesVersionOne(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	seedValueTree(fv)
+
+	got, _, err := v.FindValueMatches(
+		[]string{"secret"}, []string{"secret123"}, vault.ValueSearchOpts{AllVersions: true})
+	if err != nil {
+		t.Fatalf("FindValueMatches: %v", err)
+	}
+
+	want := []string{"secret/nested/path^1", "secret/test1^1", "secret/test2^1"}
+	if !slices.Equal(got, want) {
+		t.Errorf("FindValueMatches(--all-versions) = %v, want %v", got, want)
+	}
+
+	got, _, err = v.FindValueMatches(
+		[]string{"secret"}, []string{"secret123"},
+		vault.ValueSearchOpts{AllVersions: true, ShowKeys: true})
+	if err != nil {
+		t.Fatalf("FindValueMatches(--keys): %v", err)
+	}
+
+	want = []string{"secret/nested/path:password^1", "secret/test1:password^1", "secret/test2:token^1"}
+	if !slices.Equal(got, want) {
+		t.Errorf("FindValueMatches(--all-versions --keys) = %v, want %v", got, want)
 	}
 }

--- a/pkg/vault/tree.go
+++ b/pkg/vault/tree.go
@@ -1003,24 +1003,43 @@ func (w *treeWorker) workVersions(t secretTree) ([]secretTree, error) {
 	return ret, nil
 }
 
+// ValueSearchOpts tunes what FindValueMatches searches and what it reports.
+type ValueSearchOpts struct {
+	//ShowKeys reports each matching key of a secret rather than the path of
+	// the secret alone.
+	ShowKeys bool
+	//AllVersions searches every readable version of each secret rather than
+	// only the newest live one, and names the version each match came from.
+	AllVersions bool
+}
+
 // FindValueMatches walks each of the given paths and reports the secrets
-// whose latest live version contains any of targetValues, compared exactly
-// and case-sensitively against whole stored values. With showKeys, each
-// match is rendered as escaped path:key exactly as Secrets.Paths() renders
-// keyed entries; otherwise the bare path of each matching secret is
-// reported once.
+// containing any of targetValues, compared exactly and case-sensitively
+// against whole stored values. With ShowKeys, each match is rendered as
+// escaped path:key exactly as Secrets.Paths() renders keyed entries;
+// otherwise the path of each matching secret is reported once.
 //
-// Results sort by PathLessThan on path with a bytewise key tiebreak.
-// skipped counts the subtrees the walk dropped because Vault denied access
-// to them. Walk errors are accumulated per path and returned joined,
+// Only the newest live version of a secret is searched unless AllVersions
+// is set, which searches the whole readable history and appends ^version to
+// every match, so that a match in a superseded version can be told from one
+// in the current value and read back as printed. Versions the walk cannot
+// read — deleted and destroyed ones — are searched in neither mode, since
+// reading them would mean writing to the Vault.
+//
+// Results sort by PathLessThan on path, then by version, then bytewise by
+// key. skipped counts the subtrees the walk dropped because Vault denied
+// access to them. Walk errors are accumulated per path and returned joined,
 // alongside whatever results the remaining paths produced.
-func (v *Vault) FindValueMatches(paths []string, targetValues []string, showKeys bool) (results []string, skipped uint64, err error) {
+func (v *Vault) FindValueMatches(paths []string, targetValues []string, opts ValueSearchOpts) (results []string, skipped uint64, err error) {
 	valueSet := make(map[string]bool, len(targetValues))
 	for _, value := range targetValues {
 		valueSet[value] = true
 	}
 
-	type valueMatch struct{ path, key string }
+	type valueMatch struct {
+		path, key string
+		version   uint64
+	}
 	var (
 		skipCount  atomic.Uint64
 		matches    []valueMatch
@@ -1030,6 +1049,7 @@ func (v *Vault) FindValueMatches(paths []string, targetValues []string, showKeys
 	for _, path := range paths {
 		secrets, cerr := v.ConstructSecrets(path, TreeOpts{
 			FetchKeys:        true,
+			FetchAllVersions: opts.AllVersions,
 			SkippedForbidden: &skipCount,
 		})
 		if cerr != nil {
@@ -1047,14 +1067,37 @@ func (v *Vault) FindValueMatches(paths []string, targetValues []string, showKeys
 				continue
 			}
 
-			data := secret.Versions[len(secret.Versions)-1].Data
-			for _, key := range data.Keys() {
-				if !valueSet[data.Get(key)] {
+			versions := secret.Versions
+			if !opts.AllVersions {
+				versions = versions[len(versions)-1:]
+			}
+
+			for _, version := range versions {
+				//The walk fetches no data for a version it cannot read, so a
+				// deleted or destroyed one compares against nothing anyway.
+				// Skipping it by state says so outright, and keeps a walk that
+				// did undelete to read them — which a search must not do —
+				// from quietly reporting what it found.
+				if version.State != SecretStateAlive {
 					continue
 				}
-				matches = append(matches, valueMatch{path: secret.Path, key: key})
-				if !showKeys {
-					break
+
+				//Version 0 renders no ^suffix, which is what a search of the
+				// current value alone should print.
+				var number uint64
+				if opts.AllVersions {
+					number = uint64(version.Number)
+				}
+
+				data := version.Data
+				for _, key := range data.Keys() {
+					if !valueSet[data.Get(key)] {
+						continue
+					}
+					matches = append(matches, valueMatch{path: secret.Path, key: key, version: number})
+					if !opts.ShowKeys {
+						break
+					}
 				}
 			}
 		}
@@ -1064,16 +1107,19 @@ func (v *Vault) FindValueMatches(paths []string, targetValues []string, showKeys
 		if matches[i].path != matches[j].path {
 			return PathLessThan(matches[i].path, matches[j].path)
 		}
+		if matches[i].version != matches[j].version {
+			return matches[i].version < matches[j].version
+		}
 		return matches[i].key < matches[j].key
 	})
 
 	results = make([]string, 0, len(matches))
 	for _, match := range matches {
-		if showKeys {
-			results = append(results, EncodePath(match.path, match.key, 0))
-		} else {
-			results = append(results, EncodePath(match.path, "", 0))
+		key := ""
+		if opts.ShowKeys {
+			key = match.key
 		}
+		results = append(results, EncodePath(match.path, key, match.version))
 	}
 
 	return results, skipCount.Load(), err

--- a/pkg/vault/tree.go
+++ b/pkg/vault/tree.go
@@ -1011,6 +1011,10 @@ type ValueSearchOpts struct {
 	//AllVersions searches every readable version of each secret rather than
 	// only the newest live one, and names the version each match came from.
 	AllVersions bool
+	//Deleted searches versions that have been deleted, by undeleting each
+	// one, reading it, and deleting it again. Destroyed versions are gone
+	// for good and are never searched.
+	Deleted bool
 }
 
 // FindValueMatches walks each of the given paths and reports the secrets
@@ -1048,9 +1052,11 @@ func (v *Vault) FindValueMatches(paths []string, targetValues []string, opts Val
 
 	for _, path := range paths {
 		secrets, cerr := v.ConstructSecrets(path, TreeOpts{
-			FetchKeys:        true,
-			FetchAllVersions: opts.AllVersions,
-			SkippedForbidden: &skipCount,
+			FetchKeys:           true,
+			FetchAllVersions:    opts.AllVersions,
+			GetDeletedVersions:  opts.Deleted,
+			AllowDeletedSecrets: opts.Deleted,
+			SkippedForbidden:    &skipCount,
 		})
 		if cerr != nil {
 			err = errors.Join(err, fmt.Errorf("%s: %w", path, cerr))
@@ -1073,19 +1079,21 @@ func (v *Vault) FindValueMatches(paths []string, targetValues []string, opts Val
 			}
 
 			for _, version := range versions {
-				//The walk fetches no data for a version it cannot read, so a
-				// deleted or destroyed one compares against nothing anyway.
-				// Skipping it by state says so outright, and keeps a walk that
-				// did undelete to read them — which a search must not do —
-				// from quietly reporting what it found.
-				if version.State != SecretStateAlive {
+				//Without Deleted the walk fetched no data for a version it
+				// could not read, so a deleted or destroyed one compares
+				// against nothing anyway; skipping it by state says so
+				// outright. With Deleted the walk undeleted and read them, and
+				// a destroyed version stays empty either way.
+				if !opts.Deleted && version.State != SecretStateAlive {
 					continue
 				}
 
 				//Version 0 renders no ^suffix, which is what a search of the
-				// current value alone should print.
+				// current value alone should print. Once more than the current
+				// value is in play, naming the version is what tells a match on
+				// a superseded or deleted one apart from a live match.
 				var number uint64
-				if opts.AllVersions {
+				if opts.AllVersions || opts.Deleted {
 					number = uint64(version.Number)
 				}
 


### PR DESCRIPTION
`safe values` searched the newest live version of each secret and nothing
else. That is the wrong half of the history for the job the command exists to
do: after a credential leaks, the value an operator hunts for is the one that
has already been rotated away, and it survives in the versions behind the
current one.

`-a` / `--all-versions` searches the whole readable history and reports each
match as `path^version`, so a hit on a superseded value is distinguishable
from a hit on the value in use, and reads back exactly as printed.

Verified against a dev Vault on a kv v2 mount, with `secret/prod/db` written
twice — `password=hunter2` then `password=hunter3`:

```
$ safe values hunter2                          # default: nothing, exit 0
$ safe values -a hunter2
secret/prod/db^1
$ safe values --all-versions --keys hunter2
secret/prod/db:password^1
$ safe get secret/prod/db:password^1
hunter2
$ safe delete secret/prod/db^1 && safe values -a hunter2
                                               # nothing: a deleted version
                                               # is not searched
```

## Notes on the design

Deleted and destroyed versions are searched in neither mode. Reading one means
undeleting it, reading, and deleting it again — writes, from a command
registered `NonDestructiveCommand`. `export -d` is the precedent for doing
that, and it is a separate decision from this one.

The version suffix is unconditional in this mode, including on kv v1 mounts
where the one version is numbered 1. A script consuming the output then does
not have to know which kind of mount it searched.

`FindValueMatches` now takes a `ValueSearchOpts` instead of a bare `showKeys`
bool. Two positional bools at a call site read as neither.

## Tests

Five CLI tests against the kv v2 fake cover the default staying latest-only,
a rotated value found by version, the `--keys` shape, a value present in two
versions reported once per version oldest-first, and a deleted version
dropping out. A pkg/vault test pins the kv v1 shape.

Mutation-tested on four axes. Reverting the `FetchAllVersions` walk option,
the version-slice widening, or the version rendering fails 3, 3, and 5 tests
respectively. Dropping the alive-state guard fails none — a version the walk
did not fetch holds no data to match against, so that guard is deliberate
belt-and-braces rather than load-bearing, and the comment says so.

`make check` and `go test -race ./...` green.


---

## Also in this PR: `-d` / `--deleted`

Pushed after the first round, into the same PR rather than a stacked one.

A leaked credential is often exactly the one someone tried to make go away,
and `safe delete` leaves it readable. The search could not reach it: a deleted
version is never fetched, so it compared against nothing. `-d` walks with the
undelete → read → delete-again cycle `safe export -d` already uses.

It writes to the Vault to answer a question. That is why it stays behind a
flag, why the help says so outright, and why an interrupted search leaving a
version undeleted is called out there too. Destroyed versions are gone and
stay unreachable under both flags.

Verified against a dev Vault, `secret/audit/db` with version 1 deleted,
version 2 destroyed, version 3 alive:

```
$ safe values -a leaked            # nothing: -a alone does not undelete
$ safe values -a -d leaked
secret/audit/db^1
$ safe values -a -d interim        # nothing: version 2 is destroyed
$ safe versions secret/audit/db
version  status     created at
1        deleted    ...            # put back exactly as found
2        destroyed  ...
3        alive      ...
```

`values` stays registered `NonDestructiveCommand`, matching `export`, which
also writes under `-d`. That field only colours the name in `safe commands`;
it guards nothing.

Five more tests, including one asserting the version states are identical
before and after the search. Mutation-tested: dropping `GetDeletedVersions`
fails 2, dropping `AllowDeletedSecrets` fails 1, restoring the strict
alive-only guard fails 2, and removing the re-delete in the tree walk fails
the two state-invariant assertions.
