### PR TITLE
Fix x509 signing defects that destroy or corrupt certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,35 @@ Issues a new X.509 TLS/SSL certificate, and stores the new RSA
 private key and the certificate in the Vault at _path_, in PEM
 format.
 
+`--signed-by` has to name a certificate authority, and cannot name
+_path_ itself.  Issuing writes the signing CA back, to record the
+serial number it handed out, and then writes the new certificate
+over whatever _path_ held.
+
+Where `path:certificate` holds the issuers above the certificate as
+well as the certificate itself, they stay with it: every command
+that writes a certificate back keeps the whole chain.
+
+### x509 reissue \[OPTIONS\] path
+
+Reissues the certificate at _path_ with a freshly generated key,
+keeping its subject, its names, and the rest of its details unless
+options ask for something else.
+
+The signing authority comes from `--signed-by`, which has to name a
+certificate authority.  Naming one moves the certificate to it, so
+it does not have to be the authority that signed the certificate
+originally.  Without the option, `safe` looks for a sibling secret
+named `ca` and uses it only if it is the authority that signed the
+certificate, since it is a guess rather than an instruction.  A
+certificate that signed itself signs itself again, with the new key.
+
+### x509 renew \[OPTIONS\] path
+
+Renews the certificate at _path_, keeping its existing key, and
+resets its validity period.  The signing authority is found the same
+way as for `x509 reissue`.
+
 ### x509 revoke \[OPTIONS\] --signed-by path/to/ca path/to/cert
 
 Revoke a certificate that was signed by a Certificate Authority.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1206,6 +1206,11 @@ The following options are recognized:
                       (and signing key) can be found.
                       Without this option, 'x509 issue' creates
                       self-signed certificates.
+                      The path must hold a certificate authority,
+                      and cannot be the path the new certificate
+                      is written to: issuing writes the signing CA
+                      back, then writes the new certificate over
+                      whatever was there.
 
   -n, --name          Subject Alternate Name(s) for this
                       certificate.  These can be domain names,
@@ -1294,11 +1299,16 @@ The following options are recognized:
                       existing certificate's curve.
 
   -i, --signed-by     Path in the Vault where the CA certificate
-                      (and signing key) can be found.  If this is not
-                      provided, a sibling secret named 'ca' will used
-                      if it exists. This should be the same CA that
-                      originally signed the certificate, but does not
-                      have to be.
+                      (and signing key) can be found.  The path must
+                      hold a certificate authority.  Naming one here
+                      moves the certificate to it, so it does not
+                      have to be the CA that signed it originally.
+                      If this is not provided, a sibling secret named
+                      'ca' is used, and that one does have to be the
+                      CA that signed the certificate, since it is a
+                      guess rather than an instruction.  A certificate
+                      that signed itself signs itself again, and no
+                      sibling is looked for.
 
   -t, --ttl           How long the new certificate will be valid
                       for.  Specified in units h (hours), m (months)
@@ -1355,11 +1365,16 @@ The following options are recognized:
                       it would for a new issue command.
 
   -i, --signed-by   	Path in the Vault where the CA certificate
-                      (and signing key) can be found.  If this is not
-                      provided, a sibling secret named 'ca' will used
-                      if it exists.  This should be the same CA that
-                      originally signed the certificate, but does not
-                      have to be.
+                      (and signing key) can be found.  The path must
+                      hold a certificate authority.  Naming one here
+                      moves the certificate to it, so it does not
+                      have to be the CA that signed it originally.
+                      If this is not provided, a sibling secret named
+                      'ca' is used, and that one does have to be the
+                      CA that signed the certificate, since it is a
+                      guess rather than an instruction.  A certificate
+                      that signed itself signs itself again, and no
+                      sibling is looked for.
 
   -t, --ttl           How long the new certificate will be valid
                       for.  Specified in units h (hours), m (months)

--- a/internal/cli/x509.go
+++ b/internal/cli/x509.go
@@ -151,6 +151,15 @@ func (c *CLI) cmdX509Issue(command string, args ...string) error {
 		return err
 	}
 
+	//Issuing writes the new certificate over whatever the path held. Naming
+	// the signing authority as the destination — a slip of one word on the
+	// command line — replaces the authority with the certificate it just
+	// signed, taking its private key, its serial number, and its revocation
+	// list with it, and everything it ever issued becomes unverifiable.
+	if args[0] == opt.X509.Issue.SignedBy {
+		return fmt.Errorf("refusing to overwrite the signing authority %s with the certificate it signs", args[0])
+	}
+
 	if opt.X509.Issue.Subject == "" {
 		opt.X509.Issue.Subject = fmt.Sprintf("CN=%s", opt.X509.Issue.Name[0])
 	}

