### PR TITLE
Check listing liveness without reading secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,9 +304,11 @@ instead.  `-1` prints one entry per line.
 A secret is listed only if its newest version can still be read, so
 one whose newest version has been deleted or destroyed is left out —
 even when an older version of it is still live.  Finding that out
-costs a read per secret, and `-q` skips the check and lists those
-secrets too.  Only a version 2 mount keeps versions, so neither the
-check nor `-q` does anything on a version 1 mount.
+costs a version lookup per secret, and `-q` skips the check and lists
+those secrets too.  The lookup reads version metadata rather than the
+secret, so listing a folder needs no access to the values in it.  Only
+a version 2 mount keeps versions, so neither the check nor `-q` does
+anything on a version 1 mount.
 
 ```
 safe ls secret/dc1
@@ -326,7 +328,8 @@ Vault.
 `-d` draws only the folders, which is a quicker way to get your
 bearings in an unfamiliar Vault.  `--keys` names the keys inside each
 secret beside it.  `-q` skips the liveness check, exactly as it does
-for `ls` above.
+for `ls` above; with `--keys` the lookup is made anyway, since that is
+how the keys are reached.
 
 ```
 safe tree secret/dc1
@@ -349,7 +352,8 @@ Provide a flat listing of all reachable keys in the Vault.
 
 `--keys` prints a line per key, as `path:key`, rather than a line per
 secret.  `-q` skips the liveness check, exactly as it does for `ls`
-above.
+above; with `--keys` the lookup is made anyway, since that is how the
+keys are reached.
 
 ```
 safe paths secret/dc1

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -739,7 +739,14 @@ paths/keys.
 		Type:    NonDestructiveCommand,
 		Description: `
 	Specifying the -1 flag will print one result per line.
-	Specifying the -q flag will show secrets which have been marked as deleted.
+
+	A secret is listed only if its newest version can still be read, which
+	costs one version lookup per secret. The lookup reads version metadata
+	and not the secret, so listing a folder needs no access to the values
+	in it. Specifying the -q flag skips the lookup, which is quicker on a
+	large folder and lists the secrets that have been marked as deleted
+	along with the rest. Only a kv v2 mount keeps versions, so neither the
+	check nor -q does anything on a kv v1 mount.
 `,
 	}, c.cmdLs)
 
@@ -752,11 +759,14 @@ Walks the hierarchy of secrets stored underneath a given path, listing all
 reachable name/value pairs and displaying them in a tree format.  If '-d' is
 given, only the containing folders will be printed; this more concise output
 can be useful when you're trying to get your bearings. If '-q' is given, safe
-will not inspect each key in a v1 v2 mount backend to see if it has been marked
-as deleted. This may cause keys which would 404 in an attempt to read them to
-appear in the tree, but is often considerably quicker for larger vaults. This
-flag does nothing for kv v1 mounts. If '--keys' is given, the keys within each
-secret will be displayed inline with the secret name in the format:
+will not look up the versions of each secret on a kv v2 mount to see whether
+the newest one has been marked as deleted. This may cause secrets which would
+404 in an attempt to read them to appear in the tree, but is often considerably
+quicker for larger vaults. This flag does nothing for kv v1 mounts. With
+'--keys' the lookup is made anyway, since the keys are reached through it, so
+'-q' then changes which secrets are listed without saving any work. If '--keys'
+is given, the keys within each secret will be displayed inline with the secret
+name in the format:
 <secret-name>: key1, key2, key3
 `,
 	}, c.cmdTree)
