### PR TITLE
Fix what safe delete does with -r and --all

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,21 @@ they apply only when the key is the whole secret; otherwise the key would
 stay behind in the versions already written, and safe says so rather than
 writing a new version and calling it done.
 
+`-a` works on every version there is, so a path that names one version
+asks for two different things at once, and safe refuses the pair:
+
+```
+safe delete -a secret/db^3     # refused; drop the -a or drop the ^3
+```
+
+`-r` (`--recurse`) removes a whole tree of secrets, and refuses in the
+same way a path that names a key or a version, neither of which is a
+tree. `-f` (`--force`) skips the confirmation `-r` asks for, and carries
+on past a path that holds no secret.
+
+Every path given is read against the flags before any of them is
+removed, so a refusal on the last one leaves the rest where they were.
+
 ### move oldpath newpath
 
 Move a secret from `oldpath` to `newpath`, a rename of sorts.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -841,8 +841,11 @@ each match is printed as path:key instead.
 		Description: `
 -d (--destroy) will cause KV v2 secrets to be destroyed instead of
 being marked as deleted. For KV v1 backends, this would do nothing.
--a (--all) will delete (or destroy) all versions of the secret instead
-of just the specified (or latest if unspecified) version.
+-a (--all) will delete (or destroy) every version of the secret instead
+of the latest one.
+-r (--recurse) removes a whole tree of secrets, asking first unless
+-f (--force) is given. -f also carries on past a path that holds no
+secret.
 
 A path may name a single key, and may name a version as well. Removing
 a key writes what is left of the secret as a new version; a version
@@ -851,11 +854,17 @@ version therefore only works when that version holds nothing but the
 key, and what goes is the version itself. Anything else is refused —
 safe copy is the command that reads a key out of an old version.
 
-Both flags above work on whole versions, so with a key they apply only
-when the key is the whole secret. Where the secret holds other keys the
-key would stay behind in the versions already written, and the request
-is refused rather than answered with a new version that leaves the old
+-d and -a work on whole versions, so with a key they apply only when
+the key is the whole secret. Where the secret holds other keys the key
+would stay behind in the versions already written, and the request is
+refused rather than answered with a new version that leaves the old
 value where it was.
+
+-a works on every version there is, and -r on a tree of secrets, so
+neither can be given a path that names one version, nor -r a path that
+names a key. Each pair asks for two different things at once and is
+refused. Every path given is read this way before any of them is
+removed, so a refusal on the last one leaves the rest where they were.
 `}, c.cmdDelete)
 
 	r.Dispatch("undelete", &Help{

--- a/internal/cli/delete_all_version_test.go
+++ b/internal/cli/delete_all_version_test.go
@@ -1,0 +1,149 @@
+package cli
+
+// --all works on every version of a secret, so a path that also names one
+// version asks for two different things at once. What safe did with that pair
+// was take the --all and drop the version.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDeletingEveryVersionRefusesANamedVersion(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+		map[string]string{"password": "three"},
+	)
+
+	c := newTestCLI(t)
+	c.opt.Delete.All = true
+	err := c.cmdDelete("delete", "secret/app^2")
+	if err == nil {
+		t.Fatal("expected a refusal deleting every version of a path that names version 2, got nil")
+	}
+	if !strings.Contains(err.Error(), "2") {
+		t.Errorf("error %q should name the version", err)
+	}
+
+	got := fv.versionStates("secret/app")
+	want := []string{"alive", "alive", "alive"}
+	if !equalStrings(got, want) {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+}
+
+func TestDestroyingEveryVersionRefusesANamedVersion(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+		map[string]string{"password": "three"},
+	)
+
+	c := newTestCLI(t)
+	c.opt.Delete.Destroy = true
+	c.opt.Delete.All = true
+	err := c.cmdDelete("delete", "secret/app^2")
+	if err == nil {
+		t.Fatal("expected a refusal destroying every version of a path that names version 2, got nil")
+	}
+
+	//A destroy cannot be taken back, so this one has to be refused before it
+	// reaches Vault rather than reported afterwards.
+	got := fv.versionStates("secret/app")
+	want := []string{"alive", "alive", "alive"}
+	if !equalStrings(got, want) {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+}
+
+// The version named need not be one that was ever written. Without --all safe
+// says so and stops; with it, the whole secret went.
+func TestDestroyingEveryVersionRefusesAVersionThatNeverExisted(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+
+	c := newTestCLI(t)
+	c.opt.Delete.Destroy = true
+	c.opt.Delete.All = true
+	if err := c.cmdDelete("delete", "secret/app^99"); err == nil {
+		t.Fatal("expected a refusal, got nil")
+	}
+
+	if states := fv.versionStates("secret/app"); len(states) != 2 {
+		t.Errorf("version states = %v, want both versions still there", states)
+	}
+}
+
+// Naming no version leaves --all meaning what it always meant.
+func TestDeletingEveryVersionOfAWholeSecret(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+
+	c := newTestCLI(t)
+	c.opt.Delete.All = true
+	if err := c.cmdDelete("delete", "secret/app"); err != nil {
+		t.Fatalf("cmdDelete --all: %v", err)
+	}
+
+	got := fv.versionStates("secret/app")
+	want := []string{"deleted", "deleted"}
+	if !equalStrings(got, want) {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+}
+
+func TestDestroyingEveryVersionOfAWholeSecret(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+
+	c := newTestCLI(t)
+	c.opt.Delete.Destroy = true
+	c.opt.Delete.All = true
+	if err := c.cmdDelete("delete", "secret/app"); err != nil {
+		t.Fatalf("cmdDelete --destroy --all: %v", err)
+	}
+
+	if states := fv.versionStates("secret/app"); len(states) != 0 {
+		t.Errorf("version states = %v, want the secret gone", states)
+	}
+}
+
+// One version at a time is what a named version has always meant, and it goes
+// on meaning it.
+func TestDeletingOneNamedVersionWithoutAll(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+		map[string]string{"password": "three"},
+	)
+
+	c := newTestCLI(t)
+	if err := c.cmdDelete("delete", "secret/app^2"); err != nil {
+		t.Fatalf("cmdDelete: %v", err)
+	}
+
+	got := fv.versionStates("secret/app")
+	want := []string{"alive", "deleted", "alive"}
+	if !equalStrings(got, want) {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+}

--- a/internal/cli/delete_arg_check_test.go
+++ b/internal/cli/delete_arg_check_test.go
@@ -1,0 +1,79 @@
+package cli
+
+// safe delete takes any number of paths. A refusal on the third of them used
+// to arrive with the first two already gone.
+
+import (
+	"testing"
+)
+
+func TestNoPathGoesWhenAnotherIsRefused(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(c *CLI)
+		args  []string
+	}{
+		{
+			name:  "a key named alongside -r",
+			setup: func(c *CLI) { c.opt.Delete.Recurse = true; c.opt.Delete.Force = true },
+			args:  []string{"secret/keep", "secret/app:password"},
+		},
+		{
+			name:  "a version named alongside -r",
+			setup: func(c *CLI) { c.opt.Delete.Recurse = true; c.opt.Delete.Force = true },
+			args:  []string{"secret/keep", "secret/app^1"},
+		},
+		{
+			name:  "a version named alongside --all",
+			setup: func(c *CLI) { c.opt.Delete.All = true },
+			args:  []string{"secret/keep", "secret/app^1"},
+		},
+		{
+			name:  "a version named alongside --destroy --all",
+			setup: func(c *CLI) { c.opt.Delete.Destroy = true; c.opt.Delete.All = true },
+			args:  []string{"secret/keep", "secret/app^1"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			fv := newCLIFakeV2(t)
+			fv.setV2("secret/keep", map[string]string{"password": "keep me"})
+			fv.setV2("secret/app", map[string]string{"password": "one"})
+
+			c := newTestCLI(t)
+			tc.setup(c)
+			if err := c.cmdDelete("delete", tc.args...); err == nil {
+				t.Fatal("expected a refusal, got nil")
+			}
+
+			got := fv.versionStates("secret/keep")
+			want := []string{"alive"}
+			if !equalStrings(got, want) {
+				t.Errorf("version states of secret/keep = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// Paths that are all fine still all go.
+func TestEveryPathGoesWhenNoneIsRefused(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/one", map[string]string{"password": "a"})
+	fv.setV2("secret/two", map[string]string{"password": "b"})
+
+	c := newTestCLI(t)
+	if err := c.cmdDelete("delete", "secret/one", "secret/two"); err != nil {
+		t.Fatalf("cmdDelete: %v", err)
+	}
+
+	for _, path := range []string{"secret/one", "secret/two"} {
+		got := fv.versionStates(path)
+		want := []string{"deleted"}
+		if !equalStrings(got, want) {
+			t.Errorf("version states of %s = %v, want %v", path, got, want)
+		}
+	}
+}

--- a/internal/cli/delete_recurse_guard_test.go
+++ b/internal/cli/delete_recurse_guard_test.go
@@ -1,0 +1,95 @@
+package cli
+
+// -r deletes a tree of secrets. A key or a version names something inside one
+// secret, which is not a tree, so the two cannot be asked for together.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRecursiveDeleteRefusesAKeyPath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app", map[string]string{"password": "one", "username": "admin"})
+
+	c := newTestCLI(t)
+	c.opt.Delete.Recurse = true
+	c.opt.Delete.Force = true
+	err := c.cmdDelete("delete", "secret/app:password")
+	if err == nil {
+		t.Fatal("expected a refusal deleting a key recursively, got nil")
+	}
+	if !strings.Contains(err.Error(), "password") {
+		t.Errorf("error %q should name the key", err)
+	}
+
+	//Quietly deleting the one key is not what -r asked for, and the reader of
+	// the exit code has no way to tell the two apart.
+	assertVersionData(t, fv, "secret/app", 1, map[string]string{"password": "one", "username": "admin"})
+	if states := fv.versionStates("secret/app"); len(states) != 1 {
+		t.Errorf("version states = %v, want the one version untouched", states)
+	}
+}
+
+func TestRecursiveDeleteRefusesAVersionPath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+
+	c := newTestCLI(t)
+	c.opt.Delete.Recurse = true
+	c.opt.Delete.Force = true
+	err := c.cmdDelete("delete", "secret/app^1")
+	if err == nil {
+		t.Fatal("expected a refusal deleting a version recursively, got nil")
+	}
+	if !strings.Contains(err.Error(), "1") {
+		t.Errorf("error %q should name the version", err)
+	}
+
+	got := fv.versionStates("secret/app")
+	want := []string{"alive", "alive"}
+	if !equalStrings(got, want) {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+}
+
+// A path that names neither still takes the whole tree.
+func TestRecursiveDeleteTakesTheTree(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app/one", map[string]string{"password": "a"})
+	fv.setV2("secret/app/two", map[string]string{"password": "b"})
+
+	c := newTestCLI(t)
+	c.opt.Delete.Recurse = true
+	c.opt.Delete.Force = true
+	if err := c.cmdDelete("delete", "secret/app"); err != nil {
+		t.Fatalf("cmdDelete -r: %v", err)
+	}
+
+	for _, path := range []string{"secret/app/one", "secret/app/two"} {
+		got := fv.versionStates(path)
+		want := []string{"deleted"}
+		if !equalStrings(got, want) {
+			t.Errorf("version states of %s = %v, want %v", path, got, want)
+		}
+	}
+}
+
+// Without -r a key path goes on meaning the key.
+func TestDeletingAKeyWithoutRecurse(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFakeV2(t)
+	fv.setV2("secret/app", map[string]string{"password": "one", "username": "admin"})
+
+	c := newTestCLI(t)
+	if err := c.cmdDelete("delete", "secret/app:password"); err != nil {
+		t.Fatalf("cmdDelete: %v", err)
+	}
+	assertVersionData(t, fv, "secret/app", 2, map[string]string{"username": "admin"})
+}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -594,10 +594,21 @@ func (c *CLI) cmdDelete(command string, args ...string) error {
 	}
 
 	for _, path := range args {
-		_, key, version := vault.ParsePath(path)
+		secretPath, key, version := vault.ParsePath(path)
 
-		//Ignore -r if path has a version or key because that seems like a mistake
-		if opt.Delete.Recurse && key == "" && version == 0 {
+		//-r takes a tree of secrets; a key or a version names one thing inside
+		// one secret. Asking for both was read as a mistake and answered by
+		// dropping the -r, so `safe rm -r secret/app:password' deleted the one
+		// key and `safe rm -r secret/app^2' the one version, both reporting the
+		// success of something nobody asked for.
+		if opt.Delete.Recurse {
+			switch {
+			case key != "":
+				return fmt.Errorf("cannot %s `%s' recursively: -r takes a tree of secrets, and the path names the key %s", verb, secretPath, key)
+			case version != 0:
+				return fmt.Errorf("cannot %s `%s' recursively: -r takes a tree of secrets, and the path names version %d", verb, secretPath, version)
+			}
+
 			if !opt.Delete.Force && !recursively(verb, path) {
 				continue /* skip this command, process the next */
 			}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -575,6 +575,32 @@ func (c *CLI) cmdValues(command string, args ...string) error {
 	return err
 }
 
+// checkDeletePath reads one argument to safe delete against the options it
+// arrived with, and says so when the two ask for different things. It makes no
+// request, so the whole argument list can go past it first.
+func checkDeletePath(path, verb string, opt *Options) error {
+	secretPath, key, version := vault.ParsePath(path)
+
+	//-r takes a tree of secrets; a key or a version names one thing inside one
+	// secret. Asking for both was read as a mistake and answered by dropping
+	// the -r, so `safe rm -r secret/app:password' deleted the one key and
+	// `safe rm -r secret/app^2' the one version, each reporting the success of
+	// something nobody asked for.
+	if opt.Delete.Recurse {
+		switch {
+		case key != "":
+			return fmt.Errorf("cannot %s `%s' recursively: -r takes a tree of secrets, and the path names the key %s", verb, secretPath, key)
+		case version != 0:
+			return fmt.Errorf("cannot %s `%s' recursively: -r takes a tree of secrets, and the path names version %d", verb, secretPath, version)
+		}
+	}
+
+	return vault.CheckDeletePath(path, vault.DeleteOpts{
+		Destroy: opt.Delete.Destroy,
+		All:     opt.Delete.All,
+	})
+}
+
 func (c *CLI) cmdDelete(command string, args ...string) error {
 	opt := c.opt
 	r := c.r
@@ -586,29 +612,25 @@ func (c *CLI) cmdDelete(command string, args ...string) error {
 	if len(args) < 1 {
 		return r.Usage("delete")
 	}
-	v := connect(true)
-
 	verb := "delete"
 	if opt.Delete.Destroy {
 		verb = "destroy"
 	}
 
+	//Every path is read before any of them is deleted, and before anything is
+	// connected to. A refusal on the third argument used to arrive with the
+	// first two already gone, and a destroy cannot be taken back to try the
+	// command again.
 	for _, path := range args {
-		secretPath, key, version := vault.ParsePath(path)
+		if err := checkDeletePath(path, verb, opt); err != nil {
+			return err
+		}
+	}
 
-		//-r takes a tree of secrets; a key or a version names one thing inside
-		// one secret. Asking for both was read as a mistake and answered by
-		// dropping the -r, so `safe rm -r secret/app:password' deleted the one
-		// key and `safe rm -r secret/app^2' the one version, both reporting the
-		// success of something nobody asked for.
+	v := connect(true)
+
+	for _, path := range args {
 		if opt.Delete.Recurse {
-			switch {
-			case key != "":
-				return fmt.Errorf("cannot %s `%s' recursively: -r takes a tree of secrets, and the path names the key %s", verb, secretPath, key)
-			case version != 0:
-				return fmt.Errorf("cannot %s `%s' recursively: -r takes a tree of secrets, and the path names version %d", verb, secretPath, version)
-			}
-
 			if !opt.Delete.Force && !recursively(verb, path) {
 				continue /* skip this command, process the next */
 			}

--- a/pkg/vault/delete_all_version_test.go
+++ b/pkg/vault/delete_all_version_test.go
@@ -1,0 +1,57 @@
+package vault_test
+
+// Delete refuses --all together with a version named on the path. The refusal
+// belongs here rather than in the command, because deleteEntireSecret has no
+// way to honour both and every caller of Delete would otherwise have to know
+// that.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+func TestDeleteRefusesAllWithANamedVersion(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/app", map[string]string{"password": "one"})
+
+	for _, opts := range []vault.DeleteOpts{
+		{All: true},
+		{All: true, Destroy: true},
+	} {
+		err := v.Delete("secret/app^2", opts)
+		if err == nil {
+			t.Fatalf("Delete(%+v) on a path naming a version returned nil, want a refusal", opts)
+		}
+		//Said so that it is clear which of the two the caller has to give up;
+		// a plain "no version 2 exists" would be true of the v1 mount here
+		// and would say nothing about the pair.
+		for _, want := range []string{"secret/app", "--all", "2"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q should mention %q", err, want)
+			}
+		}
+		//Nothing is read or written before the refusal, so the secret is
+		// still whole.
+		if _, err := v.Read("secret/app"); err != nil {
+			t.Fatalf("reading the secret afterwards: %v", err)
+		}
+	}
+}
+
+// An escaped caret is part of the name rather than a version, and a secret
+// named that way deletes like any other.
+func TestDeleteAllAcceptsAnEscapedCaret(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/od^d", map[string]string{"password": "one"})
+
+	if err := v.Delete(`secret/od\^d`, vault.DeleteOpts{All: true}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := v.Read(`secret/od\^d`); !vault.IsNotFound(err) {
+		t.Fatalf("reading the secret afterwards: %v, want not found", err)
+	}
+}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -455,6 +455,25 @@ type DeleteOpts struct {
 	All     bool
 }
 
+// CheckDeletePath reports whether a path and the options it is to be deleted
+// under ask for the same thing. It reads the path alone and makes no request,
+// so a caller holding several paths can put all of them past it before any one
+// of them is deleted.
+func CheckDeletePath(path string, opts DeleteOpts) error {
+	//All works on every version, so a path that names one version asks for two
+	// different things at once. The version used to be dropped and the All
+	// taken: deleting every version of a secret when one was named, and, with
+	// Destroy, destroying every version and the metadata along with them --
+	// which cannot be undone, was reported as success, and happened just the
+	// same for a version that had never been written, since All also turns off
+	// the check that the named version exists.
+	if secretPath, _, version := ParsePath(path); opts.All && version != 0 {
+		return fmt.Errorf("cannot delete version %d of `%s' and every version of it at once: drop the version to keep --all, or drop --all to work on the one version", version, secretPath)
+	}
+
+	return nil
+}
+
 func (v *Vault) canSemanticallyDelete(path string) error {
 	justSecret, key, version := ParsePath(path)
 	if key == "" || version == 0 {
@@ -500,15 +519,8 @@ func (v *Vault) canSemanticallyDelete(path string) error {
 func (v *Vault) Delete(path string, opts DeleteOpts) error {
 	path = Canonicalize(path)
 
-	//All works on every version, so a path that names one version asks for two
-	// different things at once. The version used to be dropped and the All
-	// taken: deleting every version of a secret when one was named, and, with
-	// Destroy, destroying every version and the metadata along with them --
-	// which cannot be undone, was reported as success, and happened just the
-	// same for a version that had never been written, since All also turns off
-	// the check that the named version exists.
-	if secretPath, _, version := ParsePath(path); opts.All && version != 0 {
-		return fmt.Errorf("cannot delete version %d of `%s' and every version of it at once: drop the version to keep --all, or drop --all to work on the one version", version, secretPath)
+	if err := CheckDeletePath(path, opts); err != nil {
+		return err
 	}
 
 	reqState := verifyStateAlive

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -660,11 +660,6 @@ func (v *Vault) DeleteVersions(path string, versions []uint) error {
 	return v.client.Delete(path, &vaultkv.KVDeleteOpts{Versions: versions, V1Destroy: true})
 }
 
-// DestroyVersions irrevocably destroys the given versions of the given secret
-func (v *Vault) DestroyVersions(path string, versions []uint) error {
-	return v.client.Destroy(path, versions)
-}
-
 func (v *Vault) Undelete(path string) error {
 	secret, key, version := ParsePath(path)
 	if key != "" {

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -500,6 +500,17 @@ func (v *Vault) canSemanticallyDelete(path string) error {
 func (v *Vault) Delete(path string, opts DeleteOpts) error {
 	path = Canonicalize(path)
 
+	//All works on every version, so a path that names one version asks for two
+	// different things at once. The version used to be dropped and the All
+	// taken: deleting every version of a secret when one was named, and, with
+	// Destroy, destroying every version and the metadata along with them --
+	// which cannot be undone, was reported as success, and happened just the
+	// same for a version that had never been written, since All also turns off
+	// the check that the named version exists.
+	if secretPath, _, version := ParsePath(path); opts.All && version != 0 {
+		return fmt.Errorf("cannot delete version %d of `%s' and every version of it at once: drop the version to keep --all, or drop --all to work on the one version", version, secretPath)
+	}
+
 	reqState := verifyStateAlive
 	if opts.Destroy {
 		reqState = verifyStateAliveOrDeleted


### PR DESCRIPTION
Two flag and path combinations that `safe delete` read as something other
than what was asked. One of them destroys every version of a secret and the
metadata with them, cannot be undone, and reports success.

## --all took the secret when one version was named

`-a` (`--all`) works on every version. A path may also name one version. Given
both, the version was dropped and the `--all` taken:

```
before:  $ safe rm -a secret/db^2
         (exit 0)
         v1=deleted v2=deleted v3=deleted v4=deleted

after:   !! cannot delete version 2 of `secret/db' and every version of it
            at once: drop the version to keep --all, or drop --all to work
            on the one version
         (exit 1, nothing touched)
```

With `--destroy` the same pair went further, and there is no undelete for it:

```
before:  $ safe rm -D -a secret/db^2
         (exit 0)
         $ vault kv metadata get secret/db
         No value found at secret/metadata/db
```

`--all` also turns off the check that the named version exists, so the version
need never have been written. Without `--all` safe says so and stops; with it,
the whole secret went:

```
before:  $ safe rm -D secret/db^99
         !! no version 99 of secret `secret/db` exists

         $ safe rm -D -a secret/db^99
         (exit 0, and secret/db is gone)
```

The refusal lives in `Vault.Delete` rather than in the command, because
`deleteEntireSecret` has no way to honour both and every caller would
otherwise have to know that.

## -r took the key when a key was named

`-r` removes a tree of secrets. A key or a version names one thing inside one
secret, which is not a tree. The pair was read as a mistake and answered by
dropping the `-r` without saying so:

```
before:  $ safe rm -r secret/app:password
         (exit 0; the one key is gone, the tree is not)

         $ safe rm -r -f secret/app^2
         (exit 0; nothing happened at all)

after:   !! cannot delete `secret/app' recursively: -r takes a tree of
            secrets, and the path names the key password
         (exit 1)
```

## A refusal used to arrive with the earlier paths already gone

`safe delete` takes any number of paths and read each one as it came to it, so
a refusal on the last argument left the earlier ones deleted — and with
`--destroy`, no way to ask for them again:

```
before:  $ safe rm -D -a secret/keep secret/db^1
         !! (refused, eventually)
         $ vault kv metadata get secret/keep
         No value found at secret/metadata/keep
```

The reading of a path against its options moves into `vault.CheckDeletePath`,
which makes no request. The whole argument list goes past it before the first
delete, and before the connection to Vault is opened.

## Behaviour otherwise

Unchanged. `safe rm -a PATH` still deletes every version, `safe rm -D -a PATH`
still destroys the secret outright, a named version on its own still deletes
or destroys that one version, `-r` still takes a tree, a key still goes into a
new version, and a secret whose name contains an escaped caret still deletes
like any other.

`Vault.DestroyVersions` is gone. Nothing called it: destroying versions goes
through `deleteEntireSecret`, which decides between destroying the versions
named and removing the metadata along with them, and a bare passthrough to the
client skips that.

## Tests

| function | before | after |
|---|---|---|
| `cmdDelete` | 85.0% | 86.4% |
| `checkDeletePath` | new | 100.0% |
| `Vault.Delete` | 84.6% | 86.7% |
| `Vault.CheckDeletePath` | new | 100.0% |
| `deleteEntireSecret` | 21.2% | 36.4% |

Twelve mutations, each reverted after, and each one caught:

| mutation | tests failing |
|---|---|
| guard removed entirely | 7 |
| guard fires only when no version is named | 11 |
| guard fires only for a destroy | 4 |
| guard fires on any version, --all or not | 8 |
| guard looks for a caret in the path text | 1 |
| Delete stops calling CheckDeletePath | 1 |
| the argument check moves back inside the loop | 5 |
| -r stops refusing a key | 2 |
| -r stops refusing a version | 2 |
| -r refuses nothing | 3 |
| the command stops checking --all against the path | 3 |
| -r refuses a key even without -r | 9 |

Every transcript above is from a real Vault, before and after. `make check`
and `go test -race ./...` pass, and each of the five commits builds and passes
on its own.

## Docs

The help text said `--all` applies to every version "instead of just the
specified version", which is what it used to do; `-r` and `-f` were named in
the usage line and nowhere else. Both the help and the README now say what the
two refuse and that every path is read before any is removed.