--- a/internal/cli/x509.go
+++ b/internal/cli/x509.go
@@ -177,6 +177,13 @@ func (c *CLI) cmdX509Issue(command string, args ...string) error {
 		if err != nil {
 			return err
 		}
+
+		//Signing with a certificate that is not an authority produces one no
+		// relying party will accept, and nothing further along says so: the
+		// certificate is written, looks ordinary, and fails at the far end.
+		if !ca.IsCA() {
+			return fmt.Errorf("%s is not a certificate authority", opt.X509.Issue.SignedBy)
+		}
 	}
 
 	if len(opt.X509.Issue.KeyUsage) == 0 {

--- a/internal/cli/x509.go
+++ b/internal/cli/x509.go
@@ -283,6 +283,15 @@ func (c *CLI) cmdX509Reissue(command string, args ...string) error {
 		return err
 	}
 
+	//Which authority signed this is a fact about the certificate as stored,
+	// and answering it reads the signature the certificate arrived with. The
+	// changes below overwrite the algorithm that signature was made with, so
+	// the authority has to be found before they are applied.
+	ca, caPath, err := v.FindSigningCA(cert, args[0], opt.X509.Reissue.SignedBy)
+	if err != nil {
+		return err
+	}
+
 	if len(opt.X509.Reissue.Name) > 0 {
 		ips, dns, email := vault.CategorizeSANs(uniq(opt.X509.Reissue.Name))
 		cert.Certificate.IPAddresses = ips
@@ -324,12 +333,6 @@ func (c *CLI) cmdX509Reissue(command string, args ...string) error {
 		// signing CA at signing time, rather than preserving the previous
 		// certificate's value, which may not match the new key.
 		cert.Certificate.SignatureAlgorithm = x509.UnknownSignatureAlgorithm
-	}
-
-	/* find the CA */
-	ca, caPath, err := v.FindSigningCA(cert, args[0], opt.X509.Reissue.SignedBy)
-	if err != nil {
-		return err
 	}
 
 	// Get new expiry date
@@ -411,6 +414,15 @@ func (c *CLI) cmdX509Renew(command string, args ...string) error {
 		return err
 	}
 
+	//Which authority signed this is a fact about the certificate as stored,
+	// and answering it reads the signature the certificate arrived with.
+	// --sig-algorithm overwrites the algorithm that signature was made with,
+	// so the authority has to be found before the changes below are applied.
+	ca, caPath, err := v.FindSigningCA(cert, args[0], opt.X509.Renew.SignedBy)
+	if err != nil {
+		return err
+	}
+
 	if len(opt.X509.Renew.Name) > 0 {
 		ips, dns, email := vault.CategorizeSANs(uniq(opt.X509.Renew.Name))
 		cert.Certificate.IPAddresses = ips
@@ -447,12 +459,6 @@ func (c *CLI) cmdX509Renew(command string, args ...string) error {
 		}
 
 		cert.Certificate.SignatureAlgorithm = sigAlgo
-	}
-
-	/* find the CA */
-	ca, caPath, err := v.FindSigningCA(cert, args[0], opt.X509.Renew.SignedBy)
-	if err != nil {
-		return err
 	}
 
 	// Get new expiry date

--- a/internal/cli/x509_chain_test.go
+++ b/internal/cli/x509_chain_test.go
@@ -1,0 +1,107 @@
+package cli
+
+// Commands that write a certificate back rewrite the whole secret from the
+// certificate they read. An intermediate CA is commonly stored with the
+// issuers above it in the same attribute, and regenerating its revocation
+// list — or issuing anything under it — used to leave only the intermediate
+// behind.
+
+import (
+	"encoding/pem"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// storeChainedCA writes an intermediate CA to path with the root appended to
+// its certificate attribute, the way a chain is usually kept.
+func storeChainedCA(t *testing.T, fv *cliFakeVault, path string, root *vault.X509) *vault.X509 {
+	t.Helper()
+
+	inter, err := vault.NewCertificate("CN=inter", []string{"inter"},
+		[]string{"key_cert_sign", "crl_sign"}, "",
+		vault.KeySpec{Algorithm: "rsa", Bits: 2048})
+	if err != nil {
+		t.Fatalf("NewCertificate: %v", err)
+	}
+	inter.MakeCA()
+	if err := root.Sign(inter, 24*time.Hour); err != nil {
+		t.Fatalf("sign the intermediate: %v", err)
+	}
+	storeCert(t, fv, path, inter)
+
+	stored := fv.get(path)
+	stored["certificate"] += string(pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: root.Certificate.Raw,
+	}))
+	stored["combined"] = stored["certificate"] + stored["key"]
+	fv.set(path, stored)
+
+	return inter
+}
+
+// certCount reports how many certificates the attribute at path holds.
+func certCount(t *testing.T, fv *cliFakeVault, path, attr string) int {
+	t.Helper()
+	return strings.Count(fv.get(path)[attr], "-----BEGIN CERTIFICATE-----")
+}
+
+// Regenerating a revocation list writes the CA back over itself.
+func TestRegeneratingACRLKeepsTheChain(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeChainedCA(t, fv, "secret/inter", newCA(t, "root"))
+
+	c := newX509CLI(t)
+	c.opt.X509.CRL.Renew = true
+	if err := c.cmdX509Crl("x509 crl", "secret/inter"); err != nil {
+		t.Fatalf("crl --renew: %v", err)
+	}
+
+	if got := certCount(t, fv, "secret/inter", "certificate"); got != 2 {
+		t.Errorf("certificate holds %d certificates, want 2", got)
+	}
+	if got := certCount(t, fv, "secret/inter", "combined"); got != 2 {
+		t.Errorf("combined holds %d certificates, want 2", got)
+	}
+}
+
+// Issuing a certificate saves the signing CA back, to record the serial
+// number it just handed out.
+func TestIssuingUnderAChainedCAKeepsItsChain(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeChainedCA(t, fv, "secret/inter", newCA(t, "root"))
+
+	c := newX509CLI(t)
+	c.opt.X509.Issue.Name = []string{"leaf.example.com"}
+	c.opt.X509.Issue.SignedBy = "secret/inter"
+	if err := c.cmdX509Issue("x509 issue", "secret/leaf"); err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+
+	if got := certCount(t, fv, "secret/inter", "certificate"); got != 2 {
+		t.Errorf("the CA's certificate holds %d certificates, want 2", got)
+	}
+}
+
+// Revoking writes the CA back to record the revoked serial number.
+func TestRevokingAgainstAChainedCAKeepsItsChain(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	inter := storeChainedCA(t, fv, "secret/inter", newCA(t, "root"))
+	storeCert(t, fv, "secret/leaf", newLeaf(t, inter, "leaf"))
+
+	c := newX509CLI(t)
+	c.opt.X509.Revoke.SignedBy = "secret/inter"
+	if err := c.cmdX509Revoke("x509 revoke", "secret/leaf"); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	if got := certCount(t, fv, "secret/inter", "certificate"); got != 2 {
+		t.Errorf("the CA's certificate holds %d certificates, want 2", got)
+	}
+}

--- a/internal/cli/x509_issue_target_test.go
+++ b/internal/cli/x509_issue_target_test.go
@@ -1,0 +1,61 @@
+package cli
+
+// Issuing writes the new certificate over whatever the destination path held,
+// and it writes the signing authority back too, to record the serial number it
+// handed out. Naming the authority as the destination did both, in that order:
+// the authority was saved and then replaced by the certificate it had just
+// signed.
+
+import (
+	"strings"
+	"testing"
+)
+
+// The authority's key, serial number, and revocation list all go with it.
+func TestIssueRefusesToOverwriteItsOwnSigningCA(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeCert(t, fv, "secret/ca", newCA(t, "root"))
+	before := fv.get("secret/ca")
+
+	c := newX509CLI(t)
+	c.opt.X509.Issue.Name = []string{"leaf.example.com"}
+	c.opt.X509.Issue.SignedBy = "secret/ca"
+
+	err := c.cmdX509Issue("x509 issue", "secret/ca")
+	if err == nil {
+		t.Fatal("issue onto its own CA = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "secret/ca") {
+		t.Errorf("error = %q, want it to name secret/ca", err)
+	}
+
+	after := fv.get("secret/ca")
+	for _, attr := range []string{"certificate", "key", "serial", "crl"} {
+		if after[attr] != before[attr] {
+			t.Errorf("the CA's %s attribute changed", attr)
+		}
+	}
+}
+
+// Issuing somewhere else under the same authority is untouched.
+func TestIssueUnderACAWritesBothPaths(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeCert(t, fv, "secret/ca", newCA(t, "root"))
+	before := fv.get("secret/ca")["serial"]
+
+	c := newX509CLI(t)
+	c.opt.X509.Issue.Name = []string{"leaf.example.com"}
+	c.opt.X509.Issue.SignedBy = "secret/ca"
+
+	if err := c.cmdX509Issue("x509 issue", "secret/leaf"); err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	if len(fv.get("secret/leaf")) == 0 {
+		t.Error("the certificate was not written")
+	}
+	if fv.get("secret/ca")["serial"] == before {
+		t.Errorf("the CA's serial number stayed at %s", before)
+	}
+}

--- a/internal/cli/x509_self_signed_test.go
+++ b/internal/cli/x509_self_signed_test.go
@@ -1,0 +1,130 @@
+package cli
+
+// A certificate that signed itself is renewed and reissued by signing itself
+// again, and the way that is recognised is by checking the certificate's
+// signature against its own key. Both commands rewrite the certificate before
+// looking, including the algorithm that signature was made with, so the check
+// was run against a field the command had already replaced.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// newSelfSigned builds an ordinary certificate that signed itself.
+func newSelfSigned(t *testing.T, cn string) *vault.X509 {
+	t.Helper()
+
+	x, err := vault.NewCertificate("CN="+cn, []string{cn},
+		[]string{"server_auth"}, "",
+		vault.KeySpec{Algorithm: "rsa", Bits: 2048})
+	if err != nil {
+		t.Fatalf("NewCertificate(%s): %v", cn, err)
+	}
+	if err := x.Sign(x, time.Hour); err != nil {
+		t.Fatalf("self-sign %s: %v", cn, err)
+	}
+	return x
+}
+
+// Reissuing clears the signature algorithm so that signing can derive one
+// from the new key, which left nothing to check the old signature with.
+func TestReissueRecognisesASelfSignedCertificate(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	self := newSelfSigned(t, "solo")
+	storeCert(t, fv, "secret/solo/cert", self)
+	beforeKey := fv.get("secret/solo/cert")["key"]
+
+	c := newX509CLI(t)
+	if err := c.cmdX509Reissue("x509 reissue", "secret/solo/cert"); err != nil {
+		t.Fatalf("reissue a self-signed certificate: %v", err)
+	}
+
+	x, err := readStoredX509(t, fv, "secret/solo/cert")
+	if err != nil {
+		t.Fatalf("read the reissued certificate: %v", err)
+	}
+	if x.Certificate.Issuer.CommonName != "solo" {
+		t.Errorf("issuer = %q, want solo", x.Certificate.Issuer.CommonName)
+	}
+	if fv.get("secret/solo/cert")["key"] == beforeKey {
+		t.Error("the key was not regenerated")
+	}
+}
+
+// The same certificate sitting next to an unrelated authority is still
+// recognised as self-signed rather than handed to the sibling.
+func TestReissueDoesNotHandASelfSignedCertToASibling(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeCert(t, fv, "secret/solo/cert", newSelfSigned(t, "solo"))
+	storeCert(t, fv, "secret/solo/ca", newCA(t, "stranger"))
+
+	c := newX509CLI(t)
+	if err := c.cmdX509Reissue("x509 reissue", "secret/solo/cert"); err != nil {
+		t.Fatalf("reissue a self-signed certificate: %v", err)
+	}
+
+	x, err := readStoredX509(t, fv, "secret/solo/cert")
+	if err != nil {
+		t.Fatalf("read the reissued certificate: %v", err)
+	}
+	if got := x.Certificate.Issuer.CommonName; got != "solo" {
+		t.Errorf("issuer = %q, want solo", got)
+	}
+}
+
+// Renewing overwrites the algorithm only when one is asked for, and asking
+// for a different one used to make the certificate look as though something
+// else had signed it.
+func TestRenewRecognisesASelfSignedCertificateUnderANewAlgorithm(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeCert(t, fv, "secret/solo/cert", newSelfSigned(t, "solo"))
+
+	//An RSA key signs with SHA512 unless told otherwise, so asking for
+	// SHA256 is asking for something the stored signature was not made with.
+	c := newX509CLI(t)
+	c.opt.X509.Renew.SigAlgorithm = "sha256-rsa"
+	if err := c.cmdX509Renew("x509 renew", "secret/solo/cert"); err != nil {
+		t.Fatalf("renew a self-signed certificate: %v", err)
+	}
+
+	x, err := readStoredX509(t, fv, "secret/solo/cert")
+	if err != nil {
+		t.Fatalf("read the renewed certificate: %v", err)
+	}
+	if got := x.Certificate.Issuer.CommonName; got != "solo" {
+		t.Errorf("issuer = %q, want solo", got)
+	}
+	if got := x.Certificate.SignatureAlgorithm.String(); !strings.Contains(got, "SHA256") {
+		t.Errorf("signature algorithm = %s, want the requested SHA256", got)
+	}
+}
+
+// A certificate an authority signed still finds that authority when it is
+// named as a sibling.
+func TestReissueUnderTheSiblingThatSignedItWorks(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	signer := newCA(t, "signer")
+	storeCert(t, fv, "secret/x/leaf", newLeaf(t, signer, "leaf"))
+	storeCert(t, fv, "secret/x/ca", signer)
+
+	c := newX509CLI(t)
+	if err := c.cmdX509Reissue("x509 reissue", "secret/x/leaf"); err != nil {
+		t.Fatalf("reissue under the sibling that signed it: %v", err)
+	}
+
+	x, err := readStoredX509(t, fv, "secret/x/leaf")
+	if err != nil {
+		t.Fatalf("read the reissued certificate: %v", err)
+	}
+	if got := x.Certificate.Issuer.CommonName; got != "signer" {
+		t.Errorf("issuer = %q, want signer", got)
+	}
+}

--- a/internal/cli/x509_sibling_ca_test.go
+++ b/internal/cli/x509_sibling_ca_test.go
@@ -1,0 +1,122 @@
+package cli
+
+// Renewing and reissuing take the signing authority from --signed-by, and
+// with no flag they guess the 'ca' sibling of the certificate's own path.
+// The guess was taken on trust: whatever sat at that path signed the
+// certificate again, giving it a new issuer without saying so.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// readStoredX509 parses the certificate stored at path back out of the fake.
+func readStoredX509(t *testing.T, fv *cliFakeVault, path string) (*vault.X509, error) {
+	t.Helper()
+
+	s := vault.NewSecret()
+	for k, v := range fv.get(path) {
+		if err := s.Set(k, v, false); err != nil {
+			t.Fatalf("rebuild the secret at %s: %v", path, err)
+		}
+	}
+	return s.X509(false)
+}
+
+// The sibling holds an authority, but not the one that issued the
+// certificate.
+func TestRenewRefusesASiblingCAThatDidNotSignIt(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	signer := newCA(t, "signer")
+	stranger := newCA(t, "stranger")
+
+	storeCert(t, fv, "secret/x/leaf", newLeaf(t, signer, "leaf"))
+	storeCert(t, fv, "secret/x/ca", stranger)
+	before := fv.get("secret/x/leaf")["certificate"]
+
+	c := newX509CLI(t)
+	err := c.cmdX509Renew("x509 renew", "secret/x/leaf")
+	if err == nil {
+		t.Fatal("renew under an unrelated sibling = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "secret/x/ca did not sign secret/x/leaf") {
+		t.Errorf("error = %q, want it to say the sibling did not sign the certificate", err)
+	}
+	if !strings.Contains(err.Error(), "--signed-by") {
+		t.Errorf("error = %q, want it to point at --signed-by", err)
+	}
+	if fv.get("secret/x/leaf")["certificate"] != before {
+		t.Error("the certificate was reissued anyway")
+	}
+}
+
+// Reissuing guesses the same way and refuses the same way.
+func TestReissueRefusesASiblingCAThatDidNotSignIt(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	signer := newCA(t, "signer")
+
+	storeCert(t, fv, "secret/x/leaf", newLeaf(t, signer, "leaf"))
+	storeCert(t, fv, "secret/x/ca", newCA(t, "stranger"))
+
+	c := newX509CLI(t)
+	err := c.cmdX509Reissue("x509 reissue", "secret/x/leaf")
+	if err == nil {
+		t.Fatal("reissue under an unrelated sibling = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "secret/x/ca did not sign secret/x/leaf") {
+		t.Errorf("error = %q, want it to say the sibling did not sign the certificate", err)
+	}
+}
+
+// Naming the authority is how a certificate moves to a new one, so an
+// explicit --signed-by is still taken at its word.
+func TestRenewUnderANamedAuthorityThatDidNotSignItIsAllowed(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	signer := newCA(t, "signer")
+
+	storeCert(t, fv, "secret/x/leaf", newLeaf(t, signer, "leaf"))
+	storeCert(t, fv, "secret/new/ca", newCA(t, "new-authority"))
+
+	c := newX509CLI(t)
+	c.opt.X509.Renew.SignedBy = "secret/new/ca"
+	if err := c.cmdX509Renew("x509 renew", "secret/x/leaf"); err != nil {
+		t.Fatalf("renew under a named authority: %v", err)
+	}
+
+	x, err := readStoredX509(t, fv, "secret/x/leaf")
+	if err != nil {
+		t.Fatalf("read the renewed certificate: %v", err)
+	}
+	if got := x.Certificate.Issuer.CommonName; got != "new-authority" {
+		t.Errorf("issuer = %q, want new-authority", got)
+	}
+}
+
+// The sibling that did sign it renews it, which is the whole point of the
+// guess.
+func TestRenewUnderTheSiblingThatSignedItWorks(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	signer := newCA(t, "signer")
+
+	storeCert(t, fv, "secret/x/leaf", newLeaf(t, signer, "leaf"))
+	storeCert(t, fv, "secret/x/ca", signer)
+
+	c := newX509CLI(t)
+	if err := c.cmdX509Renew("x509 renew", "secret/x/leaf"); err != nil {
+		t.Fatalf("renew under the sibling that signed it: %v", err)
+	}
+
+	x, err := readStoredX509(t, fv, "secret/x/leaf")
+	if err != nil {
+		t.Fatalf("read the renewed certificate: %v", err)
+	}
+	if got := x.Certificate.Issuer.CommonName; got != "signer" {
+		t.Errorf("issuer = %q, want signer", got)
+	}
+}

--- a/internal/cli/x509_signer_test.go
+++ b/internal/cli/x509_signer_test.go
@@ -1,0 +1,120 @@
+package cli
+
+// Signing needs a certificate authority. Nothing checked that the path named
+// as one held one, so safe would sign with an ordinary certificate and write
+// the result out without complaint. What comes back is a certificate every
+// relying party rejects, and the first sign of trouble is a handshake failing
+// somewhere else.
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Issuing under a path that holds an ordinary certificate.
+func TestIssueSignedByANonCARefuses(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	ca := newCA(t, "real")
+	storeCert(t, fv, "secret/leaf", newLeaf(t, ca, "leaf"))
+
+	c := newX509CLI(t)
+	c.opt.X509.Issue.Name = []string{"new.example.com"}
+	c.opt.X509.Issue.SignedBy = "secret/leaf"
+
+	err := c.cmdX509Issue("x509 issue", "secret/new")
+	if err == nil {
+		t.Fatal("issue signed by a non-CA = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "secret/leaf is not a certificate authority") {
+		t.Errorf("error = %q, want it to name secret/leaf as not a CA", err)
+	}
+	if len(fv.get("secret/new")) != 0 {
+		t.Error("the certificate was written anyway")
+	}
+}
+
+// Renewing and reissuing read the authority through the same helper, whether
+// it was named on the command line or found beside the certificate.
+func TestRenewAndReissueRefuseANonCASigner(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		signedBy string
+		want     string
+	}{
+		{"--signed-by names a plain certificate", "secret/other", "secret/other"},
+		{"the sibling ca is a plain certificate", "", "secret/x/ca"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			fv := newCLIFake(t)
+			ca := newCA(t, "real")
+			storeCert(t, fv, "secret/x/leaf", newLeaf(t, ca, "leaf"))
+			storeCert(t, fv, "secret/x/ca", newLeaf(t, ca, "not-a-ca"))
+			storeCert(t, fv, "secret/other", newLeaf(t, ca, "other"))
+			before := fv.get("secret/x/leaf")["certificate"]
+
+			c := newX509CLI(t)
+			c.opt.X509.Renew.SignedBy = tc.signedBy
+			err := c.cmdX509Renew("x509 renew", "secret/x/leaf")
+			if err == nil {
+				t.Fatal("renew signed by a non-CA = nil, want an error")
+			}
+			if !strings.Contains(err.Error(), tc.want+" is not a certificate authority") {
+				t.Errorf("error = %q, want it to name %s as not a CA", err, tc.want)
+			}
+			if fv.get("secret/x/leaf")["certificate"] != before {
+				t.Error("the certificate was rewritten anyway")
+			}
+
+			c = newX509CLI(t)
+			c.opt.X509.Reissue.SignedBy = tc.signedBy
+			err = c.cmdX509Reissue("x509 reissue", "secret/x/leaf")
+			if err == nil {
+				t.Fatal("reissue signed by a non-CA = nil, want an error")
+			}
+			if !strings.Contains(err.Error(), tc.want+" is not a certificate authority") {
+				t.Errorf("error = %q, want it to name %s as not a CA", err, tc.want)
+			}
+		})
+	}
+}
+
+// A certificate that signed itself still renews itself, which is the one case
+// where the signer is not a certificate authority on purpose.
+func TestASelfSignedCertificateStillRenewsItself(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	self := newCA(t, "self")
+	self.Certificate.IsCA = false
+	self.Certificate.BasicConstraintsValid = false
+	if err := self.Sign(self, time.Hour); err != nil {
+		t.Fatalf("self-sign: %v", err)
+	}
+	storeCert(t, fv, "secret/self", self)
+
+	c := newX509CLI(t)
+	if err := c.cmdX509Renew("x509 renew", "secret/self"); err != nil {
+		t.Fatalf("renew a self-signed certificate: %v", err)
+	}
+}
+
+// An authority signs as it always did.
+func TestIssueUnderARealCAStillWorks(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeCert(t, fv, "secret/ca", newCA(t, "real"))
+
+	c := newX509CLI(t)
+	c.opt.X509.Issue.Name = []string{"new.example.com"}
+	c.opt.X509.Issue.SignedBy = "secret/ca"
+
+	if err := c.cmdX509Issue("x509 issue", "secret/new"); err != nil {
+		t.Fatalf("issue under a real CA: %v", err)
+	}
+	if len(fv.get("secret/new")) == 0 {
+		t.Error("nothing was written")
+	}
+}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -1211,6 +1211,12 @@ func (v *Vault) CheckPKIBackend(backend string) error {
 	return nil
 }
 
+// FindSigningCA returns the authority that should sign cert, and the path it
+// was read from. A certificate signs itself when it is named as its own
+// authority or when it already carries its own signature; otherwise the
+// authority is read from the Vault, and has to be one — signing with a plain
+// certificate produces something no relying party will accept, and nothing
+// further along reports it.
 func (v *Vault) FindSigningCA(cert *X509, certPath string, signPath string) (*X509, string, error) {
 	/* find the CA */
 	if signPath != "" {
@@ -1224,6 +1230,9 @@ func (v *Vault) FindSigningCA(cert *X509, certPath string, signPath string) (*X5
 			ca, err := s.X509(true)
 			if err != nil {
 				return nil, "", err
+			}
+			if !ca.IsCA() {
+				return nil, "", fmt.Errorf("%s is not a certificate authority", signPath)
 			}
 			return ca, signPath, nil
 		}
@@ -1247,6 +1256,9 @@ func (v *Vault) FindSigningCA(cert *X509, certPath string, signPath string) (*X5
 			ca, err := s.X509(true)
 			if err != nil {
 				return nil, "", err
+			}
+			if !ca.IsCA() {
+				return nil, "", fmt.Errorf("%s is not a certificate authority", caPath)
 			}
 			return ca, caPath, nil
 		}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -1260,6 +1260,18 @@ func (v *Vault) FindSigningCA(cert *X509, certPath string, signPath string) (*X5
 			if !ca.IsCA() {
 				return nil, "", fmt.Errorf("%s is not a certificate authority", caPath)
 			}
+			//The sibling is a guess. Signing under it when it is not the
+			// authority that issued the certificate hands back something
+			// with a different issuer than the one it went in with, which
+			// is not what renewing or reissuing was asked to do. Naming an
+			// authority explicitly still moves a certificate to a new one.
+			if err := ca.Certificate.CheckSignature(
+				cert.Certificate.SignatureAlgorithm,
+				cert.Certificate.RawTBSCertificate,
+				cert.Certificate.Signature,
+			); err != nil {
+				return nil, "", fmt.Errorf("%s did not sign %s; name its authority with --signed-by", caPath, certPath)
+			}
 			return ca, caPath, nil
 		}
 	}

--- a/pkg/vault/x509.go
+++ b/pkg/vault/x509.go
@@ -854,6 +854,17 @@ func (x X509) Secret(skipIfExists bool) (*Secret, error) {
 		Type:  "CERTIFICATE",
 		Bytes: x.Certificate.Raw,
 	}))
+	//A certificate attribute may hold the issuers above it as well as the
+	// certificate itself, and reading one keeps them. Writing only the
+	// leading certificate would drop the rest of the chain from the secret
+	// every time anything saved it — issuing under a CA, revoking, or
+	// regenerating a revocation list all write the authority back.
+	for _, issuer := range x.Intermediaries {
+		cert += string(pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: issuer.Raw,
+		}))
+	}
 	key, err := marshalPrivateKeyPEM(x.PrivateKey)
 	if err != nil {
 		return s, err

--- a/pkg/vault/x509.go
+++ b/pkg/vault/x509.go
@@ -989,6 +989,17 @@ func (ca *X509) Sign(x *X509, ttl time.Duration) error {
 		return fmt.Errorf("requested signature algorithm is not compatible with the signing CA key: %w", err)
 	}
 
+	//Signing itself with a key it did not have before: the certificate being
+	// replaced still carries the public key of the key that is going away, and
+	// both the authority key identifier and the signature have to name the key
+	// doing the signing. Left alone, the result claims to be self-signed while
+	// carrying a signature that only the discarded key can account for, and
+	// nothing can verify it.
+	if ca == x {
+		ca.Certificate.PublicKey = x.PrivateKey.Public()
+		ca.Certificate.SubjectKeyId, _ = getKeyIDFromPublicKey(x.PrivateKey.Public())
+	}
+
 	x.Certificate.AuthorityKeyId = ca.getKeyID()
 	x.Certificate.SubjectKeyId, _ = getKeyIDFromPublicKey(x.PrivateKey.Public())
 	raw, err := x509.CreateCertificate(rand.Reader, x.Certificate, ca.Certificate, x.PrivateKey.Public(), ca.PrivateKey)

--- a/pkg/vault/x509_chain_test.go
+++ b/pkg/vault/x509_chain_test.go
@@ -1,0 +1,129 @@
+package vault_test
+
+// A certificate attribute can hold the issuers above the certificate as well
+// as the certificate itself, and safe reads them: `x509 show` lists them under
+// "via". Writing the secret back kept only the leading certificate, so every
+// command that saves a certificate — issuing under a CA, revoking, renewing,
+// regenerating a revocation list — silently dropped the rest of the chain.
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// chained builds an intermediate CA below a root and returns it as safe would
+// read it back from a secret whose certificate attribute holds both.
+func chained(t *testing.T) (*vault.X509, *vault.X509) {
+	t.Helper()
+
+	root := signingCA(t)
+	inter, err := vault.NewCertificate("CN=inter", []string{"inter"},
+		[]string{"key_cert_sign", "crl_sign"}, "",
+		vault.KeySpec{Algorithm: "rsa", Bits: 2048})
+	if err != nil {
+		t.Fatalf("NewCertificate: %v", err)
+	}
+	inter.MakeCA()
+	if err := root.Sign(inter, 24*time.Hour); err != nil {
+		t.Fatalf("sign the intermediate: %v", err)
+	}
+
+	s, err := inter.Secret(false)
+	if err != nil {
+		t.Fatalf("Secret: %v", err)
+	}
+	rootPEM := string(pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: root.Certificate.Raw,
+	}))
+	if err := s.Set("certificate", s.Get("certificate")+rootPEM, false); err != nil {
+		t.Fatalf("append the root: %v", err)
+	}
+
+	read, err := s.X509(true)
+	if err != nil {
+		t.Fatalf("read the chained secret back: %v", err)
+	}
+	return read, root
+}
+
+// certificates returns the subjects of every certificate in a PEM bundle, in
+// the order they appear.
+func certificates(t *testing.T, bundle string) []string {
+	t.Helper()
+
+	subjects := []string{}
+	rest := []byte(bundle)
+	for len(rest) > 0 {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		c, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			t.Fatalf("parse a certificate out of the bundle: %v", err)
+		}
+		subjects = append(subjects, c.Subject.CommonName)
+	}
+	return subjects
+}
+
+// Saving a certificate keeps the issuers stored with it.
+func TestSavingACertificateKeepsItsChain(t *testing.T) {
+	inter, _ := chained(t)
+
+	s, err := inter.Secret(false)
+	if err != nil {
+		t.Fatalf("Secret: %v", err)
+	}
+
+	got := certificates(t, s.Get("certificate"))
+	want := []string{"inter", "crl-ca"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("certificate holds %v, want %v", got, want)
+	}
+}
+
+// The combined attribute carries the same chain, since it is the certificate
+// attribute with the key appended.
+func TestTheCombinedAttributeKeepsTheChainToo(t *testing.T) {
+	inter, _ := chained(t)
+
+	s, err := inter.Secret(false)
+	if err != nil {
+		t.Fatalf("Secret: %v", err)
+	}
+
+	got := certificates(t, s.Get("combined"))
+	want := []string{"inter", "crl-ca"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("combined holds %v, want %v", got, want)
+	}
+	if !strings.Contains(s.Get("combined"), "PRIVATE KEY") {
+		t.Error("combined lost the private key")
+	}
+}
+
+// A certificate stored on its own still writes out on its own.
+func TestSavingACertificateWithNoChainAddsNothing(t *testing.T) {
+	ca := signingCA(t)
+
+	s, err := ca.Secret(false)
+	if err != nil {
+		t.Fatalf("Secret: %v", err)
+	}
+
+	got := certificates(t, s.Get("certificate"))
+	if len(got) != 1 || got[0] != "crl-ca" {
+		t.Errorf("certificate holds %v, want [crl-ca]", got)
+	}
+}

