### PR TITLE
Fix what safe x509 reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,17 @@ expiry.
 private key is held offline or by another team can still be validated
 against.
 
+### x509 show path \[path ...\]
+
+Print what is known about the certificate at each _path_: who issued
+it, what names it is valid for, what its key is, how long it was
+issued for, and how much of that is left.  Only the certificate is
+read, so a path holding no private key can still be shown.
+
+Each path is reported in turn.  A path that holds no certificate, or
+that cannot be read, is reported as such and the rest are still shown;
+the command exits non-zero if any path could not be shown.
+
 ### x509 crl --renew path
 
 Renews (re-signs) the certificate authority at `path`, without

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1499,6 +1499,13 @@ prints out information about a certificate, including:
   - What names / IPs is it valid for?
   - When does it expire?
 
+Only the certificate is read, so a path that holds no private key can
+still be shown.
+
+Each path is reported in turn.  A path that holds no certificate, or that
+cannot be read, is reported as such and the paths after it are still
+shown; the command exits non-zero if any path could not be shown.
+
 `,
 	}, c.cmdX509Show)
 

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -45,7 +45,12 @@ func (r *Runner) Dispatch(command string, help *Help, fn Handler) {
 	}
 
 	r.Handlers[command] = fn
-	if help != nil && help.Type != HiddenCommand {
+	//A hidden command is kept out of the listing of commands, which is where
+	// Help leaves it out. Keeping it out of the topics as well took its help
+	// with it: `safe help x509' and `safe x509' -- which prints that very
+	// topic -- both answered that there is no such command, and the
+	// description of every x509 sub-command was unreachable.
+	if help != nil {
 		r.Topics[command] = help
 	}
 }
