### PR TITLE
Fix host key checking in the SSH proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,49 @@ safe auth okta
 For each type (token, ldap, okta or github), you will be prompted for
 the necessary credentials to authenticated against the Vault.
 
+Proxies
+-------
+
+`safe` reads the usual proxy environment variables — `HTTP_PROXY`,
+`HTTPS_PROXY`, and `NO_PROXY`, in either case — and honours them when
+talking to a Vault.  `SAFE_ALL_PROXY` overrides the first two, for when
+both should go the same way.
+
+A Vault that is only reachable from inside a network can be reached
+through an SSH tunnel, by giving a proxy variable an `ssh+socks5://`
+URL naming a host to log into and a private key to log in with:
+
+```
+export SAFE_ALL_PROXY=ssh+socks5://you@bastion.example.com/home/you/.ssh/id_ed25519
+export SAFE_ALL_PROXY=ssh+socks5://you@bastion.example.com?private-key=/home/you/.ssh/id_ed25519
+```
+
+Both forms mean the same thing; use the second one when the path to the
+key is relative.  Naming the key both ways at once is an error, as is
+naming none.  The port defaults to 22, and the key must not be one that
+needs a passphrase to read.  `safe` opens the tunnel, runs a SOCKS5
+proxy on a local port for as long as the command lasts, and sends its
+Vault traffic through it.
+
+The host key of the machine being logged into is checked against a
+`known_hosts` file, the way `ssh` checks it:
+
+  - `SAFE_KNOWN_HOSTS_FILE` names the file to check against.  It
+    defaults to `$HOME/.ssh/known_hosts`, and is created empty if it
+    does not exist yet.
+
+  - A host that is not in the file is offered for you to accept, and is
+    written to the file if you answer `yes`.  Where there is nothing to
+    answer with — a script, a CI job — the host is refused.
+
+  - A host whose key has changed is always refused, and the entry that
+    the new key conflicts with is named by line.
+
+  - `SAFE_SKIP_HOST_KEY_VALIDATION` set to `true`, `yes`, `1`, or `on`
+    turns the check off and accepts whatever key is offered.  This
+    leaves the tunnel open to being intercepted, so `safe` warns on
+    stderr whenever it is set.
+
 Usage
 -----
 

