### PR TITLE
Fix what safe renew all does to each target

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,30 @@ safe auth okta
 For each type (token, ldap, okta or github), you will be prompted for
 the necessary credentials to authenticated against the Vault.
 
+A token does not last forever.  To put off its expiry, without
+authenticating again:
+
+```
+safe renew
+```
+
+That renews the token of the target you are on, or of the one
+`-T` names.  It extends the life of the token already saved; it
+does not obtain a new one, and a token that has already expired
+cannot be renewed.
+
+To renew the token of every target at once:
+
+```
+safe renew all
+```
+
+Targets are renewed in the order `safe targets` lists them.  A
+target with no saved token is skipped, and one that could not be
+renewed is reported and the rest are renewed anyway; the command
+exits non-zero with a count of what failed.  `-T` names a single
+target and is ignored here.
+
 Proxies
 -------
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -622,6 +622,21 @@ Flags:
 		Summary: "Renew one or more authentication tokens",
 		Usage:   "safe renew [all]\n",
 		Type:    AdministrativeCommand,
+		Description: `
+Puts off the expiry of the token 'safe' authenticated with, without
+authenticating again. It extends the life of the token already saved
+for the target; it does not obtain a new one, and a token that has
+already expired cannot be renewed.
+
+Without arguments, the token renewed is the one belonging to the
+target you are on, or to the target named by --target.
+
+With 'all', every configured target is renewed, in the order that
+'safe targets' lists them. A target with no saved token is skipped.
+A target that could not be renewed is reported and the rest are
+renewed anyway; the command then exits non-zero with a count of what
+failed. --target names a single target and is ignored in this form.
+`,
 	}, c.cmdRenew)
 
 	r.Dispatch("ask", &Help{

--- a/internal/cli/renew_test.go
+++ b/internal/cli/renew_test.go
@@ -194,6 +194,42 @@ vaults:
 	}
 }
 
+// Naming a target and asking for all of them at once is answered the way the
+// rest of safe answers it, rather than silently.
+func TestRenewAllSaysThatItIgnoresTheTargetFlag(t *testing.T) {
+	isolateHome(t)
+	alpha, beta := newRenewFake(t), newRenewFake(t)
+	writeSaferc(t, `version: 1
+current: alpha
+vaults:
+  alpha:
+    url: `+alpha.url+`
+    token: token-alpha
+  beta:
+    url: `+beta.url+`
+    token: token-beta
+`)
+
+	c := newRenewCLI(t)
+	c.opt.UseTarget = "beta"
+	var err error
+	said := captureStderr(t, func() {
+		_ = captureStdout(t, func() { err = c.cmdRenew("renew", "all") })
+	})
+	if err != nil {
+		t.Fatalf("renew all: %v", err)
+	}
+	if !strings.Contains(said, "ignoring") {
+		t.Errorf("output should say the target was ignored\n---\n%s", said)
+	}
+	//Ignored means every target is renewed, including the one -T named.
+	for alias, fv := range map[string]*fakeRenewVault{"alpha": alpha, "beta": beta} {
+		if got := fv.served(); len(got) != 1 {
+			t.Errorf("%s served %d renewals, want 1", alias, len(got))
+		}
+	}
+}
+
 // `all' is the only argument the command takes.
 func TestRenewRejectsAnyOtherArgument(t *testing.T) {
 	isolateHome(t)

--- a/internal/cli/renew_test.go
+++ b/internal/cli/renew_test.go
@@ -125,6 +125,32 @@ vaults:
 	}
 }
 
+// With no targets configured there is nothing for `renew all' to renew, and
+// it used to say so by printing nothing at all and succeeding. The token in
+// the environment, which plain `safe renew' does renew, is not a target and is
+// not covered by all.
+func TestRenewAllSaysWhenThereIsNothingToRenew(t *testing.T) {
+	isolateHome(t)
+	fv := newRenewFake(t)
+	t.Setenv("VAULT_ADDR", fv.url)
+	t.Setenv("VAULT_TOKEN", "token-from-the-environment")
+
+	c := newRenewCLI(t)
+	var err error
+	said := captureStderr(t, func() {
+		_ = captureStdout(t, func() { err = c.cmdRenew("renew", "all") })
+	})
+	if err != nil {
+		t.Fatalf("renew all with no targets: %v", err)
+	}
+	if !strings.Contains(said, "no targets") {
+		t.Errorf("output should say there are no targets to renew\n---\n%s", said)
+	}
+	if got := fv.served(); len(got) != 0 {
+		t.Errorf("the environment is not a target, and served %v", got)
+	}
+}
+
 // A target that cannot be connected to at all -- one carrying no address, or
 // an address that will not parse -- used to end the whole run where it stood,
 // with a message telling the user to target a Vault. The targets after it went

