### PR TITLE
Fix key deletes that act on the wrong version

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,25 @@ Removes multiple paths from the Vault.
 safe delete secret/unused
 ```
 
+A path may name a single key, and on a version 2 backend it may name a
+version as well.
+
+```
+safe delete secret/db:password
+safe delete secret/db^3
+```
+
+Removing a key writes what is left of the secret as a new version. A
+version already written is never rewritten, so naming a key together with
+an older version only works when that version holds nothing but the key —
+in which case the version itself is what goes. Anything else is refused,
+and `safe copy` is the command that reads a key out of an old version.
+
+`-D` (`--destroy`) and `-a` (`--all`) work on whole versions. With a key,
+they apply only when the key is the whole secret; otherwise the key would
+stay behind in the versions already written, and safe says so rather than
+writing a new version and calling it done.
+
 ### move oldpath newpath
 
 Move a secret from `oldpath` to `newpath`, a rename of sorts.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -843,6 +843,19 @@ each match is printed as path:key instead.
 being marked as deleted. For KV v1 backends, this would do nothing.
 -a (--all) will delete (or destroy) all versions of the secret instead
 of just the specified (or latest if unspecified) version.
+
+A path may name a single key, and may name a version as well. Removing
+a key writes what is left of the secret as a new version; a version
+already written is never rewritten. Naming a key alongside an older
+version therefore only works when that version holds nothing but the
+key, and what goes is the version itself. Anything else is refused —
+safe copy is the command that reads a key out of an old version.
+
+Both flags above work on whole versions, so with a key they apply only
+when the key is the whole secret. Where the secret holds other keys the
+key would stay behind in the versions already written, and the request
+is refused rather than answered with a new version that leaves the old
+value where it was.
 `}, c.cmdDelete)
 
 	r.Dispatch("undelete", &Help{
@@ -898,6 +911,11 @@ rting garbage data and then destroying it (which is originally done to preserve 
 		Description: `
 Specifying the --deep (-d) flag will cause versions to be grabbed from the source
 and overwrite all versions of the secret at the destination.
+
+A move is a copy followed by a delete of the source, so it can only be asked
+for where the delete half of it is possible. Moving one key off an older
+version is not: that version cannot be rewritten to leave the key out. Use
+safe copy where the source is to stay as it is.
 `}, c.cmdMove)
 
 	r.Dispatch("copy", &Help{

--- a/internal/cli/delete_key_flags_test.go
+++ b/internal/cli/delete_key_flags_test.go
@@ -1,0 +1,125 @@
+package cli
+
+// --destroy and --all both work on whole versions. What that means for a path
+// that names one key depends on whether the key is the whole secret.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDestroyingTheOnlyKeyDestroysTheSecret(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app", map[string]string{"password": "one"})
+
+	c := newTestCLI(t)
+	c.opt.Delete.Destroy = true
+	if err := c.cmdDelete("delete", "secret/app:password"); err != nil {
+		t.Fatalf("cmdDelete --destroy: %v", err)
+	}
+
+	//A destroy that leaves the version merely deleted is one an undelete
+	// brings straight back, which is the opposite of what was asked.
+	if states := fv.versionStates("secret/app"); len(states) != 0 {
+		t.Errorf("version states = %v, want the secret gone", states)
+	}
+}
+
+func TestDestroyingTheOnlyKeyOfSeveralVersions(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+
+	c := newTestCLI(t)
+	c.opt.Delete.Destroy = true
+	if err := c.cmdDelete("delete", "secret/app:password"); err != nil {
+		t.Fatalf("cmdDelete --destroy: %v", err)
+	}
+
+	got := fv.versionStates("secret/app")
+	want := []string{"alive", "destroyed"}
+	if !equalStrings(got, want) {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+}
+
+func TestDeletingEveryVersionOfTheOnlyKey(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+
+	c := newTestCLI(t)
+	c.opt.Delete.All = true
+	if err := c.cmdDelete("delete", "secret/app:password"); err != nil {
+		t.Fatalf("cmdDelete --all: %v", err)
+	}
+
+	got := fv.versionStates("secret/app")
+	want := []string{"deleted", "deleted"}
+	if !equalStrings(got, want) {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+}
+
+func TestDestroyingOneKeyOfSeveralIsRefused(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app", map[string]string{"password": "one", "username": "admin"})
+
+	c := newTestCLI(t)
+	c.opt.Delete.Destroy = true
+	err := c.cmdDelete("delete", "secret/app:password")
+	if err == nil {
+		t.Fatal("expected a refusal destroying one key of a secret that holds others, got nil")
+	}
+	if !strings.Contains(err.Error(), "password") {
+		t.Errorf("error %q should name the key", err)
+	}
+
+	//The value has to still be there. Reporting a destroy and leaving the key
+	//	readable in the version it was already written to is the failure.
+	if states := fv.versionStates("secret/app"); len(states) != 1 {
+		t.Errorf("version states = %v, want the one version untouched", states)
+	}
+	assertVersionData(t, fv, "secret/app", 1, map[string]string{"password": "one", "username": "admin"})
+}
+
+func TestDeletingEveryVersionOfOneKeyOfSeveralIsRefused(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app", map[string]string{"password": "one", "username": "admin"})
+
+	c := newTestCLI(t)
+	c.opt.Delete.All = true
+	err := c.cmdDelete("delete", "secret/app:password")
+	if err == nil {
+		t.Fatal("expected a refusal deleting every version of one key, got nil")
+	}
+	if !strings.Contains(err.Error(), "password") {
+		t.Errorf("error %q should name the key", err)
+	}
+	if states := fv.versionStates("secret/app"); len(states) != 1 {
+		t.Errorf("version states = %v, want the one version untouched", states)
+	}
+}
+
+// Without either flag the key still goes, and the rest of the secret carries
+// on into a new version.
+func TestDeletingOneKeyOfSeveralStillWorks(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app", map[string]string{"password": "one", "username": "admin"})
+
+	c := newTestCLI(t)
+	if err := c.cmdDelete("delete", "secret/app:password"); err != nil {
+		t.Fatalf("cmdDelete: %v", err)
+	}
+	assertVersionData(t, fv, "secret/app", 2, map[string]string{"username": "admin"})
+}

--- a/internal/cli/delete_key_version_test.go
+++ b/internal/cli/delete_key_version_test.go
@@ -106,6 +106,63 @@ func TestCopyingAKeyOffAnOlderVersionIsAllowed(t *testing.T) {
 	assertVersionData(t, fv, "secret/app", 1, map[string]string{"password": "one", "username": "admin"})
 }
 
+func TestDeletingTheOnlyKeyOfAnOlderVersionDeletesThatVersion(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+
+	c := newTestCLI(t)
+	if err := c.cmdDelete("delete", "secret/app:password^1"); err != nil {
+		t.Fatalf("cmdDelete: %v", err)
+	}
+
+	//Version 1 was the one named, so version 1 is the one that goes.
+	got := fv.versionStates("secret/app")
+	want := []string{"deleted", "alive"}
+	if !equalStrings(got, want) {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+	assertVersionData(t, fv, "secret/app", 2, map[string]string{"password": "two"})
+}
+
+func TestMovingTheOnlyKeyOffAnOlderVersionTakesThatVersion(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+
+	c := newTestCLI(t)
+	if err := c.cmdMove("move", "secret/app:password^1", "secret/other:password"); err != nil {
+		t.Fatalf("cmdMove: %v", err)
+	}
+
+	assertVersionData(t, fv, "secret/other", 1, map[string]string{"password": "one"})
+	got := fv.versionStates("secret/app")
+	want := []string{"deleted", "alive"}
+	if !equalStrings(got, want) {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+}
+
+// Naming the latest version is the same request as naming no version at all.
+func TestDeletingAKeyOfTheLatestVersionNamedExplicitly(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app", map[string]string{"password": "one", "username": "admin"})
+
+	c := newTestCLI(t)
+	if err := c.cmdDelete("delete", "secret/app:password^1"); err != nil {
+		t.Fatalf("cmdDelete: %v", err)
+	}
+
+	assertVersionData(t, fv, "secret/app", 2, map[string]string{"username": "admin"})
+}
+
 // A key that is not in the named version is a missing key, and saying so sends
 // the reader somewhere different than the refusal above does.
 func TestDeletingAKeyMissingFromTheNamedVersionSaysSo(t *testing.T) {

--- a/internal/cli/delete_key_version_test.go
+++ b/internal/cli/delete_key_version_test.go
@@ -1,0 +1,152 @@
+package cli
+
+// A key named together with a version — `safe delete secret/app:password^1` —
+// only means something when that version holds nothing but the key, because a
+// version already written cannot be rewritten. These cover what safe does with
+// the request either way.
+
+import (
+	"strings"
+	"testing"
+)
+
+// versionData returns the values held by one version of a path, for tests that
+// need to see that a version was left as it was.
+func (f *cliFakeVault) versionData(path string, n uint) map[string]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v := f.versionLocked(path, n)
+	if v == nil {
+		return nil
+	}
+	out := map[string]string{}
+	for k, val := range v.data {
+		out[k] = val
+	}
+	return out
+}
+
+// assertVersionData fails unless version n of path holds exactly want.
+func assertVersionData(t *testing.T, fv *cliFakeVault, path string, n uint, want map[string]string) {
+	t.Helper()
+	got := fv.versionData(path, n)
+	if len(got) != len(want) {
+		t.Fatalf("version %d of %s = %v, want %v", n, path, got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("version %d of %s = %v, want %v", n, path, got, want)
+		}
+	}
+}
+
+func TestDeletingAKeyOfAnOlderVersionThatHoldsOthersIsRefused(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one", "username": "admin"},
+		map[string]string{"password": "two", "username": "admin"},
+	)
+
+	c := newTestCLI(t)
+	err := c.cmdDelete("delete", "secret/app:password^1")
+	if err == nil {
+		t.Fatal("expected a refusal deleting one of two keys of an older version, got nil")
+	}
+	if !strings.Contains(err.Error(), "password") {
+		t.Errorf("error %q should name the key", err)
+	}
+
+	//Nothing may have moved: not the version that was named, and not the
+	// latest, which is what safe used to rewrite instead.
+	assertVersionData(t, fv, "secret/app", 1, map[string]string{"password": "one", "username": "admin"})
+	assertVersionData(t, fv, "secret/app", 2, map[string]string{"password": "two", "username": "admin"})
+	if states := fv.versionStates("secret/app"); len(states) != 2 {
+		t.Errorf("version count = %d, want 2 (no version should have been written)", len(states))
+	}
+}
+
+func TestMovingAKeyOffAnOlderVersionThatHoldsOthersIsRefused(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one", "username": "admin"},
+		map[string]string{"password": "two", "username": "admin"},
+	)
+
+	c := newTestCLI(t)
+	err := c.cmdMove("move", "secret/app:password^1", "secret/other:password")
+	if err == nil {
+		t.Fatal("expected a refusal moving one of two keys of an older version, got nil")
+	}
+
+	assertVersionData(t, fv, "secret/app", 1, map[string]string{"password": "one", "username": "admin"})
+	assertVersionData(t, fv, "secret/app", 2, map[string]string{"password": "two", "username": "admin"})
+	if states := fv.versionStates("secret/other"); len(states) != 0 {
+		t.Errorf("the destination should not have been written, got %v", states)
+	}
+}
+
+// Copying is the operation that does work here, and the refusal above points
+// at it, so it has to.
+func TestCopyingAKeyOffAnOlderVersionIsAllowed(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one", "username": "admin"},
+		map[string]string{"password": "two", "username": "admin"},
+	)
+
+	c := newTestCLI(t)
+	if err := c.cmdCopy("copy", "secret/app:password^1", "secret/other:password"); err != nil {
+		t.Fatalf("cmdCopy: %v", err)
+	}
+
+	assertVersionData(t, fv, "secret/other", 1, map[string]string{"password": "one"})
+	assertVersionData(t, fv, "secret/app", 1, map[string]string{"password": "one", "username": "admin"})
+}
+
+// A key that is not in the named version is a missing key, and saying so sends
+// the reader somewhere different than the refusal above does.
+func TestDeletingAKeyMissingFromTheNamedVersionSaysSo(t *testing.T) {
+	isolateHome(t)
+	newCLIFakeV2(t).setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two", "username": "admin"},
+	)
+
+	c := newTestCLI(t)
+	err := c.cmdDelete("delete", "secret/app:username^1")
+	if err == nil {
+		t.Fatal("expected an error for a key the named version does not hold, got nil")
+	}
+	if !strings.Contains(err.Error(), "username") {
+		t.Errorf("error %q should name the key", err)
+	}
+	if strings.Contains(err.Error(), "holds other keys") {
+		t.Errorf("a missing key should not be reported as a crowded version: %q", err)
+	}
+}
+
+// Same again where the named version does hold several keys, none of them the
+// one asked for. Counting the keys before looking for the one named answers a
+// question nobody asked.
+func TestDeletingAKeyMissingFromACrowdedVersionSaysSo(t *testing.T) {
+	isolateHome(t)
+	newCLIFakeV2(t).setV2("secret/app",
+		map[string]string{"password": "one", "username": "admin"},
+		map[string]string{"password": "two", "username": "admin", "token": "t"},
+	)
+
+	c := newTestCLI(t)
+	err := c.cmdDelete("delete", "secret/app:token^1")
+	if err == nil {
+		t.Fatal("expected an error for a key the named version does not hold, got nil")
+	}
+	if !strings.Contains(err.Error(), "token") {
+		t.Errorf("error %q should name the key", err)
+	}
+	if strings.Contains(err.Error(), "holds other keys") {
+		t.Errorf("a missing key should not be reported as a crowded version: %q", err)
+	}
+}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -587,12 +587,16 @@ func (v *Vault) deleteEntireSecret(path string, destroy bool, all bool) error {
 }
 
 func (v *Vault) deleteSpecificKey(path string) error {
-	secretPath, key, _ := ParsePath(path)
+	secretPath, key, version := ParsePath(path)
 	//ParsePath unescaped the secret path. Read, Write, and deleteEntireSecret
 	// all parse their argument again, so they need the escaped form back or
 	// they split a second time at a colon that belongs to the path.
-	encodedPath := EncodePath(secretPath, "", 0)
-	secret, err := v.Read(encodedPath)
+	//
+	// The version goes back with it. Dropping it reads and removes the key from
+	// the latest version instead of the one that was named — an edit to a
+	// secret nobody asked about, leaving the named version as it was.
+	versionedPath := EncodePath(secretPath, "", version)
+	secret, err := v.Read(versionedPath)
 	if err != nil {
 		return err
 	}
@@ -607,9 +611,12 @@ func (v *Vault) deleteSpecificKey(path string) error {
 		//
 		//At some point, we should probably get Destroy routed into here so that we can destroy
 		// secrets through specifying keys
-		return v.deleteEntireSecret(encodedPath, false, false)
+		return v.deleteEntireSecret(versionedPath, false, false)
 	}
-	return v.Write(encodedPath, secret)
+	//What is left goes on as a new version. canSemanticallyDelete has already
+	// turned away anything but the latest version by this point, so this never
+	// writes an old version forward over a newer one.
+	return v.Write(EncodePath(secretPath, "", 0), secret)
 }
 
 // DeleteVersions marks the given versions of the given secret as deleted for

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -474,13 +474,22 @@ func (v *Vault) canSemanticallyDelete(path string) error {
 		return nil
 	}
 
-	s, err := v.Read(path)
+	//Read the version, not the key: a read of a path that names a key hands
+	// back that one key, so asking this way makes every version look as though
+	// it held nothing else, and the check below can never find anything to
+	// object to. ParsePath unescaped the secret path, and Read parses its
+	// argument again, so the escaped form goes back in.
+	s, err := v.Read(EncodePath(justSecret, "", version))
 	if err != nil {
 		return err
 	}
 
-	if len(s.data) != 1 || !s.Has(key) {
-		return fmt.Errorf("cannot delete specific non-isolated key of non-latest version")
+	if !s.Has(key) {
+		return NewKeyNotFoundError(justSecret, key)
+	}
+
+	if len(s.data) != 1 {
+		return fmt.Errorf("cannot delete %s from version %d: that version holds other keys, and a version already written cannot be rewritten", key, version)
 	}
 
 	return nil

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -522,7 +522,7 @@ func (v *Vault) Delete(path string, opts DeleteOpts) error {
 		return v.deleteEntireSecret(path, opts.Destroy, opts.All)
 	}
 
-	return v.deleteSpecificKey(path)
+	return v.deleteSpecificKey(path, opts)
 }
 
 func (v *Vault) deleteEntireSecret(path string, destroy bool, all bool) error {
@@ -586,7 +586,7 @@ func (v *Vault) deleteEntireSecret(path string, destroy bool, all bool) error {
 	return v.client.Delete(secret, &vaultkv.KVDeleteOpts{Versions: versions, V1Destroy: true})
 }
 
-func (v *Vault) deleteSpecificKey(path string) error {
+func (v *Vault) deleteSpecificKey(path string, opts DeleteOpts) error {
 	secretPath, key, version := ParsePath(path)
 	//ParsePath unescaped the secret path. Read, Write, and deleteEntireSecret
 	// all parse their argument again, so they need the escaped form back or
@@ -609,9 +609,21 @@ func (v *Vault) deleteSpecificKey(path string) error {
 		// We can only be here and not be on the latest version if this was the only key remaining
 		// and we're just trying to nuke the secret
 		//
-		//At some point, we should probably get Destroy routed into here so that we can destroy
-		// secrets through specifying keys
-		return v.deleteEntireSecret(versionedPath, false, false)
+		//The key was the whole secret, so removing it removes versions, which
+		// is what --destroy and --all are asking about. They used to be dropped
+		// here: a destroy reported success and left the value where an undelete
+		// would bring it straight back.
+		return v.deleteEntireSecret(versionedPath, opts.Destroy, opts.All)
+	}
+	//Destroying, and deleting every version, both work on whole versions.
+	// Neither can be done to one key of a secret that holds others: the key
+	// stays in every version already written. Writing a new version without
+	// the key and calling that a destroy is what safe used to do.
+	if opts.Destroy {
+		return fmt.Errorf("cannot destroy the key %s: %s holds other keys, and destroying removes whole versions", key, secretPath)
+	}
+	if opts.All {
+		return fmt.Errorf("cannot delete the key %s from every version: %s holds other keys, and a version already written cannot be rewritten", key, secretPath)
 	}
 	//What is left goes on as a new version. canSemanticallyDelete has already
 	// turned away anything but the latest version by this point, so this never


### PR DESCRIPTION
Three fixes to `safe delete` where a path names a key. Two of them act on a
version nobody asked about, and one turns a `--destroy` into something an
undelete brings straight back. `safe move` inherits all three, since a move is
a copy and then a delete. Everything below was reproduced against a dev Vault
on a KV v2 mount, before and after.

## Removing a key from an older version rewrote the newest one

A key can be named together with a version — `safe delete secret/app:pw^1`.
The delete dropped the version and read, changed, and wrote back the latest
version instead:

```
before:  secret/c1 v1 = {a, b},  v2 = {a, b}  (latest)

         $ safe delete secret/c1:a^1
         (exit 0)

         v1     = {a, b}   unchanged, which is what was asked about
         latest = v3 {b}   a version written over a request about history

after:   !! cannot delete a from version 1: that version holds other keys,
            and a version already written cannot be rewritten
         (exit 1)
         nothing written
```

There is a check meant to catch this — a key can only be removed from an older
version when the version holds nothing else — and it could never fire. It read
the path it was handed, and a read of a path that names a key hands back that
one key, so every version looked as though it held nothing but the key. It now
reads the version.

## Deleting the only key of an older version deleted the newest one

Where the version does hold nothing but the key, the version itself is what
goes. The version was dropped there too, so the newest version went instead:

```
before:  secret/c2 v1 = {a}, v2 = {a}

         $ safe delete secret/c2:a^1
         (exit 0)
         v1  alive     the version that was named
         v2  deleted   the version that was not

after:   v1  deleted
         v2  alive
```

Through `move` the two halves disagreed with each other — it copied out of the
version that was named and deleted a different one:

```
before:  $ safe move secret/c10:a^1 secret/c10dst:a
         (exit 0)
         destination = v1's value
         source: v1 alive, v2 deleted

after:   destination = v1's value
         source: v1 deleted, v2 alive
```

A move whose delete half cannot be honoured at all is now refused, and names
`copy`, which is the command that reads a key out of an old version and leaves
the source alone:

```
!! can't move `secret/c9:a^1': cannot delete a from version 1: that version
   holds other keys, and a version already written cannot be rewritten.
   Did you mean cp?
```

## --destroy and --all were dropped for a key

Both flags work on whole versions. Neither reached a delete that named a key.

Where the key is the whole secret, removing it removes versions, so the flags
have something to apply to — and `--destroy` was answering with a soft delete:

```
before:  $ safe delete --destroy secret/c3:a
         (exit 0)
         version 1: deleted        an undelete brings the value back

after:   (exit 0)
         no secret exists at path `secret/c3`
```

Where the secret holds other keys, neither flag can be honoured: the key stays
in every version already written. safe wrote a new version without the key and
reported success, so a destroy left the value readable at the version it was
already in:

```
before:  $ safe delete --destroy secret/c7:a
         (exit 0)
         a still readable at v1

after:   !! cannot destroy the key a: secret/c7 holds other keys, and
            destroying removes whole versions
         (exit 1)

before:  $ safe delete --all secret/c8:a
         (exit 0)
         all versions still alive; one new version written

after:   !! cannot delete the key a from every version: secret/c8 holds
            other keys, and a version already written cannot be rewritten
         (exit 1)
```

## Behaviour otherwise

Unchanged. A plain key delete, a key delete naming the latest version, a key
delete that empties the secret, deleting a whole secret or one of its versions,
`--destroy --all` on a whole secret, moving a key off the latest version, and a
recursive delete all produce the same result as before, live.

## Tests

Eight mutations, each reverted after:

| mutation | tests failing |
|---|---|
| read the key instead of the version | 2 |
| drop the crowded-version refusal | 2 |
| drop the version from the key delete | 2 |
| delete the latest version once the key empties it | 2 |
| drop destroy and all from the key delete | 3 |
| drop the destroy refusal | 1 |
| drop the all refusal | 1 |
| report a missing key as a crowded version | 1 |

`make check` and `go test -race ./...` pass, and each of the four commits
builds and passes on its own.

## Docs

The help for `delete` described the two flags and nothing else — not that a
path may name a key, not what naming a key and a version together means, and
not what the flags do with one. `move` now says why it can refuse where `copy`
would not. README's `delete` section says the same in its own words.