--- a/pkg/vault/x509_self_sign_test.go
+++ b/pkg/vault/x509_self_sign_test.go
@@ -1,0 +1,83 @@
+package vault_test
+
+// Signing a certificate with itself after its key has been replaced — what
+// reissuing a self-signed certificate does — signed with the new key but left
+// the old public key on the certificate acting as the issuer. The result said
+// it was self-signed, and carried a signature only the discarded key could
+// account for.
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// reissued replaces x's key and signs it with itself, the way `x509 reissue`
+// does for a certificate that has no separate authority.
+func reissued(t *testing.T, x *vault.X509) {
+	t.Helper()
+
+	key, err := vault.GenerateKey(vault.KeySpec{Algorithm: "rsa", Bits: 2048})
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	x.PrivateKey = key
+	x.Certificate.SignatureAlgorithm = x509.UnknownSignatureAlgorithm
+	if err := x.Sign(x, time.Hour); err != nil {
+		t.Fatalf("self-sign with the new key: %v", err)
+	}
+	parsed, err := x509.ParseCertificate(x.Certificate.Raw)
+	if err != nil {
+		t.Fatalf("parse the signed certificate: %v", err)
+	}
+	x.Certificate = parsed
+}
+
+// The signature has to verify against the key the certificate now carries.
+func TestAReissuedSelfSignedCertificateVerifiesAgainstItself(t *testing.T) {
+	ca := signingCA(t)
+	reissued(t, ca)
+
+	if err := ca.Certificate.CheckSignatureFrom(ca.Certificate); err != nil {
+		t.Errorf("the reissued certificate does not verify against itself: %v", err)
+	}
+}
+
+// A self-signed certificate names its own key as the authority that signed
+// it, so the two identifiers have to agree.
+func TestAReissuedSelfSignedCertificateNamesItsOwnKey(t *testing.T) {
+	ca := signingCA(t)
+	reissued(t, ca)
+
+	if string(ca.Certificate.AuthorityKeyId) != string(ca.Certificate.SubjectKeyId) {
+		t.Error("the authority key identifier does not name the certificate's own key")
+	}
+}
+
+// The certificate carries the key that replaced the old one.
+func TestAReissuedSelfSignedCertificateCarriesTheNewKey(t *testing.T) {
+	ca := signingCA(t)
+	before := marshalPublic(t, ca.Certificate.PublicKey)
+	reissued(t, ca)
+
+	after := marshalPublic(t, ca.Certificate.PublicKey)
+	if after == before {
+		t.Error("the certificate still carries the old public key")
+	}
+	if after != marshalPublic(t, ca.PrivateKey.Public()) {
+		t.Error("the certificate does not carry the key stored beside it")
+	}
+}
+
+// marshalPublic renders a public key in a form two of them can be compared in.
+func marshalPublic(t *testing.T, key any) string {
+	t.Helper()
+
+	der, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		t.Fatalf("marshal a %T: %v", key, err)
+	}
+	return string(der)
+}