--- a/internal/cli/renew_test.go
+++ b/internal/cli/renew_test.go
@@ -125,6 +125,42 @@ vaults:
 	}
 }
 
+// Targets were renewed in whatever order the config map happened to hand
+// them over, so two runs over the same config reported them differently and
+// neither could be read against the last.
+func TestRenewAllVisitsTargetsInAStableOrder(t *testing.T) {
+	isolateHome(t)
+	aliases := []string{"delta", "alpha", "echo", "charlie", "bravo"}
+
+	saferc := "version: 1\ncurrent: alpha\nvaults:\n"
+	for _, alias := range aliases {
+		fv := newRenewFake(t)
+		saferc += "  " + alias + ":\n    url: " + fv.url + "\n    token: token-" + alias + "\n"
+	}
+	writeSaferc(t, saferc)
+
+	c := newRenewCLI(t)
+	var err error
+	out := captureStdout(t, func() { err = c.cmdRenew("renew", "all") })
+	if err != nil {
+		t.Fatalf("renew all: %v", err)
+	}
+
+	var renewed []string
+	for _, line := range strings.Split(out, "\n") {
+		alias, ok := strings.CutPrefix(line, "renewing token against ")
+		if !ok {
+			continue
+		}
+		renewed = append(renewed, strings.TrimSuffix(alias, "..."))
+	}
+
+	want := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+	if strings.Join(renewed, ",") != strings.Join(want, ",") {
+		t.Errorf("renewed %v, want %v", renewed, want)
+	}
+}
+
 func TestRenewAllRenewsEveryTargetThatHasAToken(t *testing.T) {
 	isolateHome(t)
 	alpha, beta := newRenewFake(t), newRenewFake(t)

--- a/internal/cli/renew_test.go
+++ b/internal/cli/renew_test.go
@@ -125,6 +125,75 @@ vaults:
 	}
 }
 
