### PR TITLE
Fix how safe target names and saves a target

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Vault with just:
 safe target myvault
 ```
 
+The two arguments may be given in either order: what makes one of
+them the URL is the scheme it carries.  An address typed without
+its `http://` or `https://` is not a URL, and `safe` says so
+rather than filing the target under it.
+
+A target can be named by its alias or by the URL it is at,
+anywhere a name is taken -- retargeting, `-T`, and
+`safe target delete`.  What gets recorded as the current target is
+always the alias.
+
 You can see what Vaults you have targeted by running
 
 ```
@@ -63,6 +73,16 @@ safe targets
 ```
 
 All commands will be run against the currently targeted Vault.
+
+To forget a target, along with the token saved with it:
+
+```
+safe target delete myvault
+```
+
+Deleting the target you are currently on leaves nothing targeted,
+so the next command will ask you to target a Vault rather than
+report a target that is no longer there.
 
 To authenticate:
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -399,9 +399,17 @@ func Main(version, buildTime, gitCommit string) {
 
 	r.Dispatch("target", &Help{
 		Summary: "Target a new Vault, or set your current Vault target",
-		Description: `Target a new Vault if URL and ALIAS are provided, or set
-your current Vault target if just ALIAS is given. If the single argument form
-if provided, the following flags are valid:
+		Description: `Target a new Vault by giving its URL and an ALIAS to call
+it by, or set your current target by naming a Vault that is already known. A
+name is either the alias a target was given or the URL it is at.
+
+A URL carries the scheme it is reached over, as in https://vault.example.com,
+and that is how it is told apart from the alias: the two may be given in either
+order. Two arguments where neither is a URL are refused rather than guessed at.
+
+The flags below apply to the two-argument form, which is where a target is
+described. -k also applies on its own, where it marks an already-known target
+as skipping validation from then on.
 
 -k (--insecure) specifies to skip x509 certificate validation. This only has an
 effect if the given URL uses an HTTPS scheme.
@@ -424,8 +432,16 @@ provided multiple times to provide multiple CA certificates.
 
 	r.Dispatch("target delete", &Help{
 		Summary: "Forget about a targeted Vault",
-		Usage:   "safe target delete ALIAS",
-		Type:    DestructiveCommand,
+		Description: `Remove a target, and the token stored with it, from
+~/.saferc. The target is named the way it is named everywhere else: by its
+alias or by its URL. A name that reaches no target is an error rather than a
+success.
+
+Deleting the current target leaves nothing targeted; the other targets are
+left alone.
+`,
+		Usage: "safe target delete ALIAS",
+		Type:  DestructiveCommand,
 	}, c.cmdTargetDelete)
 
 	r.Dispatch("status", &Help{

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -106,6 +106,36 @@ func (c *CLI) cmdTargets(command string, args ...string) error {
 	return nil
 }
 
+// isVaultAddress reports whether s reads as the address of a Vault rather than
+// as a name for one. safe speaks to Vault over HTTP, so an address is what
+// carries one of those two schemes and a host to reach.
+func isVaultAddress(s string) bool {
+	u, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	//A scheme is case-insensitive and comes back from url.Parse in lower case,
+	// so HTTPS:// is read as the address it is.
+	return (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
+}
+
+// targetArgs reads the two-argument form of `safe target', which gives an
+// address a name, in either order. The two used to be told apart by looking
+// for a literal http:// or https:// on the second one and swapping when it was
+// missing, so an address typed without its scheme was taken for a name and the
+// name for an address: the target was filed under the address, pointing at the
+// alias, and every command run against it went to port 80 of nowhere in
+// particular.
+func targetArgs(first, second string) (alias, address string, err error) {
+	switch {
+	case isVaultAddress(second):
+		return first, second, nil
+	case isVaultAddress(first):
+		return second, first, nil
+	}
+	return "", "", fmt.Errorf("neither `%s' nor `%s' is the address of a Vault: an address carries the scheme it is reached over, as in `safe target https://vault.example.com %s'", first, second, first)
+}
+
 func (c *CLI) cmdTarget(command string, args ...string) error {
 	opt := c.opt
 	r := c.r
@@ -230,11 +260,9 @@ func (c *CLI) cmdTarget(command string, args ...string) error {
 	}
 
 	if len(args) == 2 {
-		var err error
-		alias, url := args[0], args[1]
-		if !strings.HasPrefix(args[1], "http://") &&
-			!strings.HasPrefix(args[1], "https://") {
-			alias, url = url, alias
+		alias, url, err := targetArgs(args[0], args[1])
+		if err != nil {
+			return err
 		}
 
 		caCerts := []string{}

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -308,7 +308,13 @@ func (c *CLI) cmdTargetDelete(command string, args ...string) error {
 	}
 
 	delete(cfg.Vaults, alias)
-	if cfg.Current == alias {
+	//The selection is compared by resolving it rather than by matching the
+	// alias: a config written before it was recorded by alias names the current
+	// target by URL, and a URL stops naming anything once the target carrying
+	// it is gone. Left as it was, the selection would name a Vault that is not
+	// in the file, which every later command -- including the write below --
+	// reports as a missing current target.
+	if _, ok, _ := cfg.Alias(cfg.Current); !ok {
 		cfg.Current = ""
 	}
 

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -253,10 +253,16 @@ func (c *CLI) cmdTarget(command string, args ...string) error {
 		if err != nil {
 			return err
 		}
+		//Saved before it is reported: a home directory that cannot be written
+		// to used to be answered with the new target on the screen and the old
+		// one still in the file.
+		if err := cfg.Write(); err != nil {
+			return err
+		}
 		if !opt.Quiet {
 			printTarget()
 		}
-		return cfg.Write()
+		return nil
 	}
 
 	if len(args) == 2 {
@@ -302,10 +308,13 @@ func (c *CLI) cmdTarget(command string, args ...string) error {
 		if err != nil {
 			return err
 		}
+		if err := cfg.Write(); err != nil {
+			return err
+		}
 		if !opt.Quiet {
 			printTarget()
 		}
-		return cfg.Write()
+		return nil
 	}
 
 	return r.Usage("target")

--- a/internal/cli/target_address_test.go
+++ b/internal/cli/target_address_test.go
@@ -1,0 +1,109 @@
+package cli
+
+// `safe target' takes an address and an alias in either order, and told them
+// apart by looking for an http:// or https:// prefix on the second one. An
+// address typed without its scheme matched neither test, so the two arguments
+// were swapped on the assumption that the first one was the address: the
+// target was then filed under the address and pointed at the alias, and every
+// command run against it went to whatever answers on port 80 of localhost.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTargetTakesTheAddressInEitherOrder(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantAlias  string
+		wantAddres string
+	}{
+		{
+			name:       "address then alias",
+			args:       []string{"https://vault.example.com", "ops"},
+			wantAlias:  "ops",
+			wantAddres: "https://vault.example.com",
+		},
+		{
+			name:       "alias then address",
+			args:       []string{"ops", "https://vault.example.com"},
+			wantAlias:  "ops",
+			wantAddres: "https://vault.example.com",
+		},
+		{
+			name:       "an unencrypted address is still an address",
+			args:       []string{"ops", "http://vault.example.com:8200"},
+			wantAlias:  "ops",
+			wantAddres: "http://vault.example.com:8200",
+		},
+		{
+			//The scheme is matched the way a URL is read rather than by the
+			// literal prefix it usually has.
+			name:       "the scheme is not case sensitive",
+			args:       []string{"ops", "HTTPS://vault.example.com"},
+			wantAlias:  "ops",
+			wantAddres: "HTTPS://vault.example.com",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			c := newTestCLI(t)
+			c.opt.Quiet = true
+
+			if err := c.cmdTarget("target", tc.args...); err != nil {
+				t.Fatalf("cmdTarget %v: %v", tc.args, err)
+			}
+
+			cfg := readConfig(t)
+			v, ok := cfg.Vaults[tc.wantAlias]
+			if !ok {
+				t.Fatalf("config holds %v, want a target named %s", cfg.Vaults, tc.wantAlias)
+			}
+			if v.URL != tc.wantAddres {
+				t.Errorf("%s is at %q, want %q", tc.wantAlias, v.URL, tc.wantAddres)
+			}
+			if cfg.Current != tc.wantAlias {
+				t.Errorf("current = %q, want %s", cfg.Current, tc.wantAlias)
+			}
+		})
+	}
+}
+
+// Neither argument being an address is the case that used to be filed anyway.
+func TestTargetRefusesTwoArgumentsWithNoAddress(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "no scheme", args: []string{"ops", "vault.example.com"}},
+		{name: "no scheme and a port", args: []string{"ops", "vault.example.com:8200"}},
+		{name: "a scheme safe does not speak", args: []string{"ops", "ftp://vault.example.com"}},
+		{name: "a scheme naming no host", args: []string{"ops", "https://"}},
+		{name: "something no URL can be read out of", args: []string{"ops", "https://vault.example.com/%zz"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			c := newTestCLI(t)
+			c.opt.Quiet = true
+
+			err := c.cmdTarget("target", tc.args...)
+			if err == nil {
+				t.Fatalf("cmdTarget %v returned nil, want a refusal", tc.args)
+			}
+			for _, arg := range tc.args {
+				if !strings.Contains(err.Error(), arg) {
+					t.Errorf("error %q should quote the argument %q", err, arg)
+				}
+			}
+
+			cfg := readConfig(t)
+			if len(cfg.Vaults) != 0 {
+				t.Errorf("config holds %v, want nothing filed", cfg.Vaults)
+			}
+			if cfg.Current != "" {
+				t.Errorf("current = %q, want nothing targeted", cfg.Current)
+			}
+		})
+	}
+}

--- a/internal/cli/target_current_alias_test.go
+++ b/internal/cli/target_current_alias_test.go
@@ -1,0 +1,105 @@
+package cli
+
+// `safe target' names a Vault by its alias or by its URL, and both used to be
+// written back into ~/.saferc as the current target. A URL there is a name for
+// a target only for as long as one target carries it, so the listing lost the
+// (*) marker and a later `safe target delete' left the selection pointing at
+// something that no longer existed.
+
+import (
+	"strings"
+	"testing"
+)
+
+// twoAliasedTargets writes a config holding alpha and beta with none current.
+func twoAliasedTargets(t *testing.T) {
+	t.Helper()
+	writeSaferc(t, `version: 1
+current: ""
+vaults:
+  alpha:
+    url: https://alpha.example.com
+    token: token-alpha
+  beta:
+    url: https://beta.example.com
+    token: token-beta
+`)
+}
+
+func TestTargetingByURLRecordsTheAlias(t *testing.T) {
+	for _, name := range []string{"alpha", "https://alpha.example.com", "https://alpha.example.com/"} {
+		t.Run(name, func(t *testing.T) {
+			isolateHome(t)
+			twoAliasedTargets(t)
+			c := newTestCLI(t)
+			c.opt.Quiet = true
+
+			if err := c.cmdTarget("target", name); err != nil {
+				t.Fatalf("cmdTarget(%q): %v", name, err)
+			}
+
+			cfg := readConfig(t)
+			if cfg.Current != "alpha" {
+				t.Errorf("current = %q, want alpha", cfg.Current)
+			}
+		})
+	}
+}
+
+// The listing marks the current target with a (*), which it does by comparing
+// the name it was given against the aliases it prints.
+func TestTargetingByURLIsMarkedInTheListing(t *testing.T) {
+	isolateHome(t)
+	twoAliasedTargets(t)
+	c := newTestCLI(t)
+	c.opt.Quiet = true
+
+	if err := c.cmdTarget("target", "https://alpha.example.com"); err != nil {
+		t.Fatalf("cmdTarget: %v", err)
+	}
+
+	out := captureStderr(t, func() {
+		if err := c.cmdTargets("targets"); err != nil {
+			t.Fatalf("cmdTargets: %v", err)
+		}
+	})
+
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.Contains(line, "alpha") {
+			continue
+		}
+		if !strings.HasPrefix(line, "(*)") {
+			t.Errorf("alpha is current but its line reads %q", line)
+		}
+	}
+	if !strings.Contains(out, "current target indicated") {
+		t.Error("the listing should say a target is current")
+	}
+}
+
+// Targeting by URL and then deleting by alias is the pair that used to leave
+// ~/.saferc naming a target that is not there, which every later command
+// reported as a missing current target.
+func TestDeletingTheTargetSelectedByURLClearsTheSelection(t *testing.T) {
+	isolateHome(t)
+	twoAliasedTargets(t)
+	c := newTestCLI(t)
+	c.opt.Quiet = true
+
+	if err := c.cmdTarget("target", "https://alpha.example.com"); err != nil {
+		t.Fatalf("cmdTarget: %v", err)
+	}
+	if err := c.cmdTargetDelete("target delete", "alpha"); err != nil {
+		t.Fatalf("cmdTargetDelete: %v", err)
+	}
+
+	cfg := readConfig(t)
+	if cfg.Current != "" {
+		t.Errorf("current = %q, want it cleared with the target it named", cfg.Current)
+	}
+	//A selection that names nothing is what every other command trips over,
+	// so check the way they reach it rather than only the stored string.
+	if _, err := cfg.Vault(""); err != nil {
+		t.Errorf("reading the current target: %v", err)
+	}
+}

--- a/internal/cli/target_delete_test.go
+++ b/internal/cli/target_delete_test.go
@@ -99,6 +99,67 @@ func TestTargetDeleteClearsTheCurrentTargetItRemoved(t *testing.T) {
 	}
 }
 
+// A config written before the current target was recorded by alias names it
+// by URL instead. Deleting that target by alias left the selection naming a
+// Vault that is no longer in the file, which every later command -- including
+// the write that stores this deletion -- reports as a missing current target.
+func TestTargetDeleteClearsACurrentTargetNamedByURL(t *testing.T) {
+	isolateHome(t)
+	writeSaferc(t, `version: 1
+current: https://alpha.example.com
+vaults:
+  alpha:
+    url: https://alpha.example.com
+    token: token-alpha
+  beta:
+    url: https://beta.example.com
+    token: token-beta
+`)
+	c := newTestCLI(t)
+
+	if err := c.cmdTargetDelete("target delete", "alpha"); err != nil {
+		t.Fatalf("cmdTargetDelete: %v", err)
+	}
+
+	cfg := readConfig(t)
+	if cfg.Current != "" {
+		t.Errorf("current = %q, want it cleared along with the target it named", cfg.Current)
+	}
+	if _, err := cfg.Vault(""); err != nil {
+		t.Errorf("reading the current target: %v", err)
+	}
+}
+
+// Deleting one target leaves the selection on another alone, whichever way
+// that selection names it.
+func TestTargetDeleteKeepsACurrentTargetItDidNotRemove(t *testing.T) {
+	isolateHome(t)
+	writeSaferc(t, `version: 1
+current: https://beta.example.com
+vaults:
+  alpha:
+    url: https://alpha.example.com
+    token: token-alpha
+  beta:
+    url: https://beta.example.com
+    token: token-beta
+`)
+	c := newTestCLI(t)
+
+	if err := c.cmdTargetDelete("target delete", "alpha"); err != nil {
+		t.Fatalf("cmdTargetDelete: %v", err)
+	}
+
+	cfg := readConfig(t)
+	v, err := cfg.Vault("")
+	if err != nil {
+		t.Fatalf("reading the current target: %v", err)
+	}
+	if v.URL != "https://beta.example.com" {
+		t.Errorf("current target is %s, want beta", v.URL)
+	}
+}
+
 // Two aliases for one Vault leave a URL ambiguous, and guessing which to
 // delete is worse than saying so.
 func TestTargetDeleteRefusesAnAmbiguousURL(t *testing.T) {

--- a/internal/cli/target_write_order_test.go
+++ b/internal/cli/target_write_order_test.go
@@ -1,0 +1,98 @@
+package cli
+
+// `safe target' printed the target it had just selected and saved it
+// afterwards, so a configuration that could not be written -- a read-only home
+// directory, a full disk -- was reported as a target that had been changed.
+// The next command still used the old one.
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// sealHome makes the isolated home directory unwritable for the rest of the
+// test, so writing ~/.saferc fails while reading it still works. Root ignores
+// the mode, so there is nothing to test there.
+func sealHome(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: the directory mode would not stop a write")
+	}
+	home := os.Getenv("HOME")
+	if err := os.Chmod(home, 0o500); err != nil {
+		t.Fatalf("chmod %s: %v", home, err)
+	}
+	//Put the mode back before the temp directory is removed, or the cleanup
+	// that removes it fails and the failure is reported against this test.
+	t.Cleanup(func() { _ = os.Chmod(home, 0o700) })
+}
+
+func TestTargetDoesNotReportASelectionItCouldNotSave(t *testing.T) {
+	isolateHome(t)
+	twoAliasedTargets(t)
+	sealHome(t)
+	c := newTestCLI(t)
+
+	var err error
+	out := captureStderr(t, func() {
+		err = c.cmdTarget("target", "alpha")
+	})
+
+	if err == nil {
+		t.Fatal("cmdTarget returned nil with an unwritable config, want the write error")
+	}
+	if strings.Contains(out, "Currently targeting") {
+		t.Errorf("stderr reported the new target although it was not saved: %q", out)
+	}
+}
+
+func TestTargetDoesNotReportAVaultItCouldNotSave(t *testing.T) {
+	isolateHome(t)
+	twoAliasedTargets(t)
+	sealHome(t)
+	c := newTestCLI(t)
+
+	var err error
+	out := captureStderr(t, func() {
+		err = c.cmdTarget("target", "https://gamma.example.com", "gamma")
+	})
+
+	if err == nil {
+		t.Fatal("cmdTarget returned nil with an unwritable config, want the write error")
+	}
+	if strings.Contains(out, "Currently targeting") {
+		t.Errorf("stderr reported the new target although it was not saved: %q", out)
+	}
+}
+
+// The report is still made when the target is saved, in both forms.
+func TestTargetReportsASelectionItSaved(t *testing.T) {
+	for _, tc := range []struct {
+		name, want string
+		args       []string
+	}{
+		{name: "an existing target", want: "alpha", args: []string{"alpha"}},
+		{name: "a new one", want: "gamma", args: []string{"https://gamma.example.com", "gamma"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			twoAliasedTargets(t)
+			c := newTestCLI(t)
+
+			var err error
+			out := captureStderr(t, func() {
+				err = c.cmdTarget("target", tc.args...)
+			})
+			if err != nil {
+				t.Fatalf("cmdTarget %v: %v", tc.args, err)
+			}
+			if !strings.Contains(out, "Currently targeting") || !strings.Contains(out, tc.want) {
+				t.Errorf("stderr = %q, want it to report targeting %s", out, tc.want)
+			}
+			if cfg := readConfig(t); cfg.Current != tc.want {
+				t.Errorf("current = %q, want %s", cfg.Current, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/rc/config.go
+++ b/pkg/rc/config.go
@@ -249,17 +249,22 @@ func (c *Config) Apply(use string) error {
 	return nil
 }
 
-func (c *Config) SetCurrent(alias string, reskip bool) error {
-	v, ok, err := c.Find(alias)
+// SetCurrent selects the target named by either its alias or its URL. What it
+// records is the alias, because that is the name the rest of the config is
+// keyed by: a URL stored here resolves only for as long as exactly one target
+// still carries it, so deleting that target leaves a selection that names
+// nothing and every later command reporting a missing current target.
+func (c *Config) SetCurrent(name string, reskip bool) error {
+	alias, ok, err := c.Alias(name)
 	if err != nil {
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("Unknown target '%s'", alias)
+		return fmt.Errorf("Unknown target '%s'", name)
 	}
 	c.Current = alias
 	if reskip {
-		v.SkipVerify = true
+		c.Vaults[alias].SkipVerify = true
 	}
 	return nil
 }

--- a/pkg/rc/current_alias_test.go
+++ b/pkg/rc/current_alias_test.go
@@ -1,0 +1,97 @@
+package rc
+
+// A target can be named by its alias or by its URL: Alias resolves either to
+// the key the target is stored under. SetCurrent used to record the name it was
+// handed rather than that key, so targeting by URL left `current' holding a URL
+// -- a name that resolves only for as long as exactly one target still carries
+// it.
+
+import "testing"
+
+func twoTargets() Config {
+	return Config{
+		Vaults: map[string]*Vault{
+			"prod":  {URL: "https://prod.example.com:8200"},
+			"stage": {URL: "https://stage.example.com:8200/"},
+		},
+	}
+}
+
+// The URL is a name for the target, not a name for the current selection.
+func TestSetCurrentRecordsTheAliasWhenNamedByURL(t *testing.T) {
+	for _, tc := range []struct{ name, want string }{
+		{"prod", "prod"},
+		{"https://prod.example.com:8200", "prod"},
+		//Alias tolerates the trailing slash on either side of the comparison,
+		// and so does the name that comes back.
+		{"https://prod.example.com:8200/", "prod"},
+		{"https://stage.example.com:8200", "stage"},
+	} {
+		c := twoTargets()
+		if err := c.SetCurrent(tc.name, false); err != nil {
+			t.Errorf("SetCurrent(%q): %v", tc.name, err)
+			continue
+		}
+		if c.Current != tc.want {
+			t.Errorf("SetCurrent(%q) left current = %q, want %q", tc.name, c.Current, tc.want)
+		}
+	}
+}
+
+// The stored name is what everything else compares against, so it has to be
+// the map key: a lookup that happens to work today is not the same as a name
+// that names the target.
+func TestCurrentNamesAKeyOfTheVaultMap(t *testing.T) {
+	c := twoTargets()
+	if err := c.SetCurrent("https://stage.example.com:8200", false); err != nil {
+		t.Fatalf("SetCurrent: %v", err)
+	}
+	if _, ok := c.Vaults[c.Current]; !ok {
+		t.Errorf("current = %q, which is not one of the targets", c.Current)
+	}
+}
+
+// A name that reaches no target is still refused, and leaves the selection
+// alone rather than pointing it at nothing.
+func TestSetCurrentRefusesAnUnknownName(t *testing.T) {
+	c := twoTargets()
+	c.Current = "prod"
+	if err := c.SetCurrent("https://ghost.example.com", false); err == nil {
+		t.Fatal("SetCurrent with an unknown URL returned nil, want a refusal")
+	}
+	if c.Current != "prod" {
+		t.Errorf("current = %q, want the previous selection kept", c.Current)
+	}
+}
+
+// --insecure applies to the target that was named, however it was named.
+func TestSetCurrentReskipsTheTargetNamedByURL(t *testing.T) {
+	c := twoTargets()
+	if err := c.SetCurrent("https://prod.example.com:8200", true); err != nil {
+		t.Fatalf("SetCurrent: %v", err)
+	}
+	if !c.Vaults["prod"].SkipVerify {
+		t.Error("prod should have been marked skip_verify")
+	}
+	if c.Vaults["stage"].SkipVerify {
+		t.Error("stage should have been left alone")
+	}
+}
+
+// A URL two targets share names neither of them. The ambiguity is reported
+// rather than resolved by whichever key the map happened to yield.
+func TestSetCurrentReportsAnAmbiguousURL(t *testing.T) {
+	c := Config{
+		Current: "one",
+		Vaults: map[string]*Vault{
+			"one": {URL: "https://shared.example.com"},
+			"two": {URL: "https://shared.example.com"},
+		},
+	}
+	if err := c.SetCurrent("https://shared.example.com", false); err == nil {
+		t.Fatal("SetCurrent with a shared URL returned nil, want a refusal")
+	}
+	if c.Current != "one" {
+		t.Errorf("current = %q, want the previous selection kept", c.Current)
+	}
+}


### PR DESCRIPTION
Four defects in `safe target`, each reproduced against a live Vault before the fix. One of them leaves `safe` unusable until `~/.saferc` is edited by hand.

## A target selected by its URL is recorded by its URL

A target is named by its alias or by the address it is at, and both work everywhere a name is taken. `SetCurrent` wrote back whichever of the two it was handed, so targeting by address left `current:` holding an address:

```
$ safe target http://127.0.0.1:8210
Currently targeting http://127.0.0.1:8210 at http://127.0.0.1:8210

--- ~/.saferc ---
current: http://127.0.0.1:8210
vaults:
  dev:
    url: http://127.0.0.1:8210
```

An address names a target only while exactly one target carries it, and it is not the key anything else compares against. Two things follow.

The listing loses the marker it says it is showing:

```
$ safe targets

Known Vault targets - current target indicated with a (*):
    dev  	 (insecure) http://127.0.0.1:8210
    other	 (insecure) http://127.0.0.1:8299
```

And deleting that target by alias leaves the selection naming something that is no longer in the file:

```
$ safe target delete dev
!! Current target 'http://127.0.0.1:8210' not found in ~/.saferc
[exit 1]

--- ~/.saferc ---
current: http://127.0.0.1:8210
vaults:
  other:
    url: http://127.0.0.1:8299

$ safe get secret/probe:key
!! Current target 'http://127.0.0.1:8210' not found in ~/.saferc
[exit 1]
```

The failure arrives after the file has already been written that way, and every later command reads it the same way, so `safe` stays in that state until someone edits `~/.saferc`.

`SetCurrent` now resolves the name and records the alias. Deleting a target also checks that the selection still reaches a target rather than matching the name literally, which repairs a config already written by an older `safe`:

```
$ safe target delete dev
[exit 0]

--- ~/.saferc ---
current: ""

$ safe get secret/probe:key
You are not targeting a Vault.
Try safe target https://your-vault alias
```

## Two arguments where neither is an address are filed anyway

The two-argument form takes an address and a name in either order, and told them apart by looking for a literal `http://` or `https://` on the second one. An address typed without its scheme failed that test, so the arguments were swapped on the assumption that the first one was the address:

```
$ safe target ops vault.example.com
Currently targeting vault.example.com at ops
Uses Strongbox at http://:8484/strongbox
[exit 0]

--- ~/.saferc ---
  vault.example.com:
    url: ops
```

The target is filed under the address and points at the name. `ops` parses as a URL with no scheme and no host, so it becomes `:80` and every command run against that target goes to whatever answers on port 80 of localhost. `safe target ops https://` was accepted on the same terms.

Both arguments are now read as addresses -- a scheme `safe` speaks and a host to reach -- and neither of them being one is said rather than guessed at:

```
$ safe target ops vault.example.com
!! neither `ops' nor `vault.example.com' is the address of a Vault: an address carries the scheme it is reached over, as in `safe target https://vault.example.com ops'
[exit 1]
```

Reading the address instead of matching a prefix also accepts a scheme in any case, and rejects one no URL can be read out of.

## The new target is reported before it is saved

`safe target` printed the target it had selected and saved it afterwards, so a configuration that could not be written was answered with the new target on the screen, the write error under it, and the old target still in the file:

```
$ safe target other
Currently targeting other at http://127.0.0.1:8299
Uses Strongbox at http://127.0.0.1:8484/strongbox

!! open /.../.saferc: permission denied
[exit 1]
```

Now the write comes first, and nothing is reported that was not stored.

## Documentation

The help for `target` said the flags belonged to the single-argument form, which is the one form none of them describes a target in, and never said what tells the address and the alias apart. `target delete` had no description at all. The README's targeting section now covers both names, the scheme, and what deleting the current target leaves behind.

## Verification

`make check` (fmt, vet, staticcheck, tests) and `go test -race -count=1 ./...` pass; each of the five commits builds and passes `./internal/cli/ ./pkg/rc/` on its own.

Eleven mutations of the changed code, all killed: recording the name instead of the alias (6), dropping the reskip (3), accepting an unknown name (build), comparing the deleted name literally (1), always clearing the selection (2), reading only the second argument as an address (4), returning the swapped pair unswapped (4), dropping the host requirement (2), accepting two arguments that name no address (6), and reporting before saving in either form (1 each).

Coverage of the changed code: `cmdTarget` 0.0% → 39.8%, `cmdTargets` 40.0% → 88.0%, `rc.SetCurrent` 88.9% → 100%, with `targetArgs` and `isVaultAddress` new at 100%.

The transcripts above are from a full run of the same script against a dev Vault with the develop build and this one, which also confirms that targeting, `auth token`, `set`, and `get` still work end to end.