### PR DESCRIPTION
Six fixes to the `safe x509` commands that write certificates. Two of them
destroy a certificate authority, one loses part of a certificate, two produce
certificates nothing will accept, and one turns a working command away.
Everything below was reproduced against a dev Vault, before and after, with
`openssl` reading what safe wrote.

## Issuing over the signing authority destroys it

Issuing writes the signing CA back, to record the serial number it handed
out, and then writes the new certificate over whatever the destination path
held. Naming the authority as the destination — one word out of place on the
command line — did both, in that order:

```
before:  $ safe x509 issue --name oops --signed-by secret/victim secret/victim
         (exit 0)
         secret/victim was:  subject=CN=victim, serial=1, crl present
         secret/victim is:   subject=CN=oops,   serial GONE, crl GONE

after:   !! refusing to overwrite the signing authority secret/victim with
            the certificate it signs
         (exit 1)
         secret/victim unchanged
```

The authority's private key, its serial number, and its revocation list went
with it, and nothing it had ever issued could be verified again. The command
reported success.

## Saving a certificate dropped the issuers stored with it

`path:certificate` can hold the issuers above a certificate as well as the
certificate itself, and safe reads them — `x509 show` lists them under "via".
Writing the secret back kept only the leading certificate, so every command
that saves a certificate dropped the rest of the chain: issuing under a CA,
revoking against it, renewing, reissuing, and regenerating a revocation list
all write an authority back over itself.