+// A target that cannot be connected to at all -- one carrying no address, or
+// an address that will not parse -- used to end the whole run where it stood,
+// with a message telling the user to target a Vault. The targets after it went
+// unrenewed and unmentioned, and the count of what failed was never printed.
+func TestRenewAllCarriesOnPastATargetItCannotConnectTo(t *testing.T) {
+	isolateHome(t)
+	good := newRenewFake(t)
+	writeSaferc(t, `version: 1
+current: zulu
+vaults:
+  aaa-broken:
+    url: ""
+    token: token-broken
+  zulu:
+    url: `+good.url+`
+    token: token-zulu
+`)
+
+	c := newRenewCLI(t)
+	var err error
+	problems := captureStderr(t, func() {
+		_ = captureStdout(t, func() { err = c.cmdRenew("renew", "all") })
+	})
+
+	if err == nil {
+		t.Fatal("renew all over a broken target = nil, want an error")
+	}
+	if !strings.Contains(problems, "aaa-broken") {
+		t.Errorf("the target that failed should be named\n---\n%s", problems)
+	}
+	if got := good.served(); len(got) != 1 {
+		t.Errorf("the target after the broken one served %d renewals, want 1", len(got))
+	}
+}
+
+// A token the Vault will not renew is counted, and the targets after it are
+// still renewed.
+func TestRenewAllCountsTheTokensItCouldNotRenew(t *testing.T) {
+	isolateHome(t)
+	alpha, beta := newRenewFake(t), newRenewFake(t)
+	alpha.reject = true
+	writeSaferc(t, `version: 1
+current: alpha
+vaults:
+  alpha:
+    url: `+alpha.url+`
+    token: token-alpha
+  beta:
+    url: `+beta.url+`
+    token: token-beta
+`)
+
+	c := newRenewCLI(t)
+	var err error
+	_ = captureStderr(t, func() {
+		_ = captureStdout(t, func() { err = c.cmdRenew("renew", "all") })
+	})
+
+	if err == nil {
+		t.Fatal("renew all over a rejected token = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "1") {
+		t.Errorf("error %q should count the one token it could not renew", err)
+	}
+	if got := beta.served(); len(got) != 1 {
+		t.Errorf("beta served %d renewals, want 1", len(got))
+	}
+}
+
 // Targets were renewed in whatever order the config map happened to hand
 // them over, so two runs over the same config reported them differently and
 // neither could be read against the last.

--- a/internal/cli/renew_test.go
+++ b/internal/cli/renew_test.go
@@ -1,0 +1,158 @@
+package cli
+
+// `safe renew all' renews the token of every configured target in turn, and
+// it is the only command that applies more than one target in a single run.
+// Applying a target sets the environment the Vault client is built from, and
+// a setting the next target does not carry was left behind by the one before
+// it: a target with certificate verification switched off switched it off for
+// every target renewed after it, and a namespace was sent to a Vault that has
+// none.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeRenewVault answers the token renewal endpoint and records what it was
+// asked with. Renewal is the only request the command makes of it.
+type fakeRenewVault struct {
+	mu  sync.Mutex
+	url string
+	//renewals holds one entry per renewal served, oldest first.
+	renewals []renewal
+	//reject makes every renewal answer 403, the way a Vault answers for a
+	// token that has already expired.
+	reject bool
+}
+
+type renewal struct{ token, namespace string }
+
+func newRenewFake(t *testing.T) *fakeRenewVault {
+	t.Helper()
+	f := &fakeRenewVault{}
+	srv := httptest.NewServer(f)
+	t.Cleanup(srv.Close)
+	f.url = srv.URL
+	return f
+}
+
+func (f *fakeRenewVault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if r.URL.Path != "/v1/auth/token/renew-self" || r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":[]}`))
+		return
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.renewals = append(f.renewals, renewal{
+		token:     r.Header.Get("X-Vault-Token"),
+		namespace: r.Header.Get("X-Vault-Namespace"),
+	})
+	if f.reject {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"errors":["permission denied"]}`))
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// served returns the renewals this Vault answered, in order.
+func (f *fakeRenewVault) served() []renewal {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]renewal(nil), f.renewals...)
+}
+
+// newRenewCLI builds a CLI with `renew' registered, so that a bad invocation
+// can find its usage.
+func newRenewCLI(t *testing.T) *CLI {
+	t.Helper()
+	r := NewRunner()
+	c := &CLI{opt: &Options{}, r: r}
+	r.Dispatch("renew", &Help{
+		Summary: "Renew one or more authentication tokens",
+		Usage:   "safe renew [all]\n",
+		Type:    AdministrativeCommand,
+	}, c.cmdRenew)
+	return c
+}
+
+// A target that says nothing about certificate verification or namespaces is
+// entitled to both: the settings of the target renewed before it are not its
+// own.
+func TestRenewAllDoesNotCarrySettingsBetweenTargets(t *testing.T) {
+	isolateHome(t)
+	alpha, beta := newRenewFake(t), newRenewFake(t)
+	writeSaferc(t, `version: 1
+current: alpha
+vaults:
+  alpha:
+    url: `+alpha.url+`
+    token: token-alpha
+    namespace: alpha-ns
+    skip_verify: true
+  beta:
+    url: `+beta.url+`
+    token: token-beta
+`)
+
+	c := newRenewCLI(t)
+	var err error
+	warnings := captureStderr(t, func() {
+		_ = captureStdout(t, func() { err = c.cmdRenew("renew", "all") })
+	})
+	if err != nil {
+		t.Fatalf("renew all: %v", err)
+	}
+
+	got := beta.served()
+	if len(got) != 1 {
+		t.Fatalf("beta served %d renewals, want 1", len(got))
+	}
+	if got[0].namespace != "" {
+		t.Errorf("beta was renewed in namespace %q, which belongs to alpha", got[0].namespace)
+	}
+
+	//Certificate verification being switched off is announced once per Vault
+	// built with it off, which is the only place the setting shows.
+	if n := strings.Count(warnings, "verification disabled"); n != 1 {
+		t.Errorf("verification was disabled for %d targets, want 1\n---\n%s", n, warnings)
+	}
+}
+
+func TestRenewAllRenewsEveryTargetThatHasAToken(t *testing.T) {
+	isolateHome(t)
+	alpha, beta := newRenewFake(t), newRenewFake(t)
+	writeSaferc(t, `version: 1
+current: alpha
+vaults:
+  alpha:
+    url: `+alpha.url+`
+    token: token-alpha
+  beta:
+    url: `+beta.url+`
+    token: ""
+`)
+
+	c := newRenewCLI(t)
+	var err error
+	out := captureStdout(t, func() { err = c.cmdRenew("renew", "all") })
+	if err != nil {
+		t.Fatalf("renew all: %v", err)
+	}
+
+	if got := alpha.served(); len(got) != 1 || got[0].token != "token-alpha" {
+		t.Errorf("alpha served %v, want one renewal of token-alpha", got)
+	}
+	if got := beta.served(); len(got) != 0 {
+		t.Errorf("beta has no token and served %v", got)
+	}
+	if !strings.Contains(out, "skipping") || !strings.Contains(out, "beta") {
+		t.Errorf("output should say beta was skipped\n---\n%s", out)
+	}
+}

--- a/internal/cli/renew_test.go
+++ b/internal/cli/renew_test.go
@@ -125,6 +125,86 @@ vaults:
 	}
 }
 