@@ -768,10 +778,13 @@ secret will be displayed inline with the secret name in the format:
 		Description: `
 Walks the hierarchy of secrets stored underneath a given path, listing all
 reachable name/value pairs and displaying them in a list. If '-q' is given,
-safe will not inspect each key in a v1 v2 mount backend to see if it has been
-marked as deleted. This may cause keys which would 404 in an attempt to read
-them to appear in the tree, but is often considerably quicker for larger
-vaults. This flag does nothing for kv v1 mounts.
+safe will not look up the versions of each secret on a kv v2 mount to see
+whether the newest one has been marked as deleted. This may cause secrets which
+would 404 in an attempt to read them to appear in the listing, but is often
+considerably quicker for larger vaults. This flag does nothing for kv v1
+mounts. With '--keys' the lookup is made anyway, since the keys are reached
+through it, so '-q' then changes which secrets are listed without saving any
+work.
 `}, c.cmdPaths)
 
 	r.Dispatch("values", &Help{

--- a/internal/cli/ls_liveness_test.go
+++ b/internal/cli/ls_liveness_test.go
@@ -1,0 +1,167 @@
+package cli
+
+// ls decides whether to print a name by finding out whether the secret behind
+// it can still be read. It found that out by reading the secret: a GET of
+// /secret/data/<path> for every entry in the folder, whose response body is
+// the secret itself. ls prints none of that. The value crossed the wire, sat
+// in memory, and left a read of every secret in the folder in the audit log,
+// to answer a question the version metadata already answers.
+//
+// The metadata lookup is the same request the tree walk makes for the same
+// decision, so this also settles ls and tree on one notion of liveness.
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// dataReads counts the secret reads served so far.
+func dataReads(fv *cliFakeVault) int {
+	n := 0
+	for _, entry := range fv.requests() {
+		if strings.Contains(entry, "GET /v1/secret/data/") {
+			n++
+		}
+	}
+	return n
+}
+
+// lsOut lists one folder.
+func lsOut(t *testing.T, c *CLI, path string) []string {
+	t.Helper()
+	var err error
+	out := captureStdout(t, func() { err = c.cmdLs("ls", path) })
+	if err != nil {
+		t.Fatalf("cmdLs(%q): %v", path, err)
+	}
+	return entriesOf(out)
+}
+
+// The headline: listing a folder reads none of the secrets in it.
+func TestListChecksLivenessWithoutReadingTheSecrets(t *testing.T) {
+	isolateHome(t)
+	fv := walkFixture(t)
+	c := newTestCLI(t)
+
+	fv.forgetRequests()
+	got := lsOut(t, c, "secret/app")
+
+	if reads := dataReads(fv); reads != 0 {
+		t.Errorf("ls read %d secrets to list their names:\n%s",
+			reads, strings.Join(fv.requests(), "\n"))
+	}
+	want := []string{"api", "db"}
+	if !sameEntries(got, want) {
+		t.Errorf("ls secret/app = %v, want %v", got, want)
+	}
+}
+
+// The check still drops a secret whose newest version is deleted, which is the
+// whole reason it is made.
+func TestListStillOmitsADeletedLatestSecret(t *testing.T) {
+	isolateHome(t)
+	fv := walkFixture(t)
+	fv.deleteV2("secret/app/db", 2)
+	c := newTestCLI(t)
+
+	fv.forgetRequests()
+	got := lsOut(t, c, "secret/app")
+
+	if reads := dataReads(fv); reads != 0 {
+		t.Errorf("ls read %d secrets:\n%s", reads, strings.Join(fv.requests(), "\n"))
+	}
+	if !sameEntries(got, []string{"api"}) {
+		t.Errorf("ls secret/app = %v, want [api] with the deleted db left out", got)
+	}
+}
+
+// A destroyed newest version is no more readable than a deleted one.
+func TestListStillOmitsADestroyedLatestSecret(t *testing.T) {
+	isolateHome(t)
+	fv := walkFixture(t)
+	fv.destroyV2("secret/app/db", 2)
+	c := newTestCLI(t)
+
+	if got := lsOut(t, c, "secret/app"); !sameEntries(got, []string{"api"}) {
+		t.Errorf("ls secret/app = %v, want [api] with the destroyed db left out", got)
+	}
+}
+
+// A live older version does not rescue a secret whose newest version is gone.
+// safe delete leaves exactly this state behind on a version 2 mount, so a
+// listing that kept these would show every deleted secret forever.
+func TestListStillOmitsADeletedLatestWithALiveOlderVersion(t *testing.T) {
+	isolateHome(t)
+	fv := walkFixture(t)
+	fv.deleteV2("secret/app/db", 2)
+	c := newTestCLI(t)
+
+	//The fixture wrote two versions of db, and only the newest is deleted.
+	if states := fv.versionStates("secret/app/db"); len(states) != 2 || states[0] != "alive" {
+		t.Fatalf("secret/app/db states = %v, want an alive version 1", states)
+	}
+	if got := lsOut(t, c, "secret/app"); !sameEntries(got, []string{"api"}) {
+		t.Errorf("ls secret/app = %v, want [api]", got)
+	}
+}
+
+// -q keeps skipping the lookup altogether, so it asks the Vault for neither
+// the metadata nor the data of any secret.
+func TestQuickListAsksForNeitherMetadataNorData(t *testing.T) {
+	isolateHome(t)
+	fv := walkFixture(t)
+	fv.deleteV2("secret/app/db", 2)
+	c := newTestCLI(t)
+	c.opt.List.Quick = true
+
+	fv.forgetRequests()
+	got := lsOut(t, c, "secret/app")
+
+	if reads := dataReads(fv); reads != 0 {
+		t.Errorf("ls -q read %d secrets:\n%s", reads, strings.Join(fv.requests(), "\n"))
+	}
+	if lookups := versionLookups(fv); lookups != 0 {
+		t.Errorf("ls -q looked up %d version histories:\n%s",
+			lookups, strings.Join(fv.requests(), "\n"))
+	}
+	if !sameEntries(got, []string{"api", "db"}) {
+		t.Errorf("ls -q secret/app = %v, want both entries", got)
+	}
+}
+
+// Folders are named by the listing itself and are not secrets, so they are
+// never looked up.
+func TestListDoesNotLookUpFolders(t *testing.T) {
+	isolateHome(t)
+	fv := walkFixture(t)
+	c := newTestCLI(t)
+
+	fv.forgetRequests()
+	got := lsOut(t, c, "secret")
+
+	if lookups := versionLookups(fv); lookups != 1 {
+		t.Errorf("ls looked up %d version histories, want one for the single "+
+			"secret at this level:\n%s", lookups, strings.Join(fv.requests(), "\n"))
+	}
+	if !sameEntries(got, []string{"app/", "top"}) {
+		t.Errorf("ls secret = %v, want [app/ top]", got)
+	}
+}
+
+// sameEntries compares two listings without caring about order.
+func sameEntries(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	left := append([]string(nil), got...)
+	right := append([]string(nil), want...)
+	sort.Strings(left)
+	sort.Strings(right)
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -449,7 +449,12 @@ func (c *CLI) cmdTree(command string, args ...string) error {
 			return err
 		}
 		secrets, err := v.ConstructSecrets(root, vault.TreeOpts{
-			FetchKeys:           opt.Tree.ShowKeys,
+			FetchKeys: opt.Tree.ShowKeys,
+			//Version metadata is what the liveness check reads, and the tree
+			// renders none of it, so a quick walk has no reason to fetch it.
+			// ConstructSecrets turns this back on whenever it still has to
+			// decide what to drop, which is every walk without -q.
+			SkipVersionInfo:     !opt.Tree.ShowKeys,
 			AllowDeletedSecrets: opt.Tree.Quick,
 		})
 

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -396,16 +396,26 @@ func (c *CLI) cmdLs(command string, args ...string) error {
 					}
 
 					if mountVersion == 2 {
-						//Read parses the mini-language, so it takes the
-						// escaped form: a colon anywhere in the path would
-						// otherwise be read as a key separator.
-						_, err := v.Read(vault.EncodePath(child, "", 0))
+						//Version metadata answers whether the newest version
+						// can be read, which is all the listing needs to
+						// decide. Reading the secret answered the same
+						// question by fetching the value itself, so listing a
+						// folder pulled back every secret in it and logged a
+						// read of each one, for output that is names only.
+						//
+						//Versions takes a literal path rather than safe's own
+						// syntax, so a colon in a name needs no escaping round
+						// trip to survive the lookup.
+						versions, err := v.Versions(child)
 						if err != nil {
 							if vault.IsNotFound(err) {
 								continue
 							}
 
 							return err
+						}
+						if len(versions) == 0 || !versions[len(versions)-1].Alive() {
+							continue
 						}
 					}
 				}

--- a/internal/cli/tree_quick_test.go
+++ b/internal/cli/tree_quick_test.go
@@ -1,0 +1,129 @@
+package cli
+
+// -q on tree is documented as the flag that trades accuracy for speed: it
+// skips the per-secret version lookup, so secrets whose newest version is
+// deleted stay in the listing and a large Vault comes back sooner. It bought
+// the first half and none of the second. tree left TreeOpts.SkipVersionInfo
+// at its zero value, so the walk fetched the version metadata of every secret
+// and then threw the answer away, doing all of the work of the check with
+// none of the filtering. paths, which sets the field, was genuinely quicker.
+//
+// Request counts are the only place this shows up: the output of a quick walk
+// was already correct.
+
+import (
+	"strings"
+	"testing"
+)
+
+// versionLookups counts the per-secret version metadata reads served so far.
+// A listing of a folder is a metadata request too, hence the list=true
+// exclusion, and the walk probes its own root before it knows whether the
+// root is a secret, which lands on /v1/secret/metadata with nothing after it.
+func versionLookups(fv *cliFakeVault) int {
+	n := 0
+	for _, entry := range fv.requests() {
+		if strings.Contains(entry, "list=true") {
+			continue
+		}
+		if _, ok := strings.CutPrefix(entry, "GET /v1/secret/metadata/"); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// treeOut renders a tree of the whole mount.
+func treeOut(t *testing.T, c *CLI) string {
+	t.Helper()
+	return captureStdout(t, func() {
+		if err := c.cmdTree("tree", "secret"); err != nil {
+			t.Fatalf("cmdTree: %v", err)
+		}
+	})
+}
+
+// The fixture holds three secrets, so a walk that checks liveness looks up
+// three version histories and a quick one looks up none.
+func TestQuickTreeSkipsThePerSecretVersionLookups(t *testing.T) {
+	isolateHome(t)
+	fv := walkFixture(t)
+	c := newTestCLI(t)
+	c.opt.Tree.Quick = true
+
+	fv.forgetRequests()
+	treeOut(t, c)
+
+	if got := versionLookups(fv); got != 0 {
+		t.Errorf("tree -q looked up %d version histories, want 0:\n%s",
+			got, strings.Join(fv.requests(), "\n"))
+	}
+}
+
+// The control: without -q the lookups are what the check is made of.
+func TestTreeLooksUpEveryVersionHistoryWithoutQuick(t *testing.T) {
+	isolateHome(t)
+	fv := walkFixture(t)
+	c := newTestCLI(t)
+
+	fv.forgetRequests()
+	treeOut(t, c)
+
+	if got := versionLookups(fv); got != 3 {
+		t.Errorf("tree looked up %d version histories, want one per secret (3):\n%s",
+			got, strings.Join(fv.requests(), "\n"))
+	}
+}
+
+// --keys needs the version history to reach the keys, so -q cannot skip the
+// lookup there. Skipping it would have printed a tree with no keys in it.
+func TestQuickTreeWithKeysStillLooksUpVersions(t *testing.T) {
+	isolateHome(t)
+	fv := walkFixture(t)
+	c := newTestCLI(t)
+	c.opt.Tree.Quick = true
+	c.opt.Tree.ShowKeys = true
+
+	fv.forgetRequests()
+	out := treeOut(t, c)
+
+	if got := versionLookups(fv); got != 3 {
+		t.Errorf("tree -q --keys looked up %d version histories, want 3:\n%s",
+			got, strings.Join(fv.requests(), "\n"))
+	}
+	for _, want := range []string{"pw", "tok"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("tree -q --keys is missing key %q:\n%s", want, out)
+		}
+	}
+}
+
+// What -q does buy is unchanged: the secret whose newest version is deleted
+// stays in the listing, because nothing looked.
+func TestQuickTreeStillKeepsADeletedLatestSecret(t *testing.T) {
+	isolateHome(t)
+	fv := walkFixture(t)
+	fv.deleteV2("secret/app/db", 2)
+	c := newTestCLI(t)
+	c.opt.Tree.Quick = true
+
+	if out := treeOut(t, c); !strings.Contains(out, "db") {
+		t.Errorf("tree -q should list db regardless of version state:\n%s", out)
+	}
+}
+
+// And a walk that does look still drops it.
+func TestTreeStillOmitsADeletedLatestSecret(t *testing.T) {
+	isolateHome(t)
+	fv := walkFixture(t)
+	fv.deleteV2("secret/app/db", 2)
+	c := newTestCLI(t)
+
+	out := treeOut(t, c)
+	if strings.Contains(out, "db") {
+		t.Errorf("tree lists db, whose newest version is deleted:\n%s", out)
+	}
+	if !strings.Contains(out, "api") {
+		t.Errorf("tree is missing api:\n%s", out)
+	}
+}

--- a/internal/cli/vault_fake_test.go
+++ b/internal/cli/vault_fake_test.go
@@ -36,6 +36,12 @@ type cliFakeVault struct {
 	// destroyed version still occupies its number.
 	versions map[string][]*fakeVersion
 	v2       bool
+	//log holds every request served, as "METHOD /path?query", oldest first.
+	// What a command asks the Vault for is part of its behaviour: a listing
+	// that reads each secret to find out whether it is there hands back
+	// plaintext it never prints, and a flag that promises to skip a lookup
+	// has to actually skip it. Neither shows up in the output.
+	log []string
 }
 
 // fakeVersion is one version of a version 2 secret. A version is alive until
@@ -56,7 +62,30 @@ func (f *cliFakeVault) kvVersion() int {
 	return 1
 }
 
+// record notes one served request. It takes the lock and releases it before
+// the handlers take it themselves.
+func (f *cliFakeVault) record(r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.log = append(f.log, r.Method+" "+r.URL.RequestURI())
+}
+
+// requests returns a copy of the log.
+func (f *cliFakeVault) requests() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.log...)
+}
+
+// forgetRequests empties the log, so one test can measure two commands.
+func (f *cliFakeVault) forgetRequests() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.log = nil
+}
+
 func (f *cliFakeVault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.record(r)
 	w.Header().Set("Content-Type", "application/json")
 	if strings.HasPrefix(r.URL.Path, "/v1/sys/internal/ui/mounts") {
 		//The client looks for the mount under data.secret; anything else


### PR DESCRIPTION
Two fixes to how the listing commands decide whether a secret is still
readable, both invisible in the output and both visible in what safe asks
the Vault for.

## `safe ls` read every secret to list its name

`ls` prints names. To decide which names to print it checked whether each
secret's newest version could still be read — by reading it. Listing a
folder issued a `GET secret/data/<path>` per entry, whose response body is
the secret itself. The values crossed the wire, sat in memory, and left a
read of every secret in the folder in the audit log, to answer a question
the version metadata answers on its own. The tree walk already asks the
metadata for the same decision.

Against a dev Vault with an audit device, listing a two-secret folder:

| | data reads | metadata lookups |
|---|---|---|
| before | 2 | 1 |
| after | 0 | 2 |

The lookup replaces the read rather than joining it, and the deleted-latest
secret needed a metadata request anyway to build its error, so the request
count does not grow.

The permission consequence is the practical one. A token holding `list` and
`read` on `secret/metadata/*` and nothing on `secret/data/*`:

```
before:  !! 403 Forbidden: 1 error occurred:
             * permission denied
         (exit 1)
after:   api
         (exit 0)
```

Listing a folder no longer requires access to the values in it.

## `safe tree -q` did the work it promised to skip

`-q` is documented as trading accuracy for speed: skip the per-secret
version lookup, keep the secrets whose newest version is deleted, come back
sooner on a large Vault. `tree` left `TreeOpts.SkipVersionInfo` at its zero
value, so the walk fetched every secret's version metadata and then discarded
the answer without filtering on it. It bought the accuracy half and none of
the speed. `paths` sets the field and was genuinely quicker.

Metadata lookups for a three-secret mount, from the same audit log:

| | `tree -q` | `tree` |
|---|---|---|
| before | 4 | 4 |
| after | 1 | 4 |

The one that remains is the walk probing its own root. With `--keys` the
lookup is made either way, since that is how the keys are reached.

## Behaviour

Unchanged. Every listing form was run against a dev Vault holding a
deleted-latest secret, a destroyed secret, a colon-bearing folder, and a
nested tree, before and after:

```
ls secret, ls secret/app, ls -q secret/app, tree secret, tree -q secret,
tree --keys secret, tree -q --keys secret, paths secret
```

Output is byte-identical across all eight.

A secret whose newest version is deleted stays out of a default listing.
That is deliberate and unchanged: `safe delete` on a kv v2 mount deletes
only the current version, so every secret anyone has ever deleted has a live
older version behind it, and listing those would show deleted secrets
forever. `TestListStillOmitsADeletedLatestWithALiveOlderVersion` pins it.

## Tests

The fake Vault now logs the requests it serves, which is the only place
either fix shows up. Mutations, each reverted after:

| mutation | tests failing |
|---|---|
| drop `SkipVersionInfo` from tree | 1 |
| set `SkipVersionInfo` unconditionally | 1 (`--keys` loses its keys) |
| read the secret again in `ls` | 3 |
| drop the alive check in `ls` | 3 |
| check the oldest version rather than the newest | 3 |

`make check` and `go test -race ./...` pass.

## Docs

The `ls` help said only that `-q` shows deleted secrets. The `tree` and
`paths` help described the lookup as inspecting each key in "a v1 v2 mount
backend" and claimed a speed gain that `--keys` cancels. All three now say
what the check reads, what it costs, and when `-q` saves nothing. The README
note that the check costs a read per secret is no longer true and now says a
lookup.
