### PR TITLE
Delete the target a name resolves to

### DIFF
--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -43,7 +43,17 @@ func (c *CLI) cmdTargets(command string, args ...string) error {
 		}
 		vaults := make([]vault, 0)
 
-		for name, details := range cfg.Vaults {
+		//Sorted, like the listing this is the machine-readable half of. Ranging
+		// over the map put the targets in a different order on every run, which
+		// is no use to anything diffing or reviewing the output.
+		names := make([]string, 0, len(cfg.Vaults))
+		for name := range cfg.Vaults {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		for _, name := range names {
+			details := cfg.Vaults[name]
 			vaults = append(vaults, vault{
 				Name:      name,
 				URL:       details.URL,

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -285,8 +285,20 @@ func (c *CLI) cmdTargetDelete(command string, args ...string) error {
 		return r.Usage("target delete")
 	}
 
-	delete(cfg.Vaults, args[0])
-	if cfg.Current == args[0] {
+	//Resolving the name rather than deleting the map key directly: every
+	// other target command reaches a target by alias or by URL, and a delete
+	// that quietly matched neither reported success while leaving the target,
+	// and the token stored with it, in place.
+	alias, ok, err := cfg.Alias(args[0])
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("Unknown target '%s'", args[0])
+	}
+
+	delete(cfg.Vaults, alias)
+	if cfg.Current == alias {
 		cfg.Current = ""
 	}
 

--- a/internal/cli/target_delete_test.go
+++ b/internal/cli/target_delete_test.go
@@ -1,0 +1,124 @@
+package cli
+
+// `safe target delete` removed a key from the config map without checking that
+// the name matched anything. A name that reached the target everywhere else --
+// its URL -- matched nothing here, and neither did a typo, and both reported
+// success. The target stayed in ~/.saferc with its token, which is the
+// opposite of what someone deleting a target is asking for.
+
+import (
+	"strings"
+	"testing"
+)
+
+// twoNamedTargets writes a config holding alpha and beta, with beta current.
+func twoNamedTargets(t *testing.T) {
+	t.Helper()
+	writeSaferc(t, `version: 1
+current: beta
+vaults:
+  alpha:
+    url: https://alpha.example.com
+    token: token-alpha
+  beta:
+    url: https://beta.example.com
+    token: token-beta
+`)
+}
+
+func TestTargetDeleteRemovesTheTargetNamedByAlias(t *testing.T) {
+	isolateHome(t)
+	twoNamedTargets(t)
+	c := newTestCLI(t)
+
+	if err := c.cmdTargetDelete("target delete", "alpha"); err != nil {
+		t.Fatalf("cmdTargetDelete: %v", err)
+	}
+
+	cfg := readConfig(t)
+	if _, ok := cfg.Vaults["alpha"]; ok {
+		t.Error("alpha is still in the config")
+	}
+	if _, ok := cfg.Vaults["beta"]; !ok {
+		t.Error("beta should have been left alone")
+	}
+	if cfg.Current != "beta" {
+		t.Errorf("current = %q, want beta", cfg.Current)
+	}
+}
+
+// The URL is a name `safe target` accepts, so `safe target delete` accepts it.
+func TestTargetDeleteRemovesTheTargetNamedByURL(t *testing.T) {
+	isolateHome(t)
+	twoNamedTargets(t)
+	c := newTestCLI(t)
+
+	if err := c.cmdTargetDelete("target delete", "https://alpha.example.com"); err != nil {
+		t.Fatalf("cmdTargetDelete: %v", err)
+	}
+
+	cfg := readConfig(t)
+	if _, ok := cfg.Vaults["alpha"]; ok {
+		t.Error("alpha is still in the config after being deleted by URL")
+	}
+}
+
+// The headline case: a name matching nothing must not report success.
+func TestTargetDeleteReportsAnUnknownName(t *testing.T) {
+	isolateHome(t)
+	twoNamedTargets(t)
+	c := newTestCLI(t)
+
+	err := c.cmdTargetDelete("target delete", "typo")
+	if err == nil {
+		t.Fatal("deleting an unknown target should be an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "typo") {
+		t.Errorf("error %q should name the target it could not find", err)
+	}
+
+	cfg := readConfig(t)
+	if len(cfg.Vaults) != 2 {
+		t.Errorf("config holds %d targets, want both left in place", len(cfg.Vaults))
+	}
+}
+
+func TestTargetDeleteClearsTheCurrentTargetItRemoved(t *testing.T) {
+	isolateHome(t)
+	twoNamedTargets(t)
+	c := newTestCLI(t)
+
+	if err := c.cmdTargetDelete("target delete", "https://beta.example.com"); err != nil {
+		t.Fatalf("cmdTargetDelete: %v", err)
+	}
+
+	cfg := readConfig(t)
+	if cfg.Current != "" {
+		t.Errorf("current = %q, want it cleared along with the target it named", cfg.Current)
+	}
+}
+
+// Two aliases for one Vault leave a URL ambiguous, and guessing which to
+// delete is worse than saying so.
+func TestTargetDeleteRefusesAnAmbiguousURL(t *testing.T) {
+	isolateHome(t)
+	writeSaferc(t, `version: 1
+current: one
+vaults:
+  one:
+    url: https://shared.example.com
+    token: token-one
+  two:
+    url: https://shared.example.com
+    token: token-two
+`)
+	c := newTestCLI(t)
+
+	err := c.cmdTargetDelete("target delete", "https://shared.example.com")
+	if err == nil {
+		t.Fatal("an ambiguous URL should be an error, got nil")
+	}
+	if len(readConfig(t).Vaults) != 2 {
+		t.Error("neither target should have been deleted")
+	}
+}

--- a/internal/cli/target_delete_test.go
+++ b/internal/cli/target_delete_test.go
@@ -7,6 +7,7 @@ package cli
 // opposite of what someone deleting a target is asking for.
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -121,4 +122,62 @@ vaults:
 	if len(readConfig(t).Vaults) != 2 {
 		t.Error("neither target should have been deleted")
 	}
+}
+
+// The JSON listing is the machine-readable half of `safe targets`, which sorts.
+// Ranging over the config map ordered it differently on every run.
+func TestTargetsJSONListsInASortedOrder(t *testing.T) {
+	isolateHome(t)
+	writeSaferc(t, `version: 1
+current: delta
+vaults:
+  zeta:
+    url: https://zeta.example.com
+  alpha:
+    url: https://alpha.example.com
+  delta:
+    url: https://delta.example.com
+  beta:
+    url: https://beta.example.com
+`)
+	c := newTestCLI(t)
+	c.opt.Targets.JSON = true
+
+	want := []string{"alpha", "beta", "delta", "zeta"}
+	//Repeated because map iteration order is random per run: one pass could
+	// come out sorted by luck.
+	for i := 0; i < 8; i++ {
+		out := captureStdout(t, func() {
+			if err := c.cmdTargets("targets"); err != nil {
+				t.Fatalf("cmdTargets: %v", err)
+			}
+		})
+
+		var listed []struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal([]byte(out), &listed); err != nil {
+			t.Fatalf("targets --json is not JSON: %v\n%s", err, out)
+		}
+
+		got := make([]string, 0, len(listed))
+		for _, v := range listed {
+			got = append(got, v.Name)
+		}
+		if !sameNames(got, want) {
+			t.Fatalf("run %d listed %v, want %v", i+1, got, want)
+		}
+	}
+}
+
+func sameNames(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/rc/config.go
+++ b/pkg/rc/config.go
@@ -335,29 +335,41 @@ func (c *Config) Namespace() string {
 	return ""
 }
 
-func (c *Config) Find(alias string) (*Vault, bool, error) {
-	if v, ok := c.Vaults[alias]; ok {
-		return v, true, nil
+// Alias resolves a name -- either an alias or the URL of a target -- to the
+// alias that target is stored under. Callers that change the config need the
+// key rather than the target it points at, and a name reaches the same target
+// here as it does everywhere else.
+func (c *Config) Alias(name string) (string, bool, error) {
+	if _, ok := c.Vaults[name]; ok {
+		return name, true, nil
 	}
 
-	var v *Vault
+	var alias string
 	n := 0
-	want := strings.TrimSuffix(alias, "/")
+	want := strings.TrimSuffix(name, "/")
 
-	for _, maybe := range c.Vaults {
+	for maybeAlias, maybe := range c.Vaults {
 		if strings.TrimSuffix(maybe.URL, "/") == want {
 			n++
-			v = maybe
+			alias = maybeAlias
 		}
 	}
 	if n == 1 {
-		return v, true, nil
+		return alias, true, nil
 	}
 	if n > 1 {
-		return nil, true, fmt.Errorf("More than one target for Vault at '%s' (maybe try an alias?)", alias)
+		return "", true, fmt.Errorf("More than one target for Vault at '%s' (maybe try an alias?)", name)
 	}
 
-	return nil, false, nil
+	return "", false, nil
+}
+
+func (c *Config) Find(alias string) (*Vault, bool, error) {
+	name, ok, err := c.Alias(alias)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	return c.Vaults[name], true, nil
 }
 
 func (c *Config) Vault(which string) (*Vault, error) {

--- a/pkg/rc/config_test.go
+++ b/pkg/rc/config_test.go
@@ -494,6 +494,46 @@ func TestConfigAccessors(t *testing.T) {
 		}
 	})
 
+	t.Run("Alias resolves a name to the key it is stored under", func(t *testing.T) {
+		c := Config{
+			Vaults: map[string]*Vault{
+				"prod":  {URL: "https://prod:8200"},
+				"stage": {URL: "https://stage:8200/"},
+			},
+		}
+
+		for _, tc := range []struct{ name, want string }{
+			{"prod", "prod"},
+			{"https://prod:8200", "prod"},
+			{"https://prod:8200/", "prod"},
+			{"https://stage:8200", "stage"},
+		} {
+			got, ok, err := c.Alias(tc.name)
+			if err != nil || !ok {
+				t.Fatalf("Alias(%q) = %q, %v, %v", tc.name, got, ok, err)
+			}
+			if got != tc.want {
+				t.Errorf("Alias(%q) = %q, want %q", tc.name, got, tc.want)
+			}
+		}
+
+		if _, ok, err := c.Alias("ghost"); ok || err != nil {
+			t.Errorf("Alias(ghost) = %v, %v; want not found and no error", ok, err)
+		}
+
+		//An alias always wins over a URL, so a target named after another
+		//target's URL still resolves to itself.
+		shared := Config{
+			Vaults: map[string]*Vault{
+				"one": {URL: "https://shared:8200"},
+				"two": {URL: "https://shared:8200"},
+			},
+		}
+		if _, _, err := shared.Alias("https://shared:8200"); err == nil {
+			t.Error("expected an error for a URL naming two targets")
+		}
+	})
+
 	t.Run("SetCurrent validates the alias and can reskip", func(t *testing.T) {
 		c := Config{Vaults: map[string]*Vault{"prod": {URL: "u"}}}
 		if err := c.SetCurrent("ghost", false); err == nil {


### PR DESCRIPTION
Two defects in the target commands, found by reading the zero-coverage
handlers in `internal/cli/target.go`.

## `safe target delete` reported success without deleting anything

It removed a key from the config map with no check that the name matched a
target:

```go
delete(cfg.Vaults, args[0])
```

A URL matched nothing, though `safe target <url>` selects a target by URL and
`rc.Find` has always resolved either name. A typo matched nothing either. Both
exited 0 with no output, leaving the target — and the token stored beside it —
in `~/.saferc`. Someone deleting a target to get rid of its credentials was
told it had worked.

Before, against a config holding `alpha` and `beta`:

```
$ safe target delete https://alpha.example.com ; echo "exit=$?"
exit=0
$ safe target delete typo ; echo "exit=$?"
exit=0
$ grep -c 'example.com' ~/.saferc
2                                   # both targets still there, tokens and all
```

After:

```
$ safe target delete https://alpha.example.com ; echo "exit=$?"
exit=0                              # and alpha is gone
$ safe target delete typo ; echo "exit=$?"
!! Unknown target 'typo'
exit=1
```

An unknown name is now an error where it was a silent success. That is the
point of the change, and it is the one behaviour here a script could notice.

`rc` grows `Alias(name)`, which resolves an alias or a URL to the key the
target is stored under — `Find` already did that resolution but handed back
the target rather than the key a delete needs, so `Find` is now a thin wrapper
over `Alias` and the two cannot drift. Two aliases sharing one URL make the
URL ambiguous, and `Alias` says so rather than picking one, matching `Find`.

## `safe targets --json` ordered its output at random

The text listing sorts. The JSON listing ranged over the config map, so the
array came out in a different order on nearly every run:

```
$ for i in 1 2 3; do safe targets --json | jq -r '[.[].name]|join(",")'; done
beta,delta,epsilon,gamma,zeta,alpha
alpha,beta,delta,epsilon,gamma,zeta
delta,epsilon,gamma,zeta,alpha,beta
```

Anything diffing or reviewing that output saw changes that were not there.

## Tests

Six CLI tests — delete by alias, delete by URL, unknown name errors and
changes nothing, deleting the current target clears `current`, an ambiguous
URL is refused, and the JSON listing sorted across eight runs (one pass could
come out ordered by luck). Plus an `rc` unit test for `Alias` covering alias,
URL, trailing-slash URL, unknown, and ambiguous.

Mutation-tested: restoring the raw map delete fails 4, removing the sort fails
1, and making `Alias` ignore URLs fails 3.

`make check` and `go test -race ./...` green.