+// Without `all', the token renewed is the one belonging to the target the
+// command is acting on: the current one, or the one -T names.
+func TestRenewRenewsTheTargetItIsActingOn(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		useTarget string
+		renewed   string
+	}{
+		{name: "the current target", renewed: "alpha"},
+		{name: "the target -T names", useTarget: "beta", renewed: "beta"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			vaults := map[string]*fakeRenewVault{
+				"alpha": newRenewFake(t),
+				"beta":  newRenewFake(t),
+			}
+			writeSaferc(t, `version: 1
+current: alpha
+vaults:
+  alpha:
+    url: `+vaults["alpha"].url+`
+    token: token-alpha
+  beta:
+    url: `+vaults["beta"].url+`
+    token: token-beta
+`)
+
+			c := newRenewCLI(t)
+			c.opt.UseTarget = tc.useTarget
+			if err := c.cmdRenew("renew"); err != nil {
+				t.Fatalf("renew: %v", err)
+			}
+
+			for alias, fv := range vaults {
+				got := fv.served()
+				if alias != tc.renewed {
+					if len(got) != 0 {
+						t.Errorf("%s served %v, and was not the target", alias, got)
+					}
+					continue
+				}
+				if len(got) != 1 || got[0].token != "token-"+alias {
+					t.Errorf("%s served %v, want one renewal of token-%s", alias, got, alias)
+				}
+			}
+		})
+	}
+}
+
+// The token the Vault refuses to renew is the answer to the command.
+func TestRenewFailsWhenTheTokenIsNotRenewed(t *testing.T) {
+	isolateHome(t)
+	fv := newRenewFake(t)
+	fv.reject = true
+	writeSaferc(t, `version: 1
+current: alpha
+vaults:
+  alpha:
+    url: `+fv.url+`
+    token: token-alpha
+`)
+
+	c := newRenewCLI(t)
+	if err := c.cmdRenew("renew"); err == nil {
+		t.Fatal("renew of a token the Vault rejected = nil, want an error")
+	}
+}
+
+// `all' is the only argument the command takes.
+func TestRenewRejectsAnyOtherArgument(t *testing.T) {
+	isolateHome(t)
+	c := newRenewCLI(t)
+	for _, args := range [][]string{{"everything"}, {"all", "of", "them"}, {"all", "all"}} {
+		if err := c.cmdRenew("renew", args...); err == nil {
+			t.Errorf("renew %v = nil, want a usage error", args)
+		}
+	}
+}
+
 // With no targets configured there is nothing for `renew all' to renew, and
 // it used to say so by printing nothing at all and succeeding. The token in
 // the environment, which plain `safe renew' does renew, is not a target and is

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -682,7 +682,17 @@ func (c *CLI) cmdRenew(command string, args ...string) error {
 				continue
 			}
 			_, _ = fmt.Printf("renewing token against @C{%s}...\n", vault)