@@ -65,7 +70,7 @@ func (r *Runner) Help(out io.Writer, topic string) {
 
 		sort.Strings(ll)
 		for _, cmd := range ll {
-			if h := r.Topics[cmd]; h != nil {
+			if h := r.Topics[cmd]; h != nil && h.Type != HiddenCommand {
 				f := h.Type
 				if f == "" {
 					f = "@W"

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"errors"
 	"strings"
 	"testing"
@@ -52,21 +53,49 @@ func TestRunner_Dispatch_RegistersHandlerAndTopic(t *testing.T) {
 	}
 }
 
-// TestRunner_Dispatch_HiddenCommand verifies that HIDEME commands are not added
-// to Topics (so they won't appear in help listings).
+// A hidden command is one the listing of commands leaves out. Its help is
+// still meant to be reachable: `safe x509' is hidden and prints its own topic
+// to say what its sub-commands are.
 func TestRunner_Dispatch_HiddenCommand(t *testing.T) {
 	t.Parallel()
 	r := NewRunner()
 	r.Dispatch("secret-internal", &Help{
-		Summary: "hidden",
-		Type:    HiddenCommand,
+		Summary:     "hidden",
+		Usage:       "safe secret-internal",
+		Description: "what the hidden command is for",
+		Type:        HiddenCommand,
 	}, func(cmd string, args ...string) error { return nil })
 
-	if _, inTopics := r.Topics["secret-internal"]; inTopics {
-		t.Error("hidden command should not appear in Topics")
-	}
 	if _, inHandlers := r.Handlers["secret-internal"]; !inHandlers {
 		t.Error("hidden command should still be in Handlers")
+	}
+
+	var help bytes.Buffer
+	r.Help(&help, "secret-internal")
+	if !strings.Contains(help.String(), "what the hidden command is for") {
+		t.Errorf("help for a hidden command = %q, want its description", help.String())
+	}
+
+	var listing bytes.Buffer
+	r.Help(&listing, "commands")
+	if strings.Contains(listing.String(), "secret-internal") {
+		t.Errorf("listing = %q, want a hidden command left out of it", listing.String())
+	}
+}
+
+// The listing keeps the commands that are not hidden.
+func TestRunner_Help_ListsVisibleCommands(t *testing.T) {
+	t.Parallel()
+	r := NewRunner()
+	r.Dispatch("ping", &Help{
+		Summary: "ping summary",
+		Type:    NonDestructiveCommand,
+	}, func(cmd string, args ...string) error { return nil })
+
+	var listing bytes.Buffer
+	r.Help(&listing, "commands")
+	if !strings.Contains(listing.String(), "ping") {
+		t.Errorf("listing = %q, want it to name ping", listing.String())
 	}
 }
 

--- a/internal/cli/x509.go
+++ b/internal/cli/x509.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math/big"
 	"os"
+	"strings"
 	"time"
 
 	fmt "github.com/jhunt/go-ansi"
@@ -578,22 +579,34 @@ func (c *CLI) cmdX509Show(command string, args ...string) error {
 	}
 	v := connect(true)
 
-	for _, path := range args {
-		s, err := v.Read(path)
-		if err != nil {
-			return err
-		}
+	//A path that holds no certificate was reported on the screen and nowhere
+	// else, so a run that showed nothing at all still exited 0 and a script
+	// checking a batch of paths was told they were fine. A path that could
+	// not be read ended the run where it stood, leaving the paths after it
+	// unreported. Both are now said as they are reached, and the run answers
+	// for them at the end.
+	var unshown []string
 
+	for _, path := range args {
 		_, _ = fmt.Printf("%s:\n", path)
-		cert, err := s.X509(false)
+
+		var cert *vault.X509
+		s, err := v.Read(path)
+		if err == nil {
+			cert, err = s.X509(false)
+		}
 		if err != nil {
 			_, _ = fmt.Printf("  !! %s\n\n", err)
+			unshown = append(unshown, path)
 			continue
 		}
 
 		printX509(os.Stdout, cert)
 	}
 
+	if len(unshown) > 0 {
+		return fmt.Errorf("no certificate to show at %s", strings.Join(unshown, ", "))
+	}
 	return nil
 }
 

--- a/internal/cli/x509.go
+++ b/internal/cli/x509.go
@@ -779,7 +779,14 @@ func printX509(w io.Writer, cert *vault.X509) {
 		x509.SHA384WithRSAPSS:          "SHA384 With RSAPSS",
 		x509.SHA512WithRSAPSS:          "SHA512 With RSAPSS",
 	}
-	sigAlgo := sigView[cert.Certificate.SignatureAlgorithm]
+	//An algorithm the table above does not name is named the way Go names it,
+	// which for Ed25519 -- what `safe x509 issue --type ed25519' signs with --
+	// is `Ed25519'. Reading the table alone, the line came out with nothing
+	// after it.
+	sigAlgo, ok := sigView[cert.Certificate.SignatureAlgorithm]
+	if !ok {
+		sigAlgo = cert.Certificate.SignatureAlgorithm.String()
+	}
 	_, _ = fmt.Fprintf(w, "@G{%s}\n", sigAlgo)
 	_, _ = fmt.Fprintf(w, "\n")
 

--- a/internal/cli/x509.go
+++ b/internal/cli/x509.go
@@ -606,6 +606,15 @@ func daysAway(d time.Duration) int {
 	return int((d + day/2) / day)
 }
 
+// count names a quantity of something, in the singular when there is one of
+// it.
+func count(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, noun)
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}
+
 // printX509 renders the human-readable detail block for a single
 // certificate to w. Output is identical to the original inline
 // rendering in cmdX509Show (go-ansi Printf is Fprintf to os.Stdout).
@@ -664,11 +673,20 @@ func printX509(w io.Writer, cert *vault.X509) {
 	}
 	_, _ = fmt.Fprintf(w, "  valid from @C{%s} - @C{%s}", cert.Certificate.NotBefore.Format("Jan 2 2006"), cert.Certificate.NotAfter.Format("Jan 2 2006"))
 
-	life := int(cert.Certificate.NotAfter.Sub(cert.Certificate.NotBefore).Hours())
-	if life < 360*24 {
-		_, _ = fmt.Fprintf(w, " (@M{~%d days})\n", life/24)
-	} else {
-		_, _ = fmt.Fprintf(w, " (@M{~%d years})\n", life/365/24)
+	//The life a certificate was issued for is given in the largest unit that
+	// counts it. Years and days used to be the only two, divided at 360 days
+	// -- five short of the year the years are counted in -- so a life of 360
+	// to 364 days divided to nothing and was reported as `~0 years'. A life
+	// of a few hours, which `--ttl 12h' asks for, had the same nothing to say
+	// for itself in days.
+	life := cert.Certificate.NotAfter.Sub(cert.Certificate.NotBefore)
+	switch {
+	case life < day:
+		_, _ = fmt.Fprintf(w, " (@M{~%s})\n", count(int(life/time.Hour), "hour"))
+	case life < 365*day:
+		_, _ = fmt.Fprintf(w, " (@M{~%s})\n", count(int(life/day), "day"))
+	default:
+		_, _ = fmt.Fprintf(w, " (@M{~%s})\n", count(int(life/(365*day)), "year"))
 	}
 	_, _ = fmt.Fprintf(w, "\n")
 

--- a/internal/cli/x509.go
+++ b/internal/cli/x509.go
@@ -597,6 +597,15 @@ func (c *CLI) cmdX509Show(command string, args ...string) error {
 	return nil
 }
 
+const day = 24 * time.Hour
+
+// daysAway rounds a span of time still to come to the nearest whole day, so
+// that a span of very nearly n days is reported as n rather than as the n-1
+// whole days it technically holds.
+func daysAway(d time.Duration) int {
+	return int((d + day/2) / day)
+}
+
 // printX509 renders the human-readable detail block for a single
 // certificate to w. Output is identical to the original inline
 // rendering in cmdX509Show (go-ansi Printf is Fprintf to os.Stdout).
@@ -614,25 +623,43 @@ func printX509(w io.Writer, cert *vault.X509) {
 	toStart := time.Until(cert.Certificate.NotBefore)
 	toEnd := time.Until(cert.Certificate.NotAfter)
 
-	days := int(toStart.Hours() / 24)
-	if days == 1 {
-		_, _ = fmt.Fprintf(w, "  @Y{not valid for another day}\n")
-	} else if days > 1 {
+	//A wait or a countdown is reported to the nearest day rather than in
+	// whole days elapsed. A certificate issued to run for 30 days is a moment
+	// short of 30 days old the instant it is written, and counting whole days
+	// reported every one of them one day short.
+	switch days := daysAway(toStart); {
+	case toStart <= 0:
+		//Already in force; nothing to say about it starting.
+	case days <= 1:
+		//Rounding a wait of a few hours to no days at all said nothing at
+		// all, and a certificate that cannot be used yet read as usable.
+		if toStart < day {
+			_, _ = fmt.Fprintf(w, "  @Y{not valid yet}\n")
+		} else {
+			_, _ = fmt.Fprintf(w, "  @Y{not valid for another day}\n")
+		}
+	default:
 		_, _ = fmt.Fprintf(w, "  @Y{not valid for another %d days}\n", days)
 	}
 
-	days = int(toEnd.Hours() / 24)
-	if days < -1 {
-		_, _ = fmt.Fprintf(w, "  @R{EXPIRED %d days ago}\n", -1*days)
-	} else if days < 0 {
+	//Time already spent is counted in whole days, which is how "expired two
+	// days ago" is read; time still to come is rounded, as above.
+	switch days := daysAway(toEnd); {
+	case toEnd <= -2*day:
+		_, _ = fmt.Fprintf(w, "  @R{EXPIRED %d days ago}\n", int(-toEnd/day))
+	case toEnd <= -day:
 		_, _ = fmt.Fprintf(w, "  @R{EXPIRED a day ago}\n")
-	} else if days < 1 {
+	case toEnd <= 0:
 		_, _ = fmt.Fprintf(w, "  @R{EXPIRED}\n")
-	} else if days == 1 {
+	case toEnd < day:
+		//The case whole days cannot tell from an expired certificate: still
+		// valid, and out of days. It used to be reported as EXPIRED.
+		_, _ = fmt.Fprintf(w, "  @Y{expires in less than a day}\n")
+	case days <= 1:
 		_, _ = fmt.Fprintf(w, "  @Y{expires in a day}\n")
-	} else if days < 30 {
+	case days < 30:
 		_, _ = fmt.Fprintf(w, "  @Y{expires in %d days}\n", days)
-	} else {
+	default:
 		_, _ = fmt.Fprintf(w, "  expires in @G{%d days}\n", days)
 	}
 	_, _ = fmt.Fprintf(w, "  valid from @C{%s} - @C{%s}", cert.Certificate.NotBefore.Format("Jan 2 2006"), cert.Certificate.NotAfter.Format("Jan 2 2006"))

--- a/internal/cli/x509_help_test.go
+++ b/internal/cli/x509_help_test.go
@@ -1,0 +1,39 @@
+package cli
+
+// `safe x509' is dispatched to a handler that prints the x509 help topic, and
+// the topic is registered hidden so the umbrella command stays out of the
+// listing of commands. A hidden command used to be left out of the help
+// entirely, so both `safe x509' and `safe help x509' answered that there is no
+// such command -- and the description of every x509 sub-command went with it.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestX509PrintsTheHelpForItsSubcommands(t *testing.T) {
+	r := NewRunner()
+	c := &CLI{opt: &Options{}, r: r}
+	r.Dispatch("x509", &Help{
+		Summary:     "Issue / Revoke X.509 Certificates and Certificate Authorities",
+		Usage:       "safe x509 <command> [OPTIONS]",
+		Type:        HiddenCommand,
+		Description: "x509 provides a handful of sub-commands for issuing certificates.",
+	}, c.cmdX509)
+
+	out := captureStdout(t, func() {
+		if err := c.cmdX509("x509"); err != nil {
+			t.Fatalf("cmdX509: %v", err)
+		}
+	})
+
+	for _, want := range []string{
+		"Issue / Revoke X.509 Certificates",
+		"safe x509 <command> [OPTIONS]",
+		"a handful of sub-commands",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("`safe x509' printed %q, want it to contain %q", out, want)
+		}
+	}
+}

--- a/internal/cli/x509_show_test.go
+++ b/internal/cli/x509_show_test.go
@@ -216,6 +216,70 @@ func TestPrintX509_NamesAnAlgorithmItDoesNotKnow(t *testing.T) {
 	}
 }
 
+// A path that holds something other than a certificate was reported on the
+// screen and nowhere else: the command exited 0, and a script checking a
+// batch of paths was told everything was fine. A path that could not be read
+// at all ended the run where it stood, so the paths after it went unreported.
+func TestX509ShowFailsOnAPathItCouldNotShow(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	ca := newCA(t, "ca")
+	storeCert(t, fv, "secret/leaf", newLeaf(t, ca, "leaf"))
+	fv.set("secret/password", map[string]string{"password": "sekrit"})
+
+	c := newX509CLI(t)
+
+	var err error
+	out := captureStdout(t, func() {
+		err = c.cmdX509Show("x509 show", "secret/password", "secret/nowhere", "secret/leaf")
+	})
+
+	if err == nil {
+		t.Fatal("show over a path holding no certificate = nil, want an error")
+	}
+	for _, path := range []string{"secret/password", "secret/nowhere"} {
+		if !strings.Contains(err.Error(), path) {
+			t.Errorf("error %q should name %s", err, path)
+		}
+	}
+	if strings.Contains(err.Error(), "secret/leaf") {
+		t.Errorf("error %q should not name the path it showed", err)
+	}
+
+	//Every path is still reported, including the ones after the failures.
+	for _, want := range []string{
+		"secret/password:", "not a valid certificate",
+		"secret/nowhere:", "secret/leaf:", "cn=leaf",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output should contain %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestX509ShowSucceedsWhenItShowedEveryPath(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	ca := newCA(t, "ca")
+	storeCert(t, fv, "secret/ca", ca)
+	storeCert(t, fv, "secret/leaf", newLeaf(t, ca, "leaf"))
+
+	c := newX509CLI(t)
+
+	var err error
+	out := captureStdout(t, func() {
+		err = c.cmdX509Show("x509 show", "secret/ca", "secret/leaf")
+	})
+	if err != nil {
+		t.Fatalf("show over two certificates: %v", err)
+	}
+	for _, want := range []string{"cn=ca", "cn=leaf", "is a CA", "is not a CA"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output should contain %q\n---\n%s", want, out)
+		}
+	}
+}
+
 // A certificate already in force says nothing about coming into force.
 func TestPrintX509_SaysNothingAboutForceForACertificateInForce(t *testing.T) {
 	now := time.Now()

--- a/internal/cli/x509_show_test.go
+++ b/internal/cli/x509_show_test.go
@@ -136,6 +136,36 @@ func TestPrintX509_ReportsACertificateThatIsNotInForceYet(t *testing.T) {
 	}
 }
 
+// The life a certificate was issued for is reported alongside its dates, in
+// years for a life of a year or more and in days for anything shorter. The
+// two were divided at 360 days, five days below the year the first of them
+// divides by, so a life between the two reported as no time at all -- as did
+// a life of a few hours, which `--ttl 12h' asks for and which no count of
+// days can express.
+func TestPrintX509_ReportsTheLifeItWasIssuedFor(t *testing.T) {
+	now := time.Now()
+	for _, tc := range []struct {
+		name string
+		life time.Duration
+		want string
+	}{
+		{name: "an hour", life: time.Hour, want: "(~1 hour)"},
+		{name: "half a day", life: 12 * time.Hour, want: "(~12 hours)"},
+		{name: "ninety days", life: 90 * day, want: "(~90 days)"},
+		{name: "just under a year", life: 363 * day, want: "(~363 days)"},
+		{name: "a year", life: 365 * day, want: "(~1 year)"},
+		{name: "two years", life: 730 * day, want: "(~2 years)"},
+		{name: "ten years", life: 3650 * day, want: "(~10 years)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := showOutput(t, showCert(t, now, now.Add(tc.life)))
+			if !strings.Contains(out, tc.want) {
+				t.Errorf("output should report a life of %q\n---\n%s", tc.want, out)
+			}
+		})
+	}
+}
+
 // A certificate already in force says nothing about coming into force.
 func TestPrintX509_SaysNothingAboutForceForACertificateInForce(t *testing.T) {
 	now := time.Now()

--- a/internal/cli/x509_show_test.go
+++ b/internal/cli/x509_show_test.go
@@ -1,0 +1,146 @@
+package cli
+
+// `safe x509 show' reports how much life a certificate has left. The report
+// was built from the number of whole days between now and the dates on the
+// certificate, and a day that is not yet whole counts as none: a certificate
+// with hours left to run was reported EXPIRED, and one that had not come into
+// force yet was reported as though it had.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// showCert builds a certificate whose validity window is exactly the one the
+// test names. The window is set after signing, which is what a certificate
+// read back out of Vault presents.
+func showCert(t *testing.T, notBefore, notAfter time.Time) *vault.X509 {
+	t.Helper()
+	cert := signedCert(t, "CN=leaf.example.com", []string{"leaf.example.com"}, false)
+	cert.Certificate.Issuer = cert.Certificate.Subject
+	cert.Certificate.NotBefore = notBefore
+	cert.Certificate.NotAfter = notAfter
+	return cert
+}
+
+func showOutput(t *testing.T, cert *vault.X509) string {
+	t.Helper()
+	var buf bytes.Buffer
+	printX509(&buf, cert)
+	return buf.String()
+}
+
+func TestPrintX509_ReportsWhatIsLeftOfTheValidityWindow(t *testing.T) {
+	now := time.Now()
+	for _, tc := range []struct {
+		name      string
+		notBefore time.Time
+		notAfter  time.Time
+		want      string
+		notWant   string
+	}{
+		{
+			name:      "expired three days ago",
+			notBefore: now.Add(-10 * day),
+			notAfter:  now.Add(-3 * day),
+			want:      "EXPIRED 3 days ago",
+		},
+		{
+			name:      "expired a day and a half ago",
+			notBefore: now.Add(-10 * day),
+			notAfter:  now.Add(-36 * time.Hour),
+			want:      "EXPIRED a day ago",
+		},
+		{
+			name:      "expired this morning",
+			notBefore: now.Add(-10 * day),
+			notAfter:  now.Add(-2 * time.Hour),
+			want:      "EXPIRED",
+			notWant:   "ago",
+		},
+		{
+			//The case a whole-day count cannot tell from an expired
+			// certificate: still valid, and out of days.
+			name:      "expires within the day",
+			notBefore: now.Add(-10 * day),
+			notAfter:  now.Add(12 * time.Hour),
+			want:      "expires in less than a day",
+			notWant:   "EXPIRED",
+		},
+		{
+			name:      "expires tomorrow",
+			notBefore: now.Add(-10 * day),
+			notAfter:  now.Add(30 * time.Hour),
+			want:      "expires in a day",
+		},
+		{
+			name:      "expires in a fortnight",
+			notBefore: now.Add(-day),
+			notAfter:  now.Add(14 * day),
+			want:      "expires in 14 days",
+		},
+		{
+			name:      "expires well after the warning window",
+			notBefore: now.Add(-day),
+			notAfter:  now.Add(400 * day),
+			want:      "expires in 400 days",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := showOutput(t, showCert(t, tc.notBefore, tc.notAfter))
+			if !strings.Contains(out, tc.want) {
+				t.Errorf("output should report %q\n---\n%s", tc.want, out)
+			}
+			if tc.notWant != "" && strings.Contains(out, tc.notWant) {
+				t.Errorf("output should not say %q\n---\n%s", tc.notWant, out)
+			}
+		})
+	}
+}
+
+func TestPrintX509_ReportsACertificateThatIsNotInForceYet(t *testing.T) {
+	now := time.Now()
+	for _, tc := range []struct {
+		name      string
+		notBefore time.Time
+		want      string
+	}{
+		{
+			name:      "comes into force in three days",
+			notBefore: now.Add(3 * day),
+			want:      "not valid for another 3 days",
+		},
+		{
+			name:      "comes into force tomorrow",
+			notBefore: now.Add(30 * time.Hour),
+			want:      "not valid for another day",
+		},
+		{
+			//A wait shorter than a day rounded to no days at all, and
+			// nothing was said about it: the certificate read as usable.
+			name:      "comes into force this afternoon",
+			notBefore: now.Add(12 * time.Hour),
+			want:      "not valid yet",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := showOutput(t, showCert(t, tc.notBefore, now.Add(100*day)))
+			if !strings.Contains(out, tc.want) {
+				t.Errorf("output should report %q\n---\n%s", tc.want, out)
+			}
+		})
+	}
+}
+
+// A certificate already in force says nothing about coming into force.
+func TestPrintX509_SaysNothingAboutForceForACertificateInForce(t *testing.T) {
+	now := time.Now()
+	out := showOutput(t, showCert(t, now.Add(-day), now.Add(100*day)))
+	if strings.Contains(out, "not valid") {
+		t.Errorf("output should not talk about validity starting\n---\n%s", out)
+	}
+}

--- a/internal/cli/x509_show_test.go
+++ b/internal/cli/x509_show_test.go
@@ -8,6 +8,7 @@ package cli
 
 import (
 	"bytes"
+	"crypto/x509"
 	"strings"
 	"testing"
 	"time"
@@ -163,6 +164,55 @@ func TestPrintX509_ReportsTheLifeItWasIssuedFor(t *testing.T) {
 				t.Errorf("output should report a life of %q\n---\n%s", tc.want, out)
 			}
 		})
+	}
+}
+
+// Every algorithm safe will sign with has a name to report. Ed25519 -- which
+// `safe x509 issue --type ed25519' produces, and which --sig-algorithm names
+// as well -- had none, and the line reporting it came out with nothing after
+// it.
+func TestPrintX509_NamesTheAlgorithmItWasSignedWith(t *testing.T) {
+	for _, tc := range []struct {
+		keyType string
+		curve   string
+		bits    int
+		want    string
+	}{
+		{keyType: "rsa", bits: 2048, want: "signed with the algorithm SHA512 With RSA"},
+		{keyType: "ec", curve: "p256", want: "signed with the algorithm ECDSA With SHA256"},
+		{keyType: "ed25519", want: "signed with the algorithm Ed25519"},
+	} {
+		t.Run(tc.keyType, func(t *testing.T) {
+			spec, err := vault.ResolveKeySpec(tc.keyType, tc.bits, tc.curve, nil)
+			if err != nil {
+				t.Fatalf("ResolveKeySpec(%s): %v", tc.keyType, err)
+			}
+			cert, err := vault.NewCertificate("CN=leaf.example.com",
+				[]string{"leaf.example.com"}, []string{"server_auth"}, "", spec)
+			if err != nil {
+				t.Fatalf("NewCertificate(%s): %v", tc.keyType, err)
+			}
+			if err := cert.Sign(cert, 30*day); err != nil {
+				t.Fatalf("Sign(%s): %v", tc.keyType, err)
+			}
+
+			if out := showOutput(t, cert); !strings.Contains(out, tc.want) {
+				t.Errorf("output should report %q\n---\n%s", tc.want, out)
+			}
+		})
+	}
+}
+
+// An algorithm safe has no name of its own for is reported by the name Go
+// gives it, rather than as a blank.
+func TestPrintX509_NamesAnAlgorithmItDoesNotKnow(t *testing.T) {
+	now := time.Now()
+	cert := showCert(t, now, now.Add(30*day))
+	cert.Certificate.SignatureAlgorithm = x509.SignatureAlgorithm(0xff)
+
+	want := "signed with the algorithm " + x509.SignatureAlgorithm(0xff).String()
+	if out := showOutput(t, cert); !strings.Contains(out, want) {
+		t.Errorf("output should report %q\n---\n%s", want, out)
 	}
 }
 


