### PR TITLE
Fix what safe gen and dhparam do with their arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,23 @@ To get a shorter password, only 16 characters long:
 safe gen 16 secret/account password
 ```
 
+The length has to be at least one.  `safe gen 0 secret/account
+password` is refused, rather than storing an empty value under a
+name that reads like a credential.
+
+`--policy` limits the characters a password is made of.  It goes
+inside a regular expression character class, so it has to be one,
+and it has to keep at least one printable character:
+
+```
+safe gen 16 --policy a-z0-9 secret/account password
+```
+
+Several secrets can be named at once, as `path:key` or as `path
+key`, and the two forms can be mixed.  The whole list is read
+before the first password is generated, so an argument that
+cannot be used stops the command with nothing written.
+
 ### fmt format_type path oldKey newKey
 
 Take the key at `path:oldKey`, reformat it according to **format_type**,
@@ -576,6 +593,17 @@ By default, a 2048-bit key will be generated.  The `nbits`
 parameter allows you to change that.
 
 Each path gets a unique RSA keypair.
+
+### dhparam \[nbits\] path \[path ...\]
+
+Generate a set of Diffie-Hellman key exchange parameters, adding
+the key "dhparam-pem" to each path.
+
+By default, 2048-bit parameters will be generated.  The `nbits`
+parameter allows you to change that, to 1024 or 4096.
+
+Each path gets its own parameter set.  Generating one takes a
+while, so every path is read before the first set is generated.
 
 ### prompt ...
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -997,7 +997,7 @@ be PEM-encoded.
 
 	r.Dispatch("dhparam", &Help{
 		Summary: "Generate Diffie-Helman key exchange parameters",
-		Usage:   "safe dhparam [NBITS] PATH",
+		Usage:   "safe dhparam [NBITS] PATH [PATH ...]",
 		Type:    DestructiveCommand,
 		Description: `
 NBITS defaults to 2048.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -938,16 +938,26 @@ and overwrite all versions of the secret at the destination.
 
 	r.Dispatch("gen", &Help{
 		Summary: "Generate a random password",
-		Usage:   "safe gen [-l <length>] [-p] PATH:KEY [PATH:KEY ...]",
+		Usage:   "safe gen [LENGTH] PATH:KEY [PATH:KEY ...]",
 		Type:    DestructiveCommand,
 		Description: `
-LENGTH defaults to 64 characters.
+LENGTH defaults to 64 characters, and can be given either as the first
+argument or with -l.  It has to be at least one; a password of no characters
+is refused rather than stored as an empty value.
+
+A secret and the key to write the password to can be named as PATH:KEY, or as
+two arguments, PATH KEY.  The two forms can be mixed.  The whole list is read
+before the first password is generated, so an argument that cannot be used
+stops the command with nothing written.
 
 The following options are recognized:
 
   -l, --length  Specify the length of the random string to generate
-	-p, --policy  Specify a regex character grouping for limiting characters used
-	              to generate the password (e.g --policy a-z0-9)
+  -p, --policy  Specify a regex character grouping for limiting characters used
+                to generate the password (e.g --policy a-z0-9).  It goes
+                inside a character class, so it has to be one, and it has to
+                keep at least one printable character; a policy that does
+                neither is refused.
 `,
 	}, c.cmdGen)
 
@@ -1000,7 +1010,11 @@ be PEM-encoded.
 		Usage:   "safe dhparam [NBITS] PATH [PATH ...]",
 		Type:    DestructiveCommand,
 		Description: `
-NBITS defaults to 2048.
+NBITS defaults to 2048, and has to be 1024, 2048, or 4096.
+
+For each PATH given, a parameter set is generated and stored under the
+'dhparam-pem' name.  Every path is read before the first set is generated,
+since generating one takes a while.
 `,
 	}, c.cmdDhparam)
 