```
an intermediate CA stored with its root:
before:  certificates in secret/inter after `x509 crl --renew`:  2 -> 1
after:   certificates in secret/inter after `x509 crl --renew`:  2 -> 2
```

## safe would sign with something that is not a CA

Issuing, renewing, and reissuing each read a signing authority out of the
Vault, and none of them checked that the path named one:

```
before:  $ safe x509 issue --name new --signed-by secret/plain secret/new
         (exit 0)
         secret/new written, issuer=CN=plain
         $ safe x509 show secret/plain
           is not a CA

after:   !! secret/plain is not a certificate authority
         (exit 1)
         nothing written
```

The certificate looks ordinary and fails at the far end, in someone else's
handshake.

## Renewing under a sibling that never signed it

With no `--signed-by`, renew and reissue look for a `ca` sibling of the
certificate's own path and sign under whatever they find. The guess was never
checked against the certificate:

```
before:  secret/x/leaf was signed by secret/signer, and secret/x/ca holds an
         unrelated authority

         $ safe x509 renew secret/x/leaf
         Renewed x509 certificate at secret/x/leaf
         (exit 0)
         issuer: CN=signer -> CN=stranger

after:   !! secret/x/ca did not sign secret/x/leaf; name its authority with
            --signed-by
         (exit 1)
         issuer unchanged
```