### PR DESCRIPTION
Five things `safe x509` reported wrongly, each reproduced against a dev Vault before the fix. One of them calls a certificate that is still in use expired; another says the command you just ran does not exist.

## `safe x509` says there is no such command

The `x509` command is dispatched to a handler whose whole job is to print the x509 help topic, and the topic is registered as a hidden command so the umbrella does not clutter the listing of commands. Hiding it was done by leaving it out of the help topics, which is where the listing reads from — and where the help reads from too:

```
$ safe x509
Unrecognized command or help topic 'x509'
Try 'safe help' to get started with safe,
 or 'safe commands' for a list of valid commands
[exit 1]

$ safe help x509
Unrecognized command or help topic 'x509'
[exit 1]
```

The description of every x509 sub-command lives in that topic, so all of it was unreachable. Hidden commands are now left out where the listing is built instead, and the listing is byte-for-byte what it was:

```
$ safe x509
safe x509 - Issue / Revoke X.509 Certificates and Certificate Authorities
USAGE: safe x509 <command> [OPTIONS]

x509 provides a handful of sub-commands for issuing, signing and revoking
SSL/TLS X.509 Certificates.  It does not utilize the pki Vault backend;
instead, all certificates and RSA keys are generated by the CLI itself,
and stored wherever you tell it to.
...
[exit 0]
```