--- a/internal/cli/dhparam_paths_test.go
+++ b/internal/cli/dhparam_paths_test.go
@@ -1,0 +1,59 @@
+package cli
+
+// safe dhparam took as many paths as were typed and generated parameters for
+// the first one only, reporting the success of something nobody asked for. Its
+// siblings, safe ssh and safe rsa, take a list and work through all of it.
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// requireOpenSSL skips when the openssl binary dhparam generation shells out to
+// is not installed.
+func requireOpenSSL(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("openssl"); err != nil {
+		t.Skip("openssl is not installed")
+	}
+}
+
+func TestDhparamWritesEveryPathGiven(t *testing.T) {
+	requireOpenSSL(t)
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	//1024 bits is the smallest size dhparam generation accepts, and this test
+	// runs it once per path.
+	if err := c.cmdDhparam("dhparam", "1024", "secret/one", "secret/two"); err != nil {
+		t.Fatalf("cmdDhparam: %v", err)
+	}
+
+	for _, path := range []string{"secret/one", "secret/two"} {
+		if pem := fv.get(path)["dhparam-pem"]; pem == "" {
+			t.Errorf("%s has no dhparam-pem, want generated parameters", path)
+		}
+	}
+	//Each path gets its own parameters, as each path gets its own key under
+	// safe ssh and safe rsa.
+	if fv.get("secret/one")["dhparam-pem"] == fv.get("secret/two")["dhparam-pem"] {
+		t.Error("both paths hold the same parameters, want a set generated for each")
+	}
+}
+
+// A refused path is refused before anything is generated: dhparam generation
+// is slow, and the first path used to be written before the second was read.
+func TestDhparamRefusesEveryPathBeforeGenerating(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	if err := c.cmdDhparam("dhparam", "1024", "secret/one", "secret/two:key"); err == nil {
+		t.Fatal("expected a refusal of the path naming a key, got nil")
+	}
+
+	if kv := fv.get("secret/one"); len(kv) != 0 {
+		t.Errorf("secret/one = %v, want nothing written", kv)
+	}
+}

--- a/internal/cli/gen_arg_check_test.go
+++ b/internal/cli/gen_arg_check_test.go
@@ -1,0 +1,116 @@
+package cli
+
+// safe gen takes any number of secrets and keys, and used to read each pair as
+// it came to it. A refusal on a later pair therefore arrived with the earlier
+// ones already generated and written, and an argument list that ran out in the
+// middle was answered with the usage after some of it had been carried out.
+
+import (
+	"strings"
+	"testing"
+)
+
+// genCLI is newKeygenCLI with the character policy the real CLI sets when
+// --policy is not given.
+func genCLI(t *testing.T) *CLI {
+	t.Helper()
+	c := newKeygenCLI(t)
+	c.opt.Gen.Policy = defaultGenPolicy
+	return c
+}
+
+// Each of these argument lists is refused on its second pair. The first pair
+// names a secret that has to be left alone.
+func TestNoPasswordIsWrittenWhenALaterPairIsRefused(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "the list runs out before the key",
+			args: []string{"secret/keep", "pw", "secret/second"},
+		},
+		{
+			name: "the path names a version",
+			args: []string{"secret/keep", "pw", "secret/second^3", "pw"},
+		},
+		{
+			name: "the key names a key",
+			args: []string{"secret/keep", "pw", "secret/second", "a:b"},
+		},
+		{
+			name: "the key of a path:key pair names a version",
+			args: []string{"secret/keep", "pw", "secret/second:pw^3"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			fv := newCLIFake(t)
+
+			c := genCLI(t)
+			if err := c.cmdGen("gen", tc.args...); err == nil {
+				t.Fatal("expected a refusal, got nil")
+			}
+
+			if kv := fv.get("secret/keep"); len(kv) != 0 {
+				t.Errorf("secret/keep = %v, want nothing written", kv)
+			}
+		})
+	}
+}
+
+// A list that runs out before the key is a matter for the usage: what is
+// wrong with it is an argument that is not there, rather than one that cannot
+// be used.
+func TestAnIncompleteGenListIsAUsageError(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := genCLI(t)
+	assertUsageError(t, c.cmdGen("gen", "secret/keep", "pw", "secret/second"), "gen")
+
+	if kv := fv.get("secret/keep"); len(kv) != 0 {
+		t.Errorf("secret/keep = %v, want nothing written", kv)
+	}
+}
+
+// A complete list still writes every pair, in either of the two forms.
+func TestEveryPairIsWrittenWhenTheListIsComplete(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := genCLI(t)
+	if err := c.cmdGen("gen", "16", "secret/one", "pw", "secret/two:token"); err != nil {
+		t.Fatalf("cmdGen: %v", err)
+	}
+
+	for _, tc := range []struct{ path, key string }{
+		{"secret/one", "pw"},
+		{"secret/two", "token"},
+	} {
+		if got := fv.get(tc.path)[tc.key]; len(got) != 16 {
+			t.Errorf("%s:%s = %q, want 16 characters", tc.path, tc.key, got)
+		}
+	}
+}
+
+// A length of zero comes back as a refusal rather than an empty password, and
+// says so before anything is written.
+func TestGeneratingNoCharactersIsRefused(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := genCLI(t)
+	err := c.cmdGen("gen", "0", "secret/empty", "pw")
+	if err == nil {
+		t.Fatal("expected a refusal generating a password of no characters, got nil")
+	}
+	if !strings.Contains(err.Error(), "0") {
+		t.Errorf("error %q should name the length", err)
+	}
+	if kv := fv.get("secret/empty"); len(kv) != 0 {
+		t.Errorf("secret/empty = %v, want nothing written", kv)
+	}
+}