-			v := connect(true)
+			//A target that cannot be connected to is one more failure to
+			// report at the end. connect would print advice about targeting a
+			// Vault -- which names no target and makes no sense here -- and
+			// end the run where it stood, leaving the targets after it
+			// unrenewed and unmentioned.
+			v, err := connectOrErr(true)
+			if err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "@R{failed to connect to %s: %s}\n", vault, err)
+				failed++
+				continue
+			}
 			if err := v.RenewLease(); err != nil {
 				_, _ = fmt.Fprintf(os.Stderr, "@R{failed to renew token against %s: %s}\n", vault, err)
 				failed++

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -652,6 +652,15 @@ func (c *CLI) cmdRenew(command string, args ...string) error {
 		if err != nil {
 			return err
 		}
+		//Renewing every one of no targets printed nothing and succeeded, so a
+		// run against a config that had been lost said as much as one that
+		// had renewed everything.
+		if len(cfg.Vaults) == 0 {
+			_, _ = fmt.Fprintf(os.Stderr, "@Y{no targets to renew.}\n")
+			_, _ = fmt.Fprintf(os.Stderr, "Try @C{safe renew} to renew the token in your environment,\n")
+			_, _ = fmt.Fprintf(os.Stderr, " or @C{safe target https://your-vault alias} to configure one.\n")
+			return nil
+		}
 		//Each target is applied to the environment the command started with,
 		// not to the one the target before it left behind. A target that says
 		// nothing about certificate verification, a CA bundle, or a namespace

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -645,6 +645,12 @@ func (c *CLI) cmdRenew(command string, args ...string) error {
 		if len(args) != 1 || args[0] != "all" {
 			return r.Usage("renew")
 		}
+		//Naming one target and asking for all of them says two things at
+		// once. The rest of safe says which one it went with; this said
+		// nothing and renewed them all.
+		if opt.UseTarget != "" {
+			_, _ = fmt.Fprintf(os.Stderr, "@Y{Specifying --target while renewing all targets makes no sense; ignoring...}\n")
+		}
 		//Reading the config rather than applying it: what the current target
 		// is has no bearing on renewing every target, and applying it here
 		// would leave its settings standing over the first target renewed.

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -660,8 +660,17 @@ func (c *CLI) cmdRenew(command string, args ...string) error {
 		env := rc.SnapshotEnv()
 		defer env.Restore()
 
+		//In the order the targets are named everywhere else. Walking the
+		// config gave them over in whatever order it held them, so two runs
+		// over the same targets reported them differently.
+		aliases := make([]string, 0, len(cfg.Vaults))
+		for alias := range cfg.Vaults {
+			aliases = append(aliases, alias)
+		}
+		sort.Strings(aliases)
+
 		failed := 0
-		for vault := range cfg.Vaults {
+		for _, vault := range aliases {
 			env.Restore()
 			if _, err := rc.Apply(vault); err != nil {
 				_, _ = fmt.Fprintf(os.Stderr, "@R{failed to apply config for %s: %s}\n", vault, err)

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -645,12 +645,24 @@ func (c *CLI) cmdRenew(command string, args ...string) error {
 		if len(args) != 1 || args[0] != "all" {
 			return r.Usage("renew")
 		}
-		cfg, err := rc.Apply("")
+		//Reading the config rather than applying it: what the current target
+		// is has no bearing on renewing every target, and applying it here
+		// would leave its settings standing over the first target renewed.
+		cfg, err := rc.Read()
 		if err != nil {
 			return err
 		}
+		//Each target is applied to the environment the command started with,
+		// not to the one the target before it left behind. A target that says
+		// nothing about certificate verification, a CA bundle, or a namespace
+		// was otherwise talked to on the terms of whichever target happened to
+		// be renewed before it.
+		env := rc.SnapshotEnv()
+		defer env.Restore()
+
 		failed := 0
 		for vault := range cfg.Vaults {
+			env.Restore()
 			if _, err := rc.Apply(vault); err != nil {
 				_, _ = fmt.Fprintf(os.Stderr, "@R{failed to apply config for %s: %s}\n", vault, err)
 				failed++

--- a/pkg/rc/config.go
+++ b/pkg/rc/config.go
@@ -215,6 +215,53 @@ func writeTempCACerts(certs []string) (string, error) {
 	return caFile.Name(), nil
 }
 
+// applied are the environment variables Apply sets from a target. Only the
+// address and the token are set unconditionally: the rest are set when the
+// target carries them and left alone when it does not, so that the standard
+// Vault variables a caller exported still hold for a target that says nothing
+// about them.
+var applied = []string{
+	"VAULT_ADDR",
+	"VAULT_TOKEN",
+	"VAULT_SKIP_VERIFY",
+	"VAULT_CACERT",
+	"VAULT_NAMESPACE",
+}
+
+// Env is what the environment held before a target was applied to it.
+type Env []envVar
+
+type envVar struct {
+	name  string
+	value string
+	set   bool
+}
+
+// SnapshotEnv records the variables Apply sets, so that a caller applying more
+// than one target can put the environment back between them. Without it the
+// second target inherits everything the first one carried and it does not --
+// skipped verification, a CA bundle, a namespace -- and is talked to on terms
+// that are not its own.
+func SnapshotEnv() Env {
+	env := make(Env, 0, len(applied))
+	for _, name := range applied {
+		value, set := os.LookupEnv(name)
+		env = append(env, envVar{name: name, value: value, set: set})
+	}
+	return env
+}
+
+// Restore returns the environment to what it held when it was recorded.
+func (e Env) Restore() {
+	for _, v := range e {
+		if v.set {
+			_ = os.Setenv(v.name, v.value)
+			continue
+		}
+		_ = os.Unsetenv(v.name)
+	}
+}
+
 func (c *Config) Apply(use string) error {
 	v, err := c.Vault(use)
 	if err != nil {

--- a/pkg/rc/env_test.go
+++ b/pkg/rc/env_test.go
@@ -1,0 +1,76 @@
+package rc
+
+// Applying a target sets the environment the Vault client is built from, and
+// applying a second one on top of the first leaves standing whatever the first
+// carried and the second does not. A caller that walks the targets records the
+// environment first and puts it back between them.
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSnapshotEnvRestoresWhatWasThere(t *testing.T) {
+	setHome(t)
+	clearVaultEnv(t)
+	t.Setenv("VAULT_ADDR", "https://before.example.com")
+	if err := os.Unsetenv("VAULT_NAMESPACE"); err != nil {
+		t.Fatalf("unset VAULT_NAMESPACE: %s", err)
+	}
+
+	env := SnapshotEnv()
+
+	c := Config{
+		Current: "one",
+		Vaults: map[string]*Vault{
+			"one": {
+				URL:        "https://one.example.com",
+				Token:      "token-one",
+				SkipVerify: true,
+				Namespace:  "ns-one",
+			},
+		},
+	}
+	if err := c.Apply(""); err != nil {
+		t.Fatalf("apply: %s", err)
+	}
+
+	env.Restore()
+
+	assertEnv(t, "VAULT_ADDR", "https://before.example.com")
+	assertEnv(t, "VAULT_SKIP_VERIFY", "")
+	//A variable that was not set is not restored as an empty one: an empty
+	// VAULT_NAMESPACE is a namespace as far as the client is concerned.
+	if _, set := os.LookupEnv("VAULT_NAMESPACE"); set {
+		t.Errorf("VAULT_NAMESPACE was not set before, and is now %q", os.Getenv("VAULT_NAMESPACE"))
+	}
+}
+
+// A second target applied over a restored environment is talked to on its own
+// terms, not on those of the first.
+func TestSnapshotEnvSeparatesOneTargetFromTheNext(t *testing.T) {
+	setHome(t)
+	clearVaultEnv(t)
+
+	c := Config{
+		Vaults: map[string]*Vault{
+			"one": {URL: "https://one.example.com", Token: "token-one",
+				SkipVerify: true, Namespace: "ns-one"},
+			"two": {URL: "https://two.example.com", Token: "token-two"},
+		},
+	}
+
+	env := SnapshotEnv()
+	if err := c.Apply("one"); err != nil {
+		t.Fatalf("apply one: %s", err)
+	}
+	env.Restore()
+	if err := c.Apply("two"); err != nil {
+		t.Fatalf("apply two: %s", err)
+	}
+
+	assertEnv(t, "VAULT_ADDR", "https://two.example.com")
+	assertEnv(t, "VAULT_TOKEN", "token-two")
+	assertEnv(t, "VAULT_SKIP_VERIFY", "")
+	assertEnv(t, "VAULT_NAMESPACE", "")
+}


### PR DESCRIPTION
`safe renew all` is the only command that applies more than one target in a single run, and applying a target only sets the variables that target carries. What the target before it carried was left standing — including whether certificates are verified.

Everything below was reproduced against two dev Vaults with the `develop` build.

## A target renewed after one that skips verification skips it too

Applying a target sets `VAULT_SKIP_VERIFY`, `VAULT_CACERT`, and `VAULT_NAMESPACE` only when the target carries them, so that the standard Vault variables a caller exported still hold for a target that says nothing about them. Applying a second target on top of the first therefore inherits all three.

With `alpha` carrying `skip_verify: true` and `mike` and `zulu` carrying nothing of the sort, four runs of `safe renew all`:

```
$ safe renew all
renewing token against alpha...
WARNING: TLS certificate verification disabled — connections to Vault are not authenticated
renewing token against mike...
WARNING: TLS certificate verification disabled — connections to Vault are not authenticated
renewing token against zulu...
WARNING: TLS certificate verification disabled — connections to Vault are not authenticated
```

Two targets that ask for a verified connection did not get one; the token was sent over a connection nothing authenticated. The same leak carries a CA bundle onto a target that has its own trust roots, and a namespace onto a Vault that has none — so the token renewed is the one in another Vault's namespace, or the request fails for a reason nothing on screen explains.

Each target is now applied to the environment the command started with:

```
$ safe renew all
renewing token against alpha...
WARNING: TLS certificate verification disabled — connections to Vault are not authenticated
renewing token against mike...
renewing token against zulu...
```

The current target is no longer applied before the walk either — the config is read instead. Which target is current has no bearing on renewing every one of them, and applying it left its settings standing over the first target renewed.

## The targets came in a different order every run

The same four runs, above, in the order they visited the targets:

```
alpha mike zulu
mike zulu alpha
mike zulu alpha
alpha mike zulu
```

Two runs over the same config reported them differently, and neither report could be read against the last. They are now renewed in the order `safe targets` lists them.

## One target it could not reach ended the whole run

A target `safe` could not build a client for — one carrying no address, or an address that will not parse — was not counted as a failure. It printed the advice a lone command prints when nothing is targeted, which names no target, and exited:

```
$ safe renew all
renewing token against alpha...
renewing token against broken...
You are not targeting a Vault.
Try safe target https://your-vault alias
 or safe target alias
[exit 1]
```

`quiet` and `zulu` were never renewed and never mentioned, and the count of what failed never printed. The whole point of the `all` form is to renew what it can and report what it could not:

```
$ safe renew all
renewing token against alpha...
renewing token against broken...
failed to connect to broken: not targeting a Vault
skipping quiet - no token found.
renewing token against zulu...
!! failed to renew 1 token(s)
[exit 1]
```

## Two smaller things

With no targets configured, `renew all` printed nothing and exited 0, so a run against a config that had been lost read exactly like one that renewed everything. It now says there is nothing to renew and points at the plain form of the command, which renews the token in the environment.

`safe -T alpha renew all` names one target and asks for all of them. Every other command that cannot honour `--target` says which way it went; this one renewed them all without a word, and now says so.

## Documentation

`safe renew` had a one-line summary and nothing else — no help topic, and no mention in the README. Both now say what renewing does (it extends the life of the token already saved, rather than obtaining a new one, and cannot revive an expired one), what `all` covers, and what it does with a target it cannot renew.

## Verification

`make check` (fmt, vet, staticcheck, tests) and `go test -race -count=1 ./...` pass; each of the seven commits builds and passes `./internal/cli/` and `./pkg/rc/` on its own.

Fifteen mutations of the changed code, all killed: restoring an unset variable as an empty one (1), unsetting every variable on restore (1), leaving the namespace or the verification flag out of the snapshot (3 each), restoring the environment once rather than per target (1), applying the current target first (1), keeping the order the config gave (1), ending the run on an unreachable target (the test binary exits, as the command does), not counting a target it could not reach (1), passing over an empty config in silence (1), ignoring `--target` in silence (1), renewing a target that has no token (1), not counting a rejected token (1), reading `--target` as the current target for a lone renew (2), and taking any argument at all for `all` (1).

Coverage: `cmdRenew` 0.0% → 89.8%, `RenewLease` 0.0% → 100%, with `SnapshotEnv` and `Restore` new at 100%. Across the tree, 66.4% → 67.3%.