An explicit `--signed-by` is still taken at its word, since naming an
authority is how a certificate moves to a new one. The sibling is a guess,
and now has to be right.

## Reissuing a self-signed certificate

Both commands work out which authority signed a certificate by checking its
signature, and both rewrite the certificate before looking. Reissue clears
the signature algorithm so signing can derive one from the regenerated key,
and `--sig-algorithm` sets it to whatever was asked for — so the check ran
against an algorithm the stored signature was not made with, and a
self-signed certificate went unrecognised:

```
before:  $ safe x509 reissue secret/solo/cert     # self-signed, no sibling
         !! no signing authority provided and no 'ca' sibling found
         (exit 1)

after:   Generating new 4096-bit RSA key...
         Reissued x509 certificate at secret/solo/cert
         (exit 0)
```

It did get through for a certificate whose path ends in `ca`, where the
sibling it guessed was itself. That is where the second half of this shows
up. Signing a certificate with itself after its key has been replaced signed
with the new key, but the certificate acting as the issuer still carried the
public key on its way out:

```
before:  $ safe x509 reissue secret/soloca/ca
         (exit 0)
         issuer=CN=soloca subject=CN=soloca
         verifies against its own public key: verification failed
         the stored key matches the stored certificate: yes

after:   verifies against its own public key: OK
```