## A certificate with hours left to run is reported EXPIRED

How much life a certificate has left was worked out from the whole days between now and the dates on it, and a day that is not yet whole counts as none. A certificate issued a moment ago, to run for twelve hours, reads as one that has already gone:

```
$ safe x509 issue --name short.example.com --ttl 12h secret/short
$ safe x509 show secret/short
secret/short:
  cn=short.example.com

  self-signed
  EXPIRED
  valid from Jul 31 2026 - Aug 1 2026 (~0 days)
```

The same rounding hid the other end of the window: a certificate that comes into force later today counted zero days of waiting, so nothing was said about it at all and it read as usable.

And a countdown always read one day short, because a certificate is a moment short of the span it was issued for the instant it is written — a 30-day certificate said `expires in 29 days`, and a 363-day one said 362.

Whether a certificate is in force is now read from its dates, and the days to a date are counted to the nearest day:

```
$ safe x509 show secret/short
secret/short:
  cn=short.example.com

  self-signed
  expires in less than a day
  valid from Jul 31 2026 - Aug 1 2026 (~12 hours)
```

## The life it was issued for is reported in a unit that cannot count it

The life is given in years once it reaches one and in days below that, and the two were divided at 360 days — five days short of the year the years are counted in. Everything in between divided to nothing:

```
$ safe x509 issue --name year.example.com --ttl 363d secret/year
$ safe x509 show secret/year
  expires in 362 days
  valid from Jul 31 2026 - Jul 29 2027 (~0 years)
```

A life of a few hours, which `--ttl 12h` asks for, had the same nothing to say for itself in days (`~0 days`, above). The years now divide at the year being counted, a life shorter than a day is given in hours, and one of anything is named in the singular — a year-long certificate used to report `~1 years`.

```
$ safe x509 show secret/year
  expires in 363 days
  valid from Jul 31 2026 - Jul 29 2027 (~363 days)
```

## An Ed25519 certificate does not say what signed it

The algorithm names come from a table of the ones `safe` knew about, and an algorithm missing from it was reported as a blank. Ed25519 was missing, though `safe x509 issue --type ed25519` signs with it and `--sig-algorithm ed25519` asks for it by name:

```
$ safe x509 issue --name ed.example.com --type ed25519 --ttl 30d secret/ed
$ safe x509 show secret/ed
  key: Ed25519

  signed with the algorithm 
```

An algorithm the table does not name is now named the way Go names it, which for this one is `Ed25519`.

## `safe x509 show` exits 0 having shown nothing

A path holding something other than a certificate was reported on the screen and nowhere else, so a run that showed nothing still succeeded:

```
$ safe x509 show secret/pw
secret/pw:
  !! not a valid certificate (missing the `certificate` attribute)

[exit 0]
```

A path that could not be read at all ended the run where it stood, so the paths named after it went unreported:

```
$ safe x509 show secret/nowhere secret/ed
!! no secret exists at path `secret/nowhere`
[exit 1]
```

Both are now said as they are reached, the run carries on, and it answers for the paths it could not show at the end:

```
$ safe x509 show secret/nowhere secret/ed
secret/nowhere:
  !! no secret exists at path `secret/nowhere`

secret/ed:
  cn=ed.example.com
  ...
!! no certificate to show at secret/nowhere
[exit 1]
```

## Documentation

`x509 show` had no entry in the README; it has one now, covering both of the above and the fact that only the certificate is read, so a path holding no private key can still be shown. Its help says the same.

## Verification

`make check` (fmt, vet, staticcheck, tests) and `go test -race -count=1 ./...` pass; each of the six commits builds and passes `./internal/cli/` on its own.

Fourteen mutations of the changed code, all killed: hiding a command from the help again (the test binary exits, as the command does), listing the hidden commands (1), counting whole days rather than rounding (5), saying nothing about a wait of hours (2), measuring the wait from the wrong date (4), reading hours left as expired (2), deciding expiry from the day count (2), swapping a day ago with n days ago (3), dividing the years five days early (2), dropping the hours (3), pluralizing one of a thing (3), reporting an unnamed algorithm as a blank (3), letting a path with no certificate pass (1), and ending the run on an unreadable path (1).

Coverage of the changed code: `cmdX509` 0.0% → 100%, `cmdX509Show` 22.2% → 95.5%, `printX509` 72.0% → 80.8%, `Runner.Help` and `Runner.PrintUsage` 0.0% → covered, with `daysAway` and `count` new at 100%. The package moves 56.0% → 58.0%.

The transcripts above are from a full run of the same script against a dev Vault with the develop build and this one, which also confirms that targeting, `auth token`, `set`, and issuing certificates still work end to end.