--- a/pkg/vault/proxy.go
+++ b/pkg/vault/proxy.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	socks5 "github.com/armon/go-socks5"
+	"github.com/cloudfoundry-community/safe/pkg/prompt"
 	isatty "github.com/mattn/go-isatty"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -299,14 +300,27 @@ func promptAddNewKnownHost(hostname string, remote net.Addr, key ssh.PublicKey) 
 %[3]s key fingerprint is %[4]s
 Are you sure you want to continue connecting (yes/no)? `, hostname, remote.String(), key.Type(), ssh.FingerprintSHA256(key))
 
-	var response string
-	_, _ = fmt.Scanln(&response)
-	for response != "yes" && response != "no" {
-		fmt.Fprintf(os.Stderr, "Please type 'yes' or 'no': ")
-		_, _ = fmt.Scanln(&response)
-	}
+	for {
+		//A read that fails is the end of the matter. Answering nothing used to
+		// leave the answer as it was and ask again, so stdin at its end -- a
+		// pipe that is done, a job with no input attached -- spun here without
+		// stopping, writing the prompt to stderr as fast as it could. No answer
+		// is no.
+		response, err := prompt.ReadLine()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "")
+			return false
+		}
 
-	return response == "yes"
+		switch strings.TrimSpace(response) {
+		case "yes":
+			return true
+		case "no":
+			return false
+		}
+
+		fmt.Fprintf(os.Stderr, "Please type 'yes' or 'no': ")
+	}
 }
 
 func writeKnownHosts(knownHostsFile, hostname string, key ssh.PublicKey) error {

--- a/pkg/vault/proxy.go
+++ b/pkg/vault/proxy.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -168,7 +169,11 @@ func StartSSHTunnel(conf SOCKS5SSHConfig) (*ssh.Client, error) {
 			if os.Getenv("HOME") == "" {
 				return nil, fmt.Errorf("no home directory set and no known hosts file explicitly given; cannot validate host key")
 			}
-			conf.KnownHostsFile = fmt.Sprintf("%s/.ssh/known_hosts", os.Getenv("HOME"))
+			conf.KnownHostsFile = filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts")
+		}
+
+		if err = ensureKnownHostsFile(conf.KnownHostsFile); err != nil {
+			return nil, err
 		}
 
 		hostKeyCallback, err = knownHostsPromptCallback(conf.KnownHostsFile)
@@ -217,6 +222,42 @@ func StartSOCKS5Server(dialFn func(string, string) (net.Conn, error)) (addr stri
 	}()
 
 	return socks5Listener.Addr().String(), socks5Listener.Close, nil
+}
+
+// ensureKnownHostsFile creates an empty known_hosts file, and the directory
+// holding it, if there is nothing there yet. Reading the file is how host keys
+// are checked, and a file that does not exist cannot be read, so without this
+// a machine that has never run ssh could not reach a host through the SSH
+// proxy at all -- the connection failed before it was tried, and the advice in
+// the error was to open a file that nothing was ever going to write. ssh
+// itself creates the file on first use; so does safe now, and the first
+// connection asks about the host key as it does under ssh.
+func ensureKnownHostsFile(path string) error {
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("could not read known_hosts file at `%s': %w", path, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("could not create directory for known_hosts file at `%s': %w", path, err)
+	}
+
+	//O_EXCL so that a file written between the check above and here is left
+	// alone rather than emptied.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600) // #nosec G304 -- known_hosts path from user-controlled SAFE_KNOWN_HOSTS_FILE env var
+	if err != nil {
+		if os.IsExist(err) {
+			return nil
+		}
+		return fmt.Errorf("could not create known_hosts file at `%s': %w", path, err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("could not create known_hosts file at `%s': %w", path, err)
+	}
+
+	return nil
 }
 
 func knownHostsPromptCallback(knownHostsFile string) (ssh.HostKeyCallback, error) {

--- a/pkg/vault/proxy.go
+++ b/pkg/vault/proxy.go
@@ -241,10 +241,18 @@ func knownHostsPromptCallback(knownHostsFile string) (ssh.HostKeyCallback, error
 		//If the error has hostnames listed under Want, it means that there was
 		// a conflicting host key
 		if len(errAsKeyError.Want) > 0 {
+			//Point at the entry that conflicts with the key the host offered,
+			// which is the one of the host's own type. Testing the candidate
+			// already chosen rather than the one in hand named whichever entry
+			// came last when the first happened to match and the first when it
+			// did not, so the line reported was the wrong one either way, and
+			// the reader who acted on it deleted a host key that was fine and
+			// left the conflicting entry where it was.
 			wantedKey := errAsKeyError.Want[0]
 			for _, k := range errAsKeyError.Want {
-				if wantedKey.Key.Type() == key.Type() {
+				if k.Key.Type() == key.Type() {
 					wantedKey = k
+					break
 				}
 			}
 
@@ -259,11 +267,15 @@ The fingerprint for the %[1]s key sent by the remote host is
 %[2]s.
 Please contact your system administrator.
 Add correct host key in %[3]s to get rid of this message.
-Offending %[1]s key in %[3]s:%[4]d
+Offending %[6]s key in %[3]s:%[4]d
 %[1]s host key for %[5]s has changed and safe uses strict checking.
 Host key verification failed`
+			//The offending line is named with the type of the key written on it,
+			// which is the type of the key the host offered whenever there is an
+			// entry of that type to conflict with.
 			return fmt.Errorf(hostKeyConflictError,
-				key.Type(), ssh.FingerprintSHA256(key), knownHostsFile, wantedKey.Line, hostname)
+				key.Type(), ssh.FingerprintSHA256(key), knownHostsFile, wantedKey.Line,
+				hostname, wantedKey.Key.Type())
 		}
 
 		//If not, then the key doesn't exist in the host key file

--- a/pkg/vault/proxy_host_key_conflict_test.go
+++ b/pkg/vault/proxy_host_key_conflict_test.go
@@ -1,0 +1,157 @@
+// Which known_hosts line the host-key-changed warning names. A reader who
+// deletes the line safe points at has to be deleting the right one.
+package vault
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+// makeRSAPublicKey generates a fresh RSA SSH public key, for tests that need
+// two entries of differing type for one host.
+func makeRSAPublicKey(t *testing.T) ssh.PublicKey {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	pub, err := ssh.NewPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("ssh.NewPublicKey: %v", err)
+	}
+	return pub
+}
+
+// seedKnownHosts writes one entry per key, in order, all for the same host.
+func seedKnownHosts(t *testing.T, path, host string, keys ...ssh.PublicKey) {
+	t.Helper()
+	normalized := knownhosts.Normalize(host)
+	var b strings.Builder
+	for _, k := range keys {
+		fmt.Fprintf(&b, "%s\n", knownhosts.Line([]string{normalized}, k))
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0600); err != nil {
+		t.Fatalf("write known_hosts: %v", err)
+	}
+}
+
+var offendingLine = regexp.MustCompile(`Offending (\S+) key in \S+:(\d+)`)
+
+// offendingKey pulls the type and line number that the warning names.
+func offendingKey(t *testing.T, err error) (string, int) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a host key conflict, got nil")
+	}
+	m := offendingLine.FindStringSubmatch(err.Error())
+	if m == nil {
+		t.Fatalf("no offending-key line in warning:\n%v", err)
+	}
+	line, convErr := strconv.Atoi(m[2])
+	if convErr != nil {
+		t.Fatalf("line number %q: %v", m[2], convErr)
+	}
+	return m[1], line
+}
+
+// TestConflictNamesTheLineOfTheOfferedKeyType checks that where a host has
+// entries of two types, the warning names the one that conflicts with the key
+// the host offered — not whichever entry happens to come first or last.
+func TestConflictNamesTheLineOfTheOfferedKeyType(t *testing.T) {
+	t.Parallel()
+	const host = "conflict.example.com:22"
+
+	//The offered key is ed25519 both times. Only the position of the ed25519
+	// entry in the file moves, so the line named has to move with it.
+	for _, tc := range []struct {
+		name string
+		keys func(rsa, ed ssh.PublicKey) []ssh.PublicKey
+		want int
+	}{
+		{
+			name: "ed25519 second",
+			keys: func(r, e ssh.PublicKey) []ssh.PublicKey { return []ssh.PublicKey{r, e} },
+			want: 2,
+		},
+		{
+			name: "ed25519 first",
+			keys: func(r, e ssh.PublicKey) []ssh.PublicKey { return []ssh.PublicKey{e, r} },
+			want: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "known_hosts")
+			seedKnownHosts(t, path, host, tc.keys(makeRSAPublicKey(t), makeEd25519PublicKey(t))...)
+
+			cb, err := knownHostsPromptCallback(path)
+			if err != nil {
+				t.Fatalf("knownHostsPromptCallback: %v", err)
+			}
+
+			//A different ed25519 key: the stored ed25519 entry is what it
+			// conflicts with.
+			typ, line := offendingKey(t, cb(host, fakeNetAddr("127.0.0.1:22"), makeEd25519PublicKey(t)))
+			if line != tc.want {
+				t.Errorf("warning names known_hosts line %d; the conflicting entry is on line %d", line, tc.want)
+			}
+			if typ != ssh.KeyAlgoED25519 {
+				t.Errorf("warning names a %s key; the conflicting entry is %s", typ, ssh.KeyAlgoED25519)
+			}
+		})
+	}
+}
+
+// TestConflictNamesTheFirstEntryOfTheOfferedType covers a host with more than
+// one entry of the same type, where every one of them conflicts. ssh names the
+// first, and someone working through the file from the top expects the same.
+func TestConflictNamesTheFirstEntryOfTheOfferedType(t *testing.T) {
+	t.Parallel()
+	const host = "doubled.example.com:22"
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	seedKnownHosts(t, path, host,
+		makeEd25519PublicKey(t), makeRSAPublicKey(t), makeEd25519PublicKey(t))
+
+	cb, err := knownHostsPromptCallback(path)
+	if err != nil {
+		t.Fatalf("knownHostsPromptCallback: %v", err)
+	}
+
+	_, line := offendingKey(t, cb(host, fakeNetAddr("127.0.0.1:22"), makeEd25519PublicKey(t)))
+	if line != 1 {
+		t.Errorf("warning names known_hosts line %d; the first conflicting entry is on line 1", line)
+	}
+}
+
+// TestConflictNamesTheStoredKeyType checks the case where the host has no
+// entry of the offered type at all. The warning still names a line, so the
+// type it prints must be the type of the key written there.
+func TestConflictNamesTheStoredKeyType(t *testing.T) {
+	t.Parallel()
+	const host = "mismatched.example.com:22"
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	seedKnownHosts(t, path, host, makeRSAPublicKey(t))
+
+	cb, err := knownHostsPromptCallback(path)
+	if err != nil {
+		t.Fatalf("knownHostsPromptCallback: %v", err)
+	}
+
+	typ, line := offendingKey(t, cb(host, fakeNetAddr("127.0.0.1:22"), makeEd25519PublicKey(t)))
+	if line != 1 {
+		t.Errorf("warning names known_hosts line %d; the only entry is on line 1", line)
+	}
+	if typ != ssh.KeyAlgoRSA {
+		t.Errorf("warning names a %s key on a line holding an %s key", typ, ssh.KeyAlgoRSA)
+	}
+}

--- a/pkg/vault/proxy_host_key_prompt_test.go
+++ b/pkg/vault/proxy_host_key_prompt_test.go
@@ -1,0 +1,91 @@
+// The yes/no prompt that offers to add an unknown host key. It reads from
+// stdin, and stdin is not always something that will answer.
+package vault
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudfoundry-community/safe/pkg/prompt"
+)
+
+// askToAddHost runs the prompt against the given input and returns its answer.
+// It fails the test if the prompt has not returned within a second, since the
+// caller of a prompt that never returns is a process that has to be killed.
+//
+// Stderr goes to the null device while the prompt runs: a prompt that does
+// loop writes to it as fast as it can, and the test should not be filling a
+// disk while it waits. Where the prompt has not returned, stderr is left at
+// the null device rather than put back, because the prompt is still writing
+// to it and the rest of the run should not be buried.
+func askToAddHost(t *testing.T, input string) bool {
+	t.Helper()
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open %s: %v", os.DevNull, err)
+	}
+	realStderr := os.Stderr
+	os.Stderr = devNull
+	prompt.SetReader(strings.NewReader(input))
+
+	answered := make(chan bool, 1)
+	go func() {
+		answered <- promptAddNewKnownHost("unknown.example.com:22",
+			fakeNetAddr("127.0.0.1:22"), makeEd25519PublicKey(t))
+	}()
+
+	select {
+	case answer := <-answered:
+		os.Stderr = realStderr
+		prompt.SetReader(nil)
+		_ = devNull.Close()
+		return answer
+	case <-time.After(time.Second):
+		t.Fatalf("prompt did not return for input %q", input)
+		return false
+	}
+}
+
+// TestPromptStopsWhenThereIsNoAnswer covers input that runs out. A read that
+// gives nothing left the answer unset and asked again, so the prompt spun
+// until the process was killed. An answer that never comes is a no.
+func TestPromptStopsWhenThereIsNoAnswer(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{name: "nothing at all", input: ""},
+		{name: "an unusable answer and then nothing", input: "maybe\n"},
+		{name: "a line with no newline to close it", input: "y"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if askToAddHost(t, tc.input) {
+				t.Error("prompt accepted the host key without being told yes")
+			}
+		})
+	}
+}
+
+// TestPromptAnswers covers the answers a person can give.
+func TestPromptAnswers(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "yes", input: "yes\n", want: true},
+		{name: "no", input: "no\n", want: false},
+		{name: "asked again after an unusable answer", input: "maybe\nyes\n", want: true},
+		{name: "trailing blanks", input: "yes  \n", want: true},
+		{name: "declined after an unusable answer", input: "sure\nno\n", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := askToAddHost(t, tc.input); got != tc.want {
+				t.Errorf("answer to %q was %t, want %t", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/vault/proxy_known_hosts_file_test.go
+++ b/pkg/vault/proxy_known_hosts_file_test.go
@@ -1,0 +1,121 @@
+// Reaching a host through the SSH proxy on a machine that has no known_hosts
+// file yet.
+package vault
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestKnownHostsFileIsCreatedWhenAbsent covers the first connection from a
+// machine that has never run ssh. Host keys are checked by reading the file,
+// and a file that is not there cannot be read, so the connection used to fail
+// before it was attempted.
+func TestKnownHostsFileIsCreatedWhenAbsent(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), ".ssh", "known_hosts")
+
+	if err := ensureKnownHostsFile(path); err != nil {
+		t.Fatalf("ensureKnownHostsFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("known_hosts was not created: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Errorf("new known_hosts holds %d bytes, want none", info.Size())
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("new known_hosts is mode %04o, want 0600", perm)
+	}
+
+	dir, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("directory for known_hosts was not created: %v", err)
+	}
+	if perm := dir.Mode().Perm(); perm != 0700 {
+		t.Errorf("directory for known_hosts is mode %04o, want 0700", perm)
+	}
+
+	//The point of creating it is that the host key check can now be set up.
+	if _, err := knownHostsPromptCallback(path); err != nil {
+		t.Errorf("host key checking could not be set up against the new file: %v", err)
+	}
+}
+
+// TestKnownHostsFileIsLeftAloneWhenPresent checks that an existing file keeps
+// its entries. Emptying it would throw away every host a person has trusted.
+func TestKnownHostsFileIsLeftAloneWhenPresent(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	writeKnownHostsFixture(t, path, "already.known:22", makeEd25519PublicKey(t))
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	if err := ensureKnownHostsFile(path); err != nil {
+		t.Fatalf("ensureKnownHostsFile: %v", err)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Errorf("known_hosts was changed\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+// TestStartSSHTunnelCreatesKnownHostsFile checks the same through the caller.
+// The tunnel cannot be made here -- the private key is not one -- but the file
+// has to exist by the time that is the reason it fails, because a missing file
+// used to be the reason instead.
+func TestStartSSHTunnelCreatesKnownHostsFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), ".ssh", "known_hosts")
+
+	_, err := StartSSHTunnel(SOCKS5SSHConfig{
+		Host:           "127.0.0.1:22",
+		User:           "someone",
+		PrivateKey:     []byte("this is not a private key"),
+		KnownHostsFile: path,
+	})
+	if err == nil {
+		t.Fatal("expected the unusable private key to be refused")
+	}
+	if !strings.Contains(err.Error(), "private key") {
+		t.Errorf("tunnel failed for some reason other than the key: %v", err)
+	}
+
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Errorf("known_hosts was not created: %v", statErr)
+	}
+}
+
+// TestKnownHostsFileIsNotCreatedWhenChecksAreOff covers the case where host
+// key validation is turned off: there is nothing to read the file for, so
+// nothing should be written to disk.
+func TestKnownHostsFileIsNotCreatedWhenChecksAreOff(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), ".ssh", "known_hosts")
+
+	_, err := StartSSHTunnel(SOCKS5SSHConfig{
+		Host:                  "127.0.0.1:22",
+		User:                  "someone",
+		PrivateKey:            []byte("this is not a private key"),
+		KnownHostsFile:        path,
+		SkipHostKeyValidation: true,
+	})
+	if err == nil {
+		t.Fatal("expected the unusable private key to be refused")
+	}
+
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("known_hosts was created although host keys are not being checked: %v", statErr)
+	}
+}

--- a/pkg/vault/proxy_socks5_url_test.go
+++ b/pkg/vault/proxy_socks5_url_test.go
@@ -1,0 +1,131 @@
+// The ssh+socks5:// proxy URL: which parts of it name the private key, and
+// what is said when they do not.
+package vault
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// openHelper runs openSOCKS5Helper against a throwaway known_hosts file, so a
+// test never reads or writes the one belonging to whoever is running it.
+func openHelper(t *testing.T, proxyURL string) (string, error) {
+	t.Helper()
+	return openSOCKS5Helper(proxyURL, filepath.Join(t.TempDir(), "known_hosts"), false)
+}
+
+// TestSOCKS5URLNamesThePrivateKey checks the two ways of naming the key, both
+// of which the README offers. Neither can connect here -- there is no host to
+// connect to -- but the path each one produces is in the error, which is how
+// we can see that the right part of the URL was read.
+func TestSOCKS5URLNamesThePrivateKey(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "as the path",
+			url:  "ssh+socks5://you@bastion.example.com/keys/id_ed25519",
+			want: "/keys/id_ed25519",
+		},
+		{
+			name: "as a query parameter",
+			url:  "ssh+socks5://you@bastion.example.com?private-key=keys/id_ed25519",
+			want: "keys/id_ed25519",
+		},
+		{
+			name: "alongside a port",
+			url:  "ssh+socks5://you@bastion.example.com:2222/keys/id_ed25519",
+			want: "/keys/id_ed25519",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := openHelper(t, tc.url)
+			if err == nil {
+				t.Fatal("expected the missing key file to be reported")
+			}
+			if !strings.Contains(err.Error(), "could not read private key file") {
+				t.Fatalf("failed before reading the key: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("looked for the key somewhere other than %s: %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// TestSOCKS5URLRefusals checks what is said about a URL that cannot be used.
+func TestSOCKS5URLRefusals(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "no user to log in as",
+			url:  "ssh+socks5://bastion.example.com/keys/id_ed25519",
+			want: "no user provided",
+		},
+		{
+			name: "no key at all",
+			url:  "ssh+socks5://you@bastion.example.com",
+			want: "no private key path provided",
+		},
+		{
+			name: "a bare host with a trailing slash names no key",
+			url:  "ssh+socks5://you@bastion.example.com/",
+			want: "no private key path provided",
+		},
+		{
+			name: "a key named both ways at once",
+			url:  "ssh+socks5://you@bastion.example.com/keys/a?private-key=keys/b",
+			want: "more than one private key",
+		},
+		{
+			name: "two keys named as query parameters",
+			url:  "ssh+socks5://you@bastion.example.com?private-key=keys/a&private-key=keys/b",
+			want: "more than one private key",
+		},
+		{
+			name: "not a URL",
+			url:  "ssh+socks5://you@bastion.example.com:port/keys/a",
+			want: "could not parse proxy URL",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := openHelper(t, tc.url)
+			if err == nil {
+				t.Fatalf("%s was accepted", tc.url)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error for %s does not mention %q: %v", tc.url, tc.want, err)
+			}
+		})
+	}
+}
+
+// TestSOCKS5URLKeyMustBeUsable checks that a key file which is not a key is
+// reported as such, rather than as a failure to reach the host.
+func TestSOCKS5URLKeyMustBeUsable(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("this is not a private key\n"), 0600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	_, err := openHelper(t, "ssh+socks5://you@bastion.example.com?private-key="+keyPath)
+	if err == nil {
+		t.Fatal("expected the unusable key to be refused")
+	}
+	if !strings.Contains(err.Error(), "signer for private key") {
+		t.Errorf("unusable key reported as something else: %v", err)
+	}
+}

--- a/pkg/vault/proxy_tunnel_test.go
+++ b/pkg/vault/proxy_tunnel_test.go
@@ -1,0 +1,267 @@
+// The SSH proxy end to end: a real SSH handshake against a real server, the
+// host key checked against a real known_hosts file, and traffic carried
+// through the SOCKS5 proxy that the tunnel is there to provide.
+package vault
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/net/proxy"
+)
+
+// makeSSHKeyPair returns a signer and the PEM the same key is written as, for
+// use as either a host key or a login key.
+func makeSSHKeyPair(t *testing.T) (ssh.Signer, []byte) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey: %v", err)
+	}
+	block, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		t.Fatalf("ssh.MarshalPrivateKey: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatalf("ssh.NewSignerFromKey: %v", err)
+	}
+	return signer, pem.EncodeToMemory(block)
+}
+
+// startEchoServer listens on a loopback port and sends back whatever it is
+// sent. It stands in for the Vault that the tunnel exists to reach.
+func startEchoServer(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, aerr := listener.Accept()
+			if aerr != nil {
+				return
+			}
+			go func() {
+				defer func() { _ = conn.Close() }()
+				_, _ = io.Copy(conn, conn)
+			}()
+		}
+	}()
+
+	return listener.Addr().String()
+}
+
+// startFakeSSHServer listens on a loopback port, accepts any login, and
+// forwards the direct-tcpip channels that a SOCKS5 proxy opens through it. It
+// returns the address it is listening on and the public half of its host key.
+func startFakeSSHServer(t *testing.T) (string, ssh.PublicKey) {
+	t.Helper()
+	hostSigner, _ := makeSSHKeyPair(t)
+
+	config := &ssh.ServerConfig{
+		PublicKeyCallback: func(ssh.ConnMetadata, ssh.PublicKey) (*ssh.Permissions, error) {
+			return &ssh.Permissions{}, nil
+		},
+	}
+	config.AddHostKey(hostSigner)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, aerr := listener.Accept()
+			if aerr != nil {
+				return
+			}
+			go serveFakeSSH(conn, config)
+		}
+	}()
+
+	return listener.Addr().String(), hostSigner.PublicKey()
+}
+
+// serveFakeSSH completes one SSH handshake and forwards its channels.
+func serveFakeSSH(conn net.Conn, config *ssh.ServerConfig) {
+	serverConn, channels, requests, err := ssh.NewServerConn(conn, config)
+	if err != nil {
+		_ = conn.Close()
+		return
+	}
+	defer func() { _ = serverConn.Close() }()
+
+	go ssh.DiscardRequests(requests)
+
+	for newChannel := range channels {
+		if newChannel.ChannelType() != "direct-tcpip" {
+			_ = newChannel.Reject(ssh.UnknownChannelType, "only direct-tcpip is forwarded")
+			continue
+		}
+		go forwardDirectTCPIP(newChannel)
+	}
+}
+
+// forwardDirectTCPIP dials where the channel asks and joins the two together,
+// which is what an SSH server does for a tunnel.
+func forwardDirectTCPIP(newChannel ssh.NewChannel) {
+	var payload struct {
+		DestAddr string
+		DestPort uint32
+		SrcAddr  string
+		SrcPort  uint32
+	}
+	if err := ssh.Unmarshal(newChannel.ExtraData(), &payload); err != nil {
+		_ = newChannel.Reject(ssh.ConnectionFailed, "unreadable direct-tcpip request")
+		return
+	}
+
+	target, err := net.Dial("tcp", net.JoinHostPort(payload.DestAddr, strconv.Itoa(int(payload.DestPort))))
+	if err != nil {
+		_ = newChannel.Reject(ssh.ConnectionFailed, err.Error())
+		return
+	}
+
+	channel, channelRequests, err := newChannel.Accept()
+	if err != nil {
+		_ = target.Close()
+		return
+	}
+	go ssh.DiscardRequests(channelRequests)
+
+	go func() {
+		defer func() { _ = target.Close() }()
+		_, _ = io.Copy(target, channel)
+	}()
+	go func() {
+		defer func() { _ = channel.Close() }()
+		_, _ = io.Copy(channel, target)
+	}()
+}
+
+// TestTunnelCarriesTrafficForAKnownHost is the whole path: the host key is
+// already trusted, so the tunnel opens, a SOCKS5 proxy comes up in front of
+// it, and what is sent through the proxy reaches the far side.
+func TestTunnelCarriesTrafficForAKnownHost(t *testing.T) {
+	t.Parallel()
+	sshAddr, hostKey := startFakeSSHServer(t)
+	echoAddr := startEchoServer(t)
+
+	knownHosts := filepath.Join(t.TempDir(), "known_hosts")
+	writeKnownHostsFixture(t, knownHosts, sshAddr, hostKey)
+
+	_, loginKey := makeSSHKeyPair(t)
+	client, err := StartSSHTunnel(SOCKS5SSHConfig{
+		Host:           sshAddr,
+		User:           "someone",
+		PrivateKey:     loginKey,
+		KnownHostsFile: knownHosts,
+	})
+	if err != nil {
+		t.Fatalf("StartSSHTunnel: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	socksAddr, closer, err := StartSOCKS5Server(client.Dial)
+	if err != nil {
+		t.Fatalf("StartSOCKS5Server: %v", err)
+	}
+	defer func() { _ = closer() }()
+
+	dialer, err := proxy.SOCKS5("tcp", socksAddr, nil, proxy.Direct)
+	if err != nil {
+		t.Fatalf("proxy.SOCKS5: %v", err)
+	}
+	conn, err := dialer.Dial("tcp", echoAddr)
+	if err != nil {
+		t.Fatalf("dial through the tunnel: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	const sent = "through the tunnel\n"
+	if _, err := io.WriteString(conn, sent); err != nil {
+		t.Fatalf("write through the tunnel: %v", err)
+	}
+	received := make([]byte, len(sent))
+	if _, err := io.ReadFull(conn, received); err != nil {
+		t.Fatalf("read back through the tunnel: %v", err)
+	}
+	if string(received) != sent {
+		t.Errorf("got %q back through the tunnel, sent %q", received, sent)
+	}
+}
+
+// TestTunnelRefusesAnUnknownHostWithNoOneToAsk covers a script or a CI job:
+// the host is not in known_hosts and there is nobody to accept it, so the
+// tunnel must be refused rather than opened or waited on.
+func TestTunnelRefusesAnUnknownHostWithNoOneToAsk(t *testing.T) {
+	t.Parallel()
+	sshAddr, _ := startFakeSSHServer(t)
+
+	knownHosts := filepath.Join(t.TempDir(), ".ssh", "known_hosts")
+	_, loginKey := makeSSHKeyPair(t)
+
+	_, err := StartSSHTunnel(SOCKS5SSHConfig{
+		Host:           sshAddr,
+		User:           "someone",
+		PrivateKey:     loginKey,
+		KnownHostsFile: knownHosts,
+	})
+	if err == nil {
+		t.Fatal("tunnel opened to a host whose key was never accepted")
+	}
+	if !strings.Contains(err.Error(), "host key verification failed") {
+		t.Errorf("unknown host refused for some other reason: %v", err)
+	}
+
+	//The file is made on the way past, so the next run has somewhere to record
+	// the key once it is accepted.
+	if _, statErr := os.Stat(knownHosts); statErr != nil {
+		t.Errorf("known_hosts was not created: %v", statErr)
+	}
+}
+
+// TestTunnelRefusesAHostWhoseKeyChanged covers the key on file disagreeing
+// with the key offered. This is the case the warning is written for, so the
+// warning has to be what comes back.
+func TestTunnelRefusesAHostWhoseKeyChanged(t *testing.T) {
+	t.Parallel()
+	sshAddr, _ := startFakeSSHServer(t)
+
+	//A key for this host that the host does not have.
+	strangerSigner, _ := makeSSHKeyPair(t)
+	knownHosts := filepath.Join(t.TempDir(), "known_hosts")
+	writeKnownHostsFixture(t, knownHosts, sshAddr, strangerSigner.PublicKey())
+
+	_, loginKey := makeSSHKeyPair(t)
+	_, err := StartSSHTunnel(SOCKS5SSHConfig{
+		Host:           sshAddr,
+		User:           "someone",
+		PrivateKey:     loginKey,
+		KnownHostsFile: knownHosts,
+	})
+	if err == nil {
+		t.Fatal("tunnel opened to a host whose key had changed")
+	}
+	if !strings.Contains(err.Error(), "REMOTE HOST IDENTIFICATION HAS CHANGED") {
+		t.Fatalf("changed host key did not raise the warning: %v", err)
+	}
+	if _, line := offendingKey(t, err); line != 1 {
+		t.Errorf("warning names known_hosts line %d; the only entry is on line 1", line)
+	}
+}


### PR DESCRIPTION
Three fixes to the host key checking behind `safe`'s SSH proxy, which is how
a Vault that is only reachable from inside a network gets reached. One of them
names the wrong line of `known_hosts` in the warning about a changed host key,
one spins forever where there is nobody to answer a prompt, and one stops the
proxy working at all on a machine that has never run `ssh`.

None of `StartSSHTunnel`, `StartSOCKS5Server`, `openSOCKS5Helper`, or
`promptAddNewKnownHost` had any coverage, so all three shipped unnoticed.

## The changed-host-key warning named the wrong line

A host with more than one key in `known_hosts` — an RSA entry and an ed25519
entry, which is ordinary — presents one of them. When it does not match, safe
prints the `ssh` warning, and the reader acts on the line it names:

```
Offending ssh-ed25519 key in /home/you/.ssh/known_hosts:1
```

The line was chosen by a loop that compared the candidate it had already
picked against the offered key, rather than the entry it was looking at. So it
took the last entry when the first happened to match the offered type, and the
first entry when it did not — the wrong one either way:

```
before:  known_hosts line 1 = ssh-rsa, line 2 = ssh-ed25519
         host offers a different ssh-ed25519 key

         Offending ssh-ed25519 key in known_hosts:1     line 1 holds RSA

         with the entries the other way round:
         Offending ssh-ed25519 key in known_hosts:2     line 2 holds RSA

after:   the line named is the ed25519 entry, wherever it is
```

The type in that sentence is now the type of the key written on the line, so
where the host offers a type that is not on file at all the two agree.

Deleting the line safe pointed at removed a host key that was fine and left
the conflicting entry in place, so the next connection raised the same warning
and the reader had no reason to trust that the second one meant anything more
than the first.

## The unknown-host prompt could not be ended

Meeting a host for the first time, safe asks whether to trust it. Any answer
that was not `yes` or `no` meant ask again, and a read that returned nothing
counted as such an answer:

```
before:  $ safe get secret/x < /dev/null      (SAFE_ALL_PROXY=ssh+socks5://...)
         The authenticity of host '...' can't be established.
         Are you sure you want to continue connecting (yes/no)? Please type
         'yes' or 'no': Please type 'yes' or 'no': Please type 'yes' or ...
         7MB/s to stderr, until killed

after:   (one prompt, then)
         !! could not start SSH tunnel: ssh: handshake failed: host key
            verification failed
         (exit 1)
```

The prompt is offered when **stderr** is a terminal, which says nothing about
whether **stdin** can answer — so a script or a CI job with a terminal
attached to its output and no input hit this. A read that fails is now taken
as a refusal, which is what `ssh` does with `StrictHostKeyChecking=ask` and no
input.

The answer now comes through the same reader the rest of safe prompts through,
rather than a direct `fmt.Scanln` on the file, so a line buffered by an earlier
prompt is no longer skipped past.

## A missing known_hosts stopped the proxy entirely

Host keys are checked by reading `known_hosts`. A file that does not exist
cannot be read, so on a machine that has never run `ssh` — a fresh container,
a CI image — the proxy could not be used at all:

```
before:  !! could not start SSH tunnel: error opening known_hosts file at
            `/home/you/.ssh/known_hosts': could not handle known hosts file:
            open /home/you/.ssh/known_hosts: no such file or directory

after:   The authenticity of host 'bastion.example.com:22 (10.0.0.4:22)'
         can't be established.
         ssh-ed25519 key fingerprint is SHA256:...
         Are you sure you want to continue connecting (yes/no)?
```

The advice in that error was to add the correct host key to a file that
nothing was ever going to create. safe now creates it empty, and the directory
holding it, as `ssh` does on first use — mode 0600 and 0700, with `O_EXCL` so
a file that appears in between is not emptied. Nothing is created where host
key checking is turned off, since the file is not read in that case.

## Behaviour otherwise

Unchanged. A host already in `known_hosts` connects, a `yes` writes the entry
and connects, a `no` refuses, and an existing `known_hosts` keeps its contents
byte for byte.

## Tests

`proxy.go` had four functions at zero coverage, including everything that
opens the tunnel. There are now tests that stand up an SSH server on loopback,
log into it, run the SOCKS5 proxy in front of it, and carry bytes to an echo
server on the far side — so the host key path is exercised against a real
handshake rather than a stub.

| function | before | after |
|---|---|---|
| `StartSSHTunnel` | 0.0% | 70.6% |
| `StartSOCKS5Server` | 0.0% | 80.0% |
| `openSOCKS5Helper` | 0.0% | 83.3% |
| `promptAddNewKnownHost` | 0.0% | 100.0% |
| `noopDialContext` | 0.0% | 100.0% |
| `knownHostsPromptCallback` | 68.2% | 78.3% |
| `ensureKnownHostsFile` | new | 57.1% |

Twelve mutations, each reverted after, and each one caught:

| mutation | tests failing |
|---|---|
| blame the first known_hosts entry always | 2 |
| blame the last matching entry | 1 |
| name the offending line with the offered key type | 1 |
| keep asking when the answer cannot be read | 11 |
| take an unreadable answer as yes | 4 |
| never create the known_hosts file | 3 |
| create the known_hosts file world readable | 1 |
| create the known_hosts directory world readable | 1 |
| empty an existing known_hosts file | 3 |
| create known_hosts even when checks are off | 1 |
| read the private key from the path only | 6 |
| take the first key when several are named | 3 |

`make check` and `go test -race ./...` pass, and each of the six commits
builds and passes on its own.

## Docs

The proxy variables, the `ssh+socks5://` URL, and the host key checking around
it were not written down anywhere. README has a Proxies section covering both
ways of naming the private key, `SAFE_KNOWN_HOSTS_FILE`, what happens to an
unknown or changed host key, and what `SAFE_SKIP_HOST_KEY_VALIDATION` gives
up.