The result claimed to be self-signed and verified against nothing: the only
key that could account for the signature had just been overwritten. The
authority is now found from the certificate as stored, before the requested
changes are applied to it, and signing a certificate with itself takes the
key it is being signed with.

## Behaviour otherwise

Unchanged. Issuing under a real CA, renewing and reissuing under the sibling
that signed them, renewing under a named authority, revoking, validating, and
`x509 show` all produce the same output as before, live.

## Tests

Ten mutations, each reverted after:

| mutation | tests failing |
|---|---|
| write only the leading certificate | 5 |
| drop the non-CA guard in issue | 1 |
| drop the non-CA guard on `--signed-by` | 2 |
| drop the non-CA guard on the sibling | 2 |
| drop the signature check on the sibling | 2 |
| drop the same-path guard in issue | 1 |
| drop the key refresh when a cert signs itself | 4 |
| keep the stale subject key id when it does | 1 |
| reissue: look up the CA after clearing the algorithm | 3 |
| renew: look up the CA after applying `--sig-algorithm` | 1 |

`make check` and `go test -race ./...` pass, and each of the seven commits
builds and passes on its own.

## Docs

The help for issue, reissue, and renew did not say that a signing authority
has to be one, that issuing cannot write over the authority it signs with, or
that the sibling `ca` is only used when it is the authority that signed the
certificate. README had nothing on reissue or renew at all, and now covers
both along with the chain.