--- a/internal/cli/keygen.go
+++ b/internal/cli/keygen.go
@@ -298,24 +298,37 @@ func (c *CLI) cmdDhparam(command string, args ...string) error {
 		return r.Usage("dhparam")
 	}
 
-	path := args[0]
-	if err := assertWritablePath(path); err != nil {
-		return err
-	}
-	v := connect(true)
-	s, err := v.Read(path)
-	if err != nil && !vault.IsNotFound(err) {
-		return err
-	}
-	exists := (err == nil)
-	if opt.SkipIfExists && exists && s.Has("dhparam-pem") {
-		if !opt.Quiet {
-			_, _ = fmt.Fprintf(os.Stderr, "@R{Cowardly refusing to generate a Diffie-Hellman key exchange parameter set at} @C{%s} @R{as it is already present in Vault}\n", path)
+	//Every path is read before any set of parameters is generated. Generating
+	// one takes long enough that a refusal on the second path used to arrive
+	// well after the first had been written.
+	for _, path := range args {
+		if err := assertWritablePath(path); err != nil {
+			return err
 		}
-		return nil
 	}
-	if err = s.DHParam(bits, opt.SkipIfExists); err != nil {
-		return err
+
+	v := connect(true)
+	//A path after the first used to be dropped without a word, so
+	// `safe dhparam secret/a secret/b' generated one set of parameters and
+	// reported the success of both.
+	for _, path := range args {
+		s, err := v.Read(path)
+		if err != nil && !vault.IsNotFound(err) {
+			return err
+		}
+		exists := (err == nil)
+		if opt.SkipIfExists && exists && s.Has("dhparam-pem") {
+			if !opt.Quiet {
+				_, _ = fmt.Fprintf(os.Stderr, "@R{Cowardly refusing to generate a Diffie-Hellman key exchange parameter set at} @C{%s} @R{as it is already present in Vault}\n", path)
+			}
+			continue
+		}
+		if err = s.DHParam(bits, opt.SkipIfExists); err != nil {
+			return err
+		}
+		if err = v.Write(path, s); err != nil {
+			return err
+		}
 	}
-	return v.Write(path, s)
+	return nil
 }

--- a/internal/cli/keygen.go
+++ b/internal/cli/keygen.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"strconv"
 
@@ -11,6 +12,53 @@ import (
 
 	uuid "github.com/pborman/uuid"
 )
+
+// A genTarget is one secret, and the key inside it that a password is to be
+// written to.
+type genTarget struct {
+	path string
+	key  string
+}
+
+// errGenIncomplete says the argument list named a secret with no key after it,
+// which is a matter for the usage rather than for a sentence of its own.
+var errGenIncomplete = errors.New("incomplete list of secrets and keys")
+
+// readGenTargets reads the whole argument list of safe gen into the secrets and
+// keys it names. It makes no request, so every argument goes past it before the
+// first password is generated: a refusal on the third pair used to arrive with
+// the first two already written.
+func readGenTargets(args []string) ([]genTarget, error) {
+	var targets []genTarget
+
+	for len(args) > 0 {
+		if err := assertWritableKeyPath(args[0]); err != nil {
+			return nil, err
+		}
+		var path, key string
+		if vault.PathHasKey(args[0]) {
+			path, key, _ = vault.ParsePath(args[0])
+			//Read and Write parse their argument as path:key syntax, so the
+			// literal path ParsePath returned goes back to the escaped form.
+			path = vault.EncodePath(path, "", 0)
+			args = args[1:]
+		} else {
+			if len(args) < 2 {
+				return nil, errGenIncomplete
+			}
+			path, key = args[0], args[1]
+			//If the key looks like a full path with a :key at the end, then the user
+			// probably botched the args
+			if vault.PathHasKey(key) {
+				return nil, fmt.Errorf("For secret `%s` and key `%s`: key cannot contain a key", path, key)
+			}
+			args = args[2:]
+		}
+		targets = append(targets, genTarget{path: path, key: key})
+	}
+
+	return targets, nil
+}
 
 func (c *CLI) cmdGen(command string, args ...string) error {
 	opt := c.opt
@@ -33,33 +81,23 @@ func (c *CLI) cmdGen(command string, args ...string) error {
 		args = args[1:]
 	}
 
+	targets, err := readGenTargets(args)
+	if err != nil {
+		if errors.Is(err, errGenIncomplete) {
+			return r.Usage("gen")
+		}
+		return err
+	}
+	//A length with nothing after it names no password to generate. It used to
+	// connect and return, which reads as a success and leaves nothing written.
+	if len(targets) == 0 {
+		return r.Usage("gen")
+	}
+
 	v := connect(true)
 
-	for len(args) > 0 {
-		//Checked before the password is generated, so a refused path costs
-		// nothing, and per path, since each one is named separately.
-		if err := assertWritableKeyPath(args[0]); err != nil {
-			return err
-		}
-		var path, key string
-		if vault.PathHasKey(args[0]) {
-			path, key, _ = vault.ParsePath(args[0])
-			//Read and Write parse their argument as path:key syntax, so the
-			// literal path ParsePath returned goes back to the escaped form.
-			path = vault.EncodePath(path, "", 0)
-			args = args[1:]
-		} else {
-			if len(args) < 2 {
-				return r.Usage("gen")
-			}
-			path, key = args[0], args[1]
-			//If the key looks like a full path with a :key at the end, then the user
-			// probably botched the args
-			if vault.PathHasKey(key) {
-				return fmt.Errorf("For secret `%s` and key `%s`: key cannot contain a key", path, key)
-			}
-			args = args[2:]
-		}
+	for _, target := range targets {
+		path, key := target.path, target.key
 		s, err := v.Read(path)
 		if err != nil && !vault.IsNotFound(err) {
 			return err

--- a/internal/cli/keygen_guard_test.go
+++ b/internal/cli/keygen_guard_test.go
@@ -66,13 +66,15 @@ func TestCmdGen_ZeroArgs_ReturnsUsageError(t *testing.T) {
 	assertUsageError(t, err, "gen")
 }
 
-// cmdGen with a numeric-only arg treats it as the length, leaving zero paths —
-// the inner loop guard fires.
+// cmdGen with a numeric-only arg treats it as the length, leaving zero paths.
+// The argument list is read before anything is connected to, so this is a
+// usage error; it used to connect and return, which reads as a success and
+// leaves no password anywhere.
 func TestCmdGen_LengthOnlyNoPath_ReturnsUsageError(t *testing.T) {
-	// "32" is parsed as length; no path follows → inner loop guard fires.
-	// The loop calls connect() before the inner guard, so this requires Vault presence.
-	// The zero-arg case above covers the outer guard.
-	t.Skip("inner loop guard runs after connect(); requires live Vault")
+	isolateHome(t)
+	c := newKeygenCLI(t)
+	err := c.cmdGen("gen", "32")
+	assertUsageError(t, err, "gen")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/cli/keygen_paths_test.go
+++ b/internal/cli/keygen_paths_test.go
@@ -1,0 +1,79 @@
+package cli
+
+// safe ssh and safe rsa take a list of paths and give each one its own key.
+// Nothing exercised that past the argument-count guard, so a change that made
+// either of them stop after the first path went unnoticed.
+
+import "testing"
+
+func TestSshWritesAKeypairToEveryPathGiven(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	//1024 is the smallest key size Go will generate, and the size is not what
+	// is under test here.
+	if err := c.cmdSsh("ssh", "1024", "secret/one", "secret/two"); err != nil {
+		t.Fatalf("cmdSsh: %v", err)
+	}
+
+	for _, path := range []string{"secret/one", "secret/two"} {
+		for _, key := range []string{"private", "public", "fingerprint"} {
+			if fv.get(path)[key] == "" {
+				t.Errorf("%s has no %s, want a generated keypair", path, key)
+			}
+		}
+	}
+	if fv.get("secret/one")["public"] == fv.get("secret/two")["public"] {
+		t.Error("both paths hold the same public key, want a keypair generated for each")
+	}
+}
+
+func TestRsaWritesAKeypairToEveryPathGiven(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	if err := c.cmdRsa("rsa", "1024", "secret/one", "secret/two"); err != nil {
+		t.Fatalf("cmdRsa: %v", err)
+	}
+
+	for _, path := range []string{"secret/one", "secret/two"} {
+		for _, key := range []string{"private", "public"} {
+			if fv.get(path)[key] == "" {
+				t.Errorf("%s has no %s, want a generated keypair", path, key)
+			}
+		}
+	}
+	if fv.get("secret/one")["public"] == fv.get("secret/two")["public"] {
+		t.Error("both paths hold the same public key, want a keypair generated for each")
+	}
+}
+
+// A path that cannot be written to stops both of them before the first key is
+// generated, rather than after the paths before it have been written.
+func TestSshRefusesEveryPathBeforeGenerating(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	if err := c.cmdSsh("ssh", "1024", "secret/one", "secret/two:key"); err == nil {
+		t.Fatal("expected a refusal of the path naming a key, got nil")
+	}
+	if kv := fv.get("secret/one"); len(kv) != 0 {
+		t.Errorf("secret/one = %v, want nothing written", kv)
+	}
+}
+
+func TestRsaRefusesEveryPathBeforeGenerating(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	if err := c.cmdRsa("rsa", "1024", "secret/one", "secret/two^2"); err == nil {
+		t.Fatal("expected a refusal of the path naming a version, got nil")
+	}
+	if kv := fv.get("secret/one"); len(kv) != 0 {
+		t.Errorf("secret/one = %v, want nothing written", kv)
+	}
+}

--- a/pkg/vault/random.go
+++ b/pkg/vault/random.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"bytes"
 	"crypto/rand"
+	"fmt"
 	"math/big"
 	"regexp"
 )
@@ -12,8 +13,26 @@ var (
 )
 
 func random(n int, policy string) (string, error) {
-	re := regexp.MustCompile("[^" + policy + "]")
+	//A policy is whatever was typed after --policy, and it is put inside a
+	// character class to say which characters to keep. Not every string is one:
+	// compiling it with MustCompile answered a mistyped policy with a panic and
+	// a stack trace, and an unset $POLICY, which arrives here empty, with the
+	// same.
+	if policy == "" {
+		return "", fmt.Errorf("no character policy to generate from: a policy goes inside a character class, as in a-zA-Z0-9")
+	}
+	re, err := regexp.Compile("[^" + policy + "]")
+	if err != nil {
+		return "", fmt.Errorf("`%s' is not a usable character policy: it goes inside a character class, as in a-zA-Z0-9 (%s)", policy, err)
+	}
+
 	keep := re.ReplaceAllString(chars, "")
+	//A policy can be a character class and still name none of the characters a
+	// password is made of, which left nothing to pick from and panicked in
+	// crypto/rand instead.
+	if keep == "" {
+		return "", fmt.Errorf("the character policy `%s' keeps none of the characters a password can be made of", policy)
+	}
 
 	var buffer bytes.Buffer
 

--- a/pkg/vault/random.go
+++ b/pkg/vault/random.go
@@ -13,6 +13,13 @@ var (
 )
 
 func random(n int, policy string) (string, error) {
+	//No characters is not a password. `safe gen 0 secret/db pw' used to store
+	// the empty string under pw and report success, leaving something that
+	// reads like a generated credential and is not one.
+	if n < 1 {
+		return "", fmt.Errorf("cannot generate a password of %d characters: a length of at least one is needed", n)
+	}
+
 	//A policy is whatever was typed after --policy, and it is put inside a
 	// character class to say which characters to keep. Not every string is one:
 	// compiling it with MustCompile answered a mistyped policy with a panic and

--- a/pkg/vault/random_length_test.go
+++ b/pkg/vault/random_length_test.go
@@ -1,0 +1,55 @@
+// White-box tests for what random() does with a length no password can have,
+// and for the Password method that hands one to it. `safe gen 0 secret/db pw'
+// used to store an empty string and report success.
+package vault
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRandomRefusesALengthBelowOne(t *testing.T) {
+	t.Parallel()
+
+	for _, n := range []int{0, -1, -64} {
+		got, err := random(n, "a-zA-Z0-9")
+		if err == nil {
+			t.Errorf("random(%d) = %q, want a refusal", n, got)
+			continue
+		}
+		//The length is said back because it is the argument that has to
+		// change, and because a caller passing 0 usually did not mean to.
+		if !strings.Contains(err.Error(), "0") && !strings.Contains(err.Error(), "-") {
+			t.Errorf("error %q should name the length %d", err, n)
+		}
+	}
+}
+
+// Password is where the length arrives from the command line, and a refused
+// one has to leave the key alone rather than store the empty string it would
+// otherwise have generated.
+func TestPasswordRefusesALengthBelowOneWithoutSettingTheKey(t *testing.T) {
+	t.Parallel()
+
+	s := NewSecret()
+	if err := s.Password("pw", 0, "a-zA-Z0-9", false); err == nil {
+		t.Fatal("Password with a length of 0 returned nil, want a refusal")
+	}
+	if s.Has("pw") {
+		t.Errorf("pw = %q, want the key left unset", s.Get("pw"))
+	}
+}
+
+// A password of one character is a poor password but a real one, so the line
+// is at zero rather than at some judgement about strength.
+func TestPasswordAcceptsALengthOfOne(t *testing.T) {
+	t.Parallel()
+
+	s := NewSecret()
+	if err := s.Password("pw", 1, "a-zA-Z0-9", false); err != nil {
+		t.Fatalf("Password: %v", err)
+	}
+	if got := s.Get("pw"); len(got) != 1 {
+		t.Errorf("pw = %q, want one character", got)
+	}
+}

--- a/pkg/vault/random_policy_test.go
+++ b/pkg/vault/random_policy_test.go
@@ -1,0 +1,74 @@
+// White-box tests for what random() does with a policy it cannot generate a
+// password from. The policy arrives from `safe gen --policy', so it can be
+// anything the user typed, and every one of these used to be a panic.
+package vault
+
+import (
+	"strings"
+	"testing"
+)
+
+// A policy goes inside a character class, and not every string is one. These
+// reached regexp.MustCompile, which panics rather than returning the error.
+func TestRandomRefusesAPolicyThatIsNotACharacterClass(t *testing.T) {
+	t.Parallel()
+
+	for _, policy := range []string{`a-\`, `\`, `z-a`} {
+		got, err := random(16, policy)
+		if err == nil {
+			t.Errorf("random(16, %q) = %q, want a refusal", policy, got)
+			continue
+		}
+		//Named so that it is clear which of several policies was the bad one,
+		// and that the complaint is about the policy rather than the length.
+		if !strings.Contains(err.Error(), policy) {
+			t.Errorf("error %q should quote the policy %q", err, policy)
+		}
+	}
+}
+
+// An empty policy is what an unset variable expands to, as in
+// `safe gen --policy "$POLICY"'.
+func TestRandomRefusesAnEmptyPolicy(t *testing.T) {
+	t.Parallel()
+
+	if got, err := random(16, ""); err == nil {
+		t.Fatalf("random(16, \"\") = %q, want a refusal", got)
+	}
+}
+
+// A policy can be a character class and still leave nothing to pick from: a
+// space is not one of the characters a password is made of, so keeping only
+// spaces keeps nothing. This one used to reach crypto/rand with an empty set
+// and panic there instead.
+func TestRandomRefusesAPolicyThatKeepsNoCharacters(t *testing.T) {
+	t.Parallel()
+
+	for _, policy := range []string{" ", "\t", "é"} {
+		got, err := random(16, policy)
+		if err == nil {
+			t.Errorf("random(16, %q) = %q, want a refusal", policy, got)
+			continue
+		}
+		if !strings.Contains(err.Error(), policy) {
+			t.Errorf("error %q should quote the policy %q", err, policy)
+		}
+	}
+}
+
+// The policies people actually pass go on working, including the one the CLI
+// sets when --policy is not given.
+func TestRandomKeepsGeneratingForUsablePolicies(t *testing.T) {
+	t.Parallel()
+
+	for _, policy := range []string{"a-zA-Z0-9", "0-9", "a", "!-~", "^", "-"} {
+		got, err := random(16, policy)
+		if err != nil {
+			t.Errorf("random(16, %q): %v", policy, err)
+			continue
+		}
+		if len(got) != 16 {
+			t.Errorf("random(16, %q) returned %d characters: %q", policy, len(got), got)
+		}
+	}
+}

--- a/pkg/vault/random_policy_test.go
+++ b/pkg/vault/random_policy_test.go
@@ -32,8 +32,15 @@ func TestRandomRefusesAPolicyThatIsNotACharacterClass(t *testing.T) {
 func TestRandomRefusesAnEmptyPolicy(t *testing.T) {
 	t.Parallel()
 
-	if got, err := random(16, ""); err == nil {
+	got, err := random(16, "")
+	if err == nil {
 		t.Fatalf("random(16, \"\") = %q, want a refusal", got)
+	}
+	//An empty policy compiles to `[^]', which the regexp parser refuses in its
+	// own words. Said in safe's words instead, since a reader who typed
+	// nothing is not helped by a complaint about a missing bracket.
+	if strings.Contains(err.Error(), "regexp") {
+		t.Errorf("error %q reads as a regexp parse failure, want it said plainly", err)
 	}
 }
 

--- a/pkg/vault/random_test.go
+++ b/pkg/vault/random_test.go
@@ -12,7 +12,9 @@ import (
 func TestRandomLength(t *testing.T) {
 	t.Parallel()
 
-	lengths := []int{0, 1, 8, 16, 32, 64, 128}
+	//A length below one is refused rather than returned as an empty password;
+	// see TestRandomRefusesALengthBelowOne.
+	lengths := []int{1, 8, 16, 32, 64, 128}
 	for _, n := range lengths {
 		n := n
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
Four things `safe gen` and `safe dhparam` did with arguments that
cannot produce a credential. Two of them are panics; one stores an empty
value under a name that reads like a password.

## A policy safe cannot generate from was a panic

`--policy` limits the characters a password is made of by being put inside
a regular expression character class. It arrives as typed, and reached
`regexp.MustCompile`:

```
before:  $ safe gen --policy 'a-\' secret/db pw
         panic: regexp: Compile(`[^a-\]`): error parsing regexp:
           invalid character class range: `a-\]`
         goroutine 1 [running]: ...
         (exit 2)

after:   !! `a-\' is not a usable character policy: it goes inside a
            character class, as in a-zA-Z0-9 (error parsing regexp:
            invalid character class range: `a-\]')
         (exit 1)
```

An unset variable arrives here empty, and `[^]` is not a character class
either:

```
before:  $ safe gen --policy "$POLICY" secret/db pw     # POLICY unset
         panic: regexp: Compile(`[^]`): ...

after:   !! no character policy to generate from: a policy goes inside a
            character class, as in a-zA-Z0-9
```

A policy can also be a character class and still keep none of the
characters a password is made of, which left nothing to pick from and
panicked one frame further along, in crypto/rand:

```
before:  $ safe gen --policy ' ' secret/db pw
         panic: crypto/rand: argument to Int is <= 0

after:   !! the character policy ` ' keeps none of the characters a
            password can be made of
```

## A password of no characters was stored and reported as generated

```
before:  $ safe gen 0 secret/db pw
         (exit 0)
         $ safe get secret/db:pw
         (empty)

after:   !! cannot generate a password of 0 characters: a length of at
            least one is needed
         (exit 1, nothing written)
```

A length with nothing after it named no password at all. That connected
to the Vault and returned, which reads as a success:

```
before:  $ safe gen 32
         (exit 0, nothing generated anywhere)

after:   the usage, exit 1
```

## A refusal used to arrive with the earlier passwords already written

`safe gen` takes any number of secrets and keys and read each pair as it
came to it:

```
before:  $ safe gen secret/keep pw secret/two^3 pw
         !! cannot write to paths in /path^version notation (secret/two^3)
         $ safe get secret/keep:pw
         MjnGqtG6yZpmqArRD0vz6l4WyIlK8zlTkz7uwdVv9XyP2aUQPDb5vNFnlr7VEHdD

         $ safe gen secret/keep pw secret/two        # list runs out
         (the usage, and secret/keep written)
```

The list is now read into secrets and keys by `readGenTargets`, which
makes no request, before the connection is opened.

## dhparam generated one set of parameters for any number of paths

```
before:  $ safe dhparam 1024 secret/dh1 secret/dh2 secret/dh3
         (exit 0)
         dh1: written   dh2: MISSING   dh3: MISSING

after:   all three written, each with its own parameters
```

`safe ssh` and `safe rsa` take a list and work through all of it; dhparam
took the list and used the first entry. Every path is now read before the
first set is generated, which matters here because generating one is slow
enough that a refusal on the second path used to arrive long after the
first had been written.

## Behaviour otherwise

Unchanged. Passwords generate at the same lengths and policies, in both
the `path:key` and the `path key` argument forms, mixed, with `-l` and
`--policy`, at escaped-caret paths, and with `--no-clobber`; `safe ssh`,
`safe rsa`, and `safe uuid` are untouched; `safe dhparam` with one path
does what it did.

## Tests

| function | before | after |
|---|---|---|
| `random` | 90.0% | 94.4% |
| `Secret.Password` | 85.7% | 100.0% |
| `cmdGen` | 61.0% | 80.6% |
| `readGenTargets` | new | 100.0% |
| `cmdDhparam` | 50.0% | 75.9% |
| `cmdSsh` | 44.8% | 75.9% |
| `cmdRsa` | 44.8% | 75.9% |

`cmdSsh` and `cmdRsa` are in the table because nothing exercised either
past the argument-count guard, so the loop dhparam now shares with them
had no test to break. They have one now.

Twelve mutations, each reverted after, and each one caught:

| mutation | tests failing |
|---|---|
| empty policy accepted | 1 |
| policy compile error ignored | 1 |
| empty character set accepted | 1 |
| length guard removed | 3 |
| length guard off by one | 3 |
| gen path guard removed | 5 |
| gen key-in-key guard removed | 2 |
| gen empty target list accepted | the package (it exits) |
| incomplete gen list not a usage error | 1 |
| ssh writes only the first path | 1 |
| ssh checks only the first path | 1 |
| dhparam writes only the first path | 1 |
| dhparam checks paths as it uses them | 1 |

Every transcript above is from a real Vault, before and after. `make check`
and `go test -race ./...` pass, and each of the six commits builds and
passes on its own.

## Docs

The gen usage line named neither the length argument nor the `PATH KEY`
form, and showed `--policy` as though it took no value. Neither the help
nor the README said what a policy is, what a length has to be, or that
dhparam takes more than one path, and the README had no dhparam section
at all.
