### PR TITLE
Fix what safe says about its own commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,20 @@ Usage
 safe ssh 2048 secret/ssh
 ```
 
+To find out what the sub-commands are, and what any one of them does:
+
+```
+safe commands
+safe help ssh
+```
+
+Both print on standard output, so they can be piped and searched.
+`safe envvars` does the same for the environment variables `safe`
+reads, and `safe version` for the version you are running.  A word
+`safe` has no command for is an error: it names the word rather than
+printing the whole list, and exits non-zero, so a mistyped command in
+a script stops the script.
+
 To set non-sensitive keys, you can just specify them inline:
 
 ```

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -388,7 +388,11 @@ func Main(version, buildTime, gitCommit string) {
 		Type:    AdministrativeCommand,
 	}, c.cmdVersion)
 
-	r.Dispatch("help", nil, c.cmdHelp)
+	r.Dispatch("help", &Help{
+		Summary: "Print help for safe, or for one of its commands",
+		Usage:   "safe help [command]",
+		Type:    MiscellaneousCommand,
+	}, c.cmdHelp)
 
 	r.Dispatch("commands", &Help{
 		Summary: "List the commands safe knows",
@@ -396,7 +400,12 @@ func Main(version, buildTime, gitCommit string) {
 		Type:    MiscellaneousCommand,
 	}, c.cmdCommands)
 
-	r.Dispatch("envvars", nil, c.cmdEnvvars)
+	r.Dispatch("envvars", &Help{
+		Summary:     "Print the environment variables safe reads",
+		Usage:       "safe envvars",
+		Type:        MiscellaneousCommand,
+		Description: envvarsHelp,
+	}, c.cmdEnvvars)
 
 	r.Dispatch("targets", &Help{
 		Summary: "List all targeted Vaults",

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1577,6 +1577,17 @@ Currently, only the --renew option is supported, and it is required:
 		}
 
 		if p.Command == "" { //No recognized command was found
+			//A word safe has no command for is a mistake to report, and the
+			// word itself is the useful half of the report. Printing the whole
+			// listing said nothing about which word was wrong, and the run
+			// ended in success, so a mistyped command in a script read as one
+			// that had done its work.
+			if len(p.Args) > 0 {
+				_, _ = fmt.Fprintf(os.Stderr, "@R{!! unrecognized command '%s'}\n", p.Args[0])
+				_, _ = fmt.Fprintf(os.Stderr, "Try 'safe commands' for a list of valid commands\n")
+				rc.Cleanup()
+				os.Exit(1)
+			}
 			_ = r.Execute("help")
 			return
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -143,8 +143,9 @@ type Options struct {
 	// the current safe target otherwise.
 	UseTarget string `cli:"-T, --target" env:"SAFE_TARGET"`
 
-	HelpCommand    struct{} `cli:"help"`
-	VersionCommand struct{} `cli:"version"`
+	HelpCommand     struct{} `cli:"help"`
+	CommandsCommand struct{} `cli:"commands"`
+	VersionCommand  struct{} `cli:"version"`
 
 	Envvars struct{} `cli:"envvars"`
 	Targets struct {
@@ -388,6 +389,12 @@ func Main(version, buildTime, gitCommit string) {
 	}, c.cmdVersion)
 
 	r.Dispatch("help", nil, c.cmdHelp)
+
+	r.Dispatch("commands", &Help{
+		Summary: "List the commands safe knows",
+		Usage:   "safe commands",
+		Type:    MiscellaneousCommand,
+	}, c.cmdCommands)
 
 	r.Dispatch("envvars", nil, c.cmdEnvvars)
 

--- a/internal/cli/main_smoke_test.go
+++ b/internal/cli/main_smoke_test.go
@@ -1,0 +1,137 @@
+package cli
+
+// safe's own output -- the command listing, a help topic, the version -- is
+// written by handlers that end in os.Exit, so what they say, where they say
+// it, and the status they leave behind can only be read from outside the
+// process. These tests build the binary once and run it.
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+var (
+	safeBuildOnce sync.Once
+	safeBinPath   string
+	safeBinDir    string
+	safeBuildErr  error
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if safeBinDir != "" {
+		_ = os.RemoveAll(safeBinDir)
+	}
+	os.Exit(code)
+}
+
+// safeBinary builds cmd/safe once per test run and returns the path to it.
+func safeBinary(t *testing.T) string {
+	t.Helper()
+	safeBuildOnce.Do(func() {
+		safeBinDir, safeBuildErr = os.MkdirTemp("", "safe-smoke")
+		if safeBuildErr != nil {
+			return
+		}
+		safeBinPath = filepath.Join(safeBinDir, "safe")
+		build := exec.Command("go", "build", "-o", safeBinPath,
+			"github.com/cloudfoundry-community/safe/cmd/safe")
+		if out, err := build.CombinedOutput(); err != nil {
+			safeBuildErr = err
+			t.Logf("go build: %s", out)
+		}
+	})
+	if safeBuildErr != nil {
+		t.Fatalf("building cmd/safe: %v", safeBuildErr)
+	}
+	return safeBinPath
+}
+
+// run invokes safe with args and returns its standard output, standard error,
+// and exit status. The command runs against an empty home directory and an
+// environment naming no Vault, so nothing it reads comes from the machine the
+// tests run on.
+func run(t *testing.T, args ...string) (stdout, stderr string, status int) {
+	t.Helper()
+	cmd := exec.Command(safeBinary(t), args...)
+	cmd.Env = append(os.Environ(),
+		"HOME="+t.TempDir(),
+		"SAFE_TARGET=",
+		"VAULT_ADDR=",
+		"VAULT_TOKEN=",
+	)
+	var out, errOut strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+
+	var exitErr *exec.ExitError
+	switch err := cmd.Run(); {
+	case err == nil:
+	case errors.As(err, &exitErr):
+		status = exitErr.ExitCode()
+	default:
+		t.Fatalf("running safe %s: %v", strings.Join(args, " "), err)
+	}
+	return out.String(), errOut.String(), status
+}
+
+// listedCommands returns the command names safe commands prints.
+func listedCommands(t *testing.T, listing string) []string {
+	t.Helper()
+	var names []string
+	for _, line := range strings.Split(listing, "\n") {
+		if !strings.HasPrefix(line, "    ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		names = append(names, fields[0])
+	}
+	if len(names) == 0 {
+		t.Fatalf("no commands parsed out of the listing:\n%s", listing)
+	}
+	return names
+}
+
+// safe commands is what safe's own help points at for a list of what it can
+// do. It was no command at all: the listing came back only because an
+// unrecognized command falls through to help, which prints it.
+func TestCommandsIsACommandOfItsOwn(t *testing.T) {
+	stdout, stderr, status := run(t, "commands")
+	if status != 0 {
+		t.Errorf("safe commands exited %d, want 0", status)
+	}
+
+	listing := stdout + stderr
+	if !strings.Contains(listing, "Valid commands are:") {
+		t.Fatalf("safe commands printed no listing:\n%s", listing)
+	}
+
+	found := false
+	for _, name := range listedCommands(t, listing) {
+		if name == "commands" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the listing leaves out commands itself:\n%s", listing)
+	}
+}
+
+// A command in the listing is a command safe help can answer for.
+func TestHelpAnswersForEveryCommandListed(t *testing.T) {
+	stdout, stderr, _ := run(t, "commands")
+	for _, name := range listedCommands(t, stdout+stderr) {
+		out, errOut, status := run(t, "help", name)
+		if status != 0 {
+			t.Errorf("safe help %s exited %d, want 0:\n%s", name, status, out+errOut)
+		}
+	}
+}

--- a/internal/cli/main_smoke_test.go
+++ b/internal/cli/main_smoke_test.go
@@ -172,6 +172,18 @@ func TestNoCommandAtAllGivesTheListing(t *testing.T) {
 	}
 }
 
+// Help is output that was asked for, so it goes where output goes. It was
+// written to standard error, so safe commands | grep came back with nothing.
+func TestHelpIsWrittenToStandardOutput(t *testing.T) {
+	for _, args := range [][]string{{"commands"}, {"help"}, {"help", "get"}, {"-h"}} {
+		stdout, stderr, _ := run(t, args...)
+		if stdout == "" {
+			t.Errorf("safe %s wrote nothing to standard output; standard error had:\n%s",
+				strings.Join(args, " "), stderr)
+		}
+	}
+}
+
 // A command in the listing is a command safe help can answer for.
 func TestHelpAnswersForEveryCommandListed(t *testing.T) {
 	stdout, stderr, _ := run(t, "commands")

--- a/internal/cli/main_smoke_test.go
+++ b/internal/cli/main_smoke_test.go
@@ -184,6 +184,21 @@ func TestHelpIsWrittenToStandardOutput(t *testing.T) {
 	}
 }
 
+// So is the version. safe -v | cut told you nothing about which safe you are
+// running, because the version was on standard error.
+func TestVersionIsWrittenToStandardOutput(t *testing.T) {
+	for _, args := range [][]string{{"version"}, {"-v"}} {
+		stdout, stderr, status := run(t, args...)
+		if status != 0 {
+			t.Errorf("safe %s exited %d, want 0", strings.Join(args, " "), status)
+		}
+		if !strings.Contains(stdout, "safe") {
+			t.Errorf("safe %s wrote %q to standard output; standard error had:\n%s",
+				strings.Join(args, " "), stdout, stderr)
+		}
+	}
+}
+
 // A command in the listing is a command safe help can answer for.
 func TestHelpAnswersForEveryCommandListed(t *testing.T) {
 	stdout, stderr, _ := run(t, "commands")

--- a/internal/cli/main_smoke_test.go
+++ b/internal/cli/main_smoke_test.go
@@ -199,6 +199,22 @@ func TestVersionIsWrittenToStandardOutput(t *testing.T) {
 	}
 }
 
+// A topic safe has nothing to say about is a mistake to report, so it is
+// reported where mistakes are reported, and not among the help that piping
+// safe help collects.
+func TestHelpForATopicThatDoesNotExistFails(t *testing.T) {
+	stdout, stderr, status := run(t, "help", "bogus")
+	if status == 0 {
+		t.Errorf("safe help bogus exited 0, want a failure")
+	}
+	if !strings.Contains(stderr, "bogus") {
+		t.Errorf("stderr = %q, want the topic safe does not have named", stderr)
+	}
+	if stdout != "" {
+		t.Errorf("standard output = %q, want the complaint kept off it", stdout)
+	}
+}
+
 // A command in the listing is a command safe help can answer for.
 func TestHelpAnswersForEveryCommandListed(t *testing.T) {
 	stdout, stderr, _ := run(t, "commands")

--- a/internal/cli/main_smoke_test.go
+++ b/internal/cli/main_smoke_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -114,14 +115,32 @@ func TestCommandsIsACommandOfItsOwn(t *testing.T) {
 		t.Fatalf("safe commands printed no listing:\n%s", listing)
 	}
 
-	found := false
-	for _, name := range listedCommands(t, listing) {
-		if name == "commands" {
-			found = true
+	if !slices.Contains(listedCommands(t, listing), "commands") {
+		t.Errorf("the listing leaves out commands itself:\n%s", listing)
+	}
+}
+
+// safe's own listing points at safe envvars for what the environment
+// variables are, and safe help had no topic for it, nor for help itself.
+// Neither was in the listing either.
+func TestHelpAnswersForEnvvarsAndForItself(t *testing.T) {
+	stdout, stderr, _ := run(t, "commands")
+	listed := listedCommands(t, stdout+stderr)
+
+	for _, name := range []string{"envvars", "help"} {
+		if !slices.Contains(listed, name) {
+			t.Errorf("the listing leaves out %s:\n%s", name, stdout+stderr)
+		}
+		out, errOut, status := run(t, "help", name)
+		if status != 0 {
+			t.Errorf("safe help %s exited %d, want 0:\n%s", name, status, out+errOut)
 		}
 	}
-	if !found {
-		t.Errorf("the listing leaves out commands itself:\n%s", listing)
+
+	//The topic is the documentation itself, not a line saying it exists.
+	out, errOut, _ := run(t, "help", "envvars")
+	if !strings.Contains(out+errOut, "SAFE_TARGET") {
+		t.Errorf("safe help envvars names no environment variable:\n%s", out+errOut)
 	}
 }
 

--- a/internal/cli/main_smoke_test.go
+++ b/internal/cli/main_smoke_test.go
@@ -125,6 +125,34 @@ func TestCommandsIsACommandOfItsOwn(t *testing.T) {
 	}
 }
 
+// A command safe does not have was not a failure: the whole listing came back
+// and the run ended in success, so a mistyped command in a script read as one
+// that had done its work.
+func TestAnUnrecognizedCommandIsNamedAndFails(t *testing.T) {
+	stdout, stderr, status := run(t, "gett", "secret/handshake")
+	if status == 0 {
+		t.Errorf("safe gett exited 0, want a failure")
+	}
+	if !strings.Contains(stderr, "gett") {
+		t.Errorf("stderr = %q, want the word safe did not recognize named", stderr)
+	}
+	if strings.Contains(stdout+stderr, "Valid commands are:") {
+		t.Errorf("one mistyped command brought back the whole listing:\n%s", stdout+stderr)
+	}
+}
+
+// Nothing at all is not a mistake to report -- it is someone asking what safe
+// can do.
+func TestNoCommandAtAllGivesTheListing(t *testing.T) {
+	stdout, stderr, status := run(t)
+	if status != 0 {
+		t.Errorf("safe with no arguments exited %d, want 0", status)
+	}
+	if !strings.Contains(stdout+stderr, "Valid commands are:") {
+		t.Errorf("safe with no arguments printed no listing:\n%s", stdout+stderr)
+	}
+}
+
 // A command in the listing is a command safe help can answer for.
 func TestHelpAnswersForEveryCommandListed(t *testing.T) {
 	stdout, stderr, _ := run(t, "commands")

--- a/internal/cli/misc.go
+++ b/internal/cli/misc.go
@@ -38,9 +38,18 @@ func (c *CLI) cmdHelp(command string, args ...string) error {
 	if len(args) == 0 {
 		args = append(args, "commands")
 	}
+	topic := strings.Join(args, " ")
 	//Help is output that was asked for. Written to standard error, it could
 	// not be piped anywhere: safe commands | grep came back with nothing.
-	r.Help(os.Stdout, strings.Join(args, " "))
+	// A topic safe does not have is the other way round -- that is a mistake,
+	// and it is reported where mistakes are.
+	if err := r.Help(os.Stdout, topic); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "@R{Unrecognized command or help topic '%s'}\n", topic)
+		_, _ = fmt.Fprintf(os.Stderr, "Try 'safe help' to get started with safe,\n")
+		_, _ = fmt.Fprintf(os.Stderr, " or 'safe commands' for a list of valid commands\n")
+		rc.Cleanup()
+		os.Exit(1)
+	}
 	rc.Cleanup()
 	os.Exit(0)
 	return nil

--- a/internal/cli/misc.go
+++ b/internal/cli/misc.go
@@ -36,7 +36,9 @@ func (c *CLI) cmdHelp(command string, args ...string) error {
 	if len(args) == 0 {
 		args = append(args, "commands")
 	}
-	r.Help(os.Stderr, strings.Join(args, " "))
+	//Help is output that was asked for. Written to standard error, it could
+	// not be piped anywhere: safe commands | grep came back with nothing.
+	r.Help(os.Stdout, strings.Join(args, " "))
 	rc.Cleanup()
 	os.Exit(0)
 	return nil

--- a/internal/cli/misc.go
+++ b/internal/cli/misc.go
@@ -42,6 +42,14 @@ func (c *CLI) cmdHelp(command string, args ...string) error {
 	return nil
 }
 
+// cmdCommands prints the listing of what safe can do. It is the topic help
+// gives when it is asked for nothing in particular, and safe's own help points
+// at it by name, so it is a command in its own right rather than something
+// that only answers because an unrecognized command falls through to help.
+func (c *CLI) cmdCommands(command string, args ...string) error {
+	return c.cmdHelp("help", "commands")
+}
+
 func (c *CLI) cmdEnvvars(command string, args ...string) error {
 
 	_, _ = fmt.Printf(`@G{[SCRIPTING]}

--- a/internal/cli/misc.go
+++ b/internal/cli/misc.go
@@ -14,16 +14,18 @@ import (
 
 func (c *CLI) cmdVersion(command string, args ...string) error {
 
+	//Which safe is running is an answer to a question that was asked, so it
+	// goes where output goes. On standard error, safe -v | cut said nothing.
 	if Version != "" {
-		_, _ = fmt.Fprintf(os.Stderr, "safe v%s\n", Version)
+		_, _ = fmt.Fprintf(os.Stdout, "safe v%s\n", Version)
 	} else {
-		_, _ = fmt.Fprintf(os.Stderr, "safe (development build)\n")
+		_, _ = fmt.Fprintf(os.Stdout, "safe (development build)\n")
 	}
 	if GitCommit != "" {
-		_, _ = fmt.Fprintf(os.Stderr, "  commit %s\n", GitCommit)
+		_, _ = fmt.Fprintf(os.Stdout, "  commit %s\n", GitCommit)
 	}
 	if BuildTime != "" {
-		_, _ = fmt.Fprintf(os.Stderr, "  built  %s\n", BuildTime)
+		_, _ = fmt.Fprintf(os.Stdout, "  built  %s\n", BuildTime)
 	}
 	rc.Cleanup()
 	os.Exit(0)

--- a/internal/cli/misc.go
+++ b/internal/cli/misc.go
@@ -50,9 +50,9 @@ func (c *CLI) cmdCommands(command string, args ...string) error {
 	return c.cmdHelp("help", "commands")
 }
 
-func (c *CLI) cmdEnvvars(command string, args ...string) error {
-
-	_, _ = fmt.Printf(`@G{[SCRIPTING]}
+// envvarsHelp is what safe envvars prints and what safe help envvars gives
+// back. One copy serves both: the command is the documentation.
+const envvarsHelp = `@G{[SCRIPTING]}
   @B{SAFE_TARGET}    The vault alias which requests are sent to.
 
 @G{[PROXYING]}
@@ -91,7 +91,10 @@ func (c *CLI) cmdEnvvars(command string, args ...string) error {
   key for the given server is present, you will be prompted to add the key. If no
   TTY when no host key is present, safe will return with a failure.
 
-`)
+`
+
+func (c *CLI) cmdEnvvars(command string, args ...string) error {
+	_, _ = fmt.Printf(envvarsHelp)
 	return nil
 }
 

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -55,10 +55,6 @@ func (r *Runner) Dispatch(command string, help *Help, fn Handler) {
 	}
 }
 
-func (r *Runner) HelpTopic(topic string, help string) {
-	r.Topics[topic] = &Help{Description: strings.Trim(help, "\n")}
-}
-
 // escapePercent hides per-cent signs from the formatter. Help text is handed
 // to ansi.Fprintf as its format string, which is how the @C{...} colouring in
 // it is read, so a per-cent sign in the text itself would be taken for the

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -59,6 +59,14 @@ func (r *Runner) HelpTopic(topic string, help string) {
 	r.Topics[topic] = &Help{Description: strings.Trim(help, "\n")}
 }
 
+// escapePercent hides per-cent signs from the formatter. Help text is handed
+// to ansi.Fprintf as its format string, which is how the @C{...} colouring in
+// it is read, so a per-cent sign in the text itself would be taken for the
+// start of a verb and the formatter's complaint would print in its place.
+func escapePercent(s string) string {
+	return strings.ReplaceAll(s, "%", "%%")
+}
+
 // ErrNoSuchTopic is what Help gives back when it is asked for a topic that
 // was never registered.
 var ErrNoSuchTopic = errors.New("no such help topic")
@@ -97,14 +105,14 @@ func (r *Runner) Help(out io.Writer, topic string) error {
 			/* this is a command, print it like one */
 			_, _ = ansi.Fprintf(out, "safe @G{%s} - @C{%s}\n", topic, help.Summary)
 			if help.Usage != "" {
-				_, _ = ansi.Fprintf(out, "USAGE: "+help.Usage+"\n")
+				_, _ = ansi.Fprintf(out, "USAGE: "+escapePercent(help.Usage)+"\n")
 			}
 			if help.Description != "" {
 				_, _ = ansi.Fprintf(out, "\n")
 			}
 		}
 		if help.Description != "" {
-			_, _ = ansi.Fprintf(out, help.Description+"\n")
+			_, _ = ansi.Fprintf(out, escapePercent(help.Description)+"\n")
 		}
 		return nil
 	}
@@ -136,7 +144,7 @@ func (r *Runner) PrintUsage(w io.Writer, topic string) {
 			/* this is a command, print it like one */
 			_, _ = ansi.Fprintf(w, "safe @G{%s} - @C{%s}\n", topic, help.Summary)
 			if help.Usage != "" {
-				_, _ = ansi.Fprintf(w, "USAGE: "+help.Usage+"\n")
+				_, _ = ansi.Fprintf(w, "USAGE: "+escapePercent(help.Usage)+"\n")
 			}
 		}
 	}

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -1,9 +1,9 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 
@@ -59,7 +59,15 @@ func (r *Runner) HelpTopic(topic string, help string) {
 	r.Topics[topic] = &Help{Description: strings.Trim(help, "\n")}
 }
 
-func (r *Runner) Help(out io.Writer, topic string) {
+// ErrNoSuchTopic is what Help gives back when it is asked for a topic that
+// was never registered.
+var ErrNoSuchTopic = errors.New("no such help topic")
+
+// Help writes the topic to out. A topic it does not have is reported back
+// rather than complained about here: what to say about it, and where, belongs
+// to the caller, and ending the process from inside the lookup skipped the
+// cleanup safe does on its way out.
+func (r *Runner) Help(out io.Writer, topic string) error {
 	if topic == "commands" {
 		_, _ = fmt.Fprintf(out, "Valid commands are:\n\n")
 
@@ -81,7 +89,7 @@ func (r *Runner) Help(out io.Writer, topic string) {
 
 		_, _ = fmt.Fprintf(out, "\nTry `safe envvars' for information on available environment variables\n")
 		_, _ = fmt.Fprintf(out, "Try 'safe help <command>' for detailed information on specific commands\n")
-		return
+		return nil
 	}
 
 	if help, ok := r.Topics[topic]; ok && help != nil {
@@ -98,13 +106,10 @@ func (r *Runner) Help(out io.Writer, topic string) {
 		if help.Description != "" {
 			_, _ = ansi.Fprintf(out, help.Description+"\n")
 		}
-		return
+		return nil
 	}
 
-	_, _ = ansi.Fprintf(out, "@R{Unrecognized command or help topic '%s'}\n", topic)
-	_, _ = fmt.Fprintf(out, "Try 'safe help' to get started with safe,\n")
-	_, _ = fmt.Fprintf(out, " or 'safe commands' for a list of valid commands\n")
-	os.Exit(1)
+	return fmt.Errorf("%w: %s", ErrNoSuchTopic, topic)
 }
 
 // UsageError signals a command was invoked incorrectly. Handlers return it

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -249,3 +249,20 @@ func TestRunner_Dispatch_DescriptionTrimmed(t *testing.T) {
 		t.Errorf("Description: got %q, want %q", h.Description, "body text")
 	}
 }
+
+// Help used to end the process itself for a topic it did not have, which left
+// the caller no chance to say anything about it and skipped the cleanup safe
+// does on its way out. It reports the topic back instead.
+func TestRunner_Help_UnknownTopic(t *testing.T) {
+	t.Parallel()
+	r := NewRunner()
+
+	var out bytes.Buffer
+	err := r.Help(&out, "no-such-topic")
+	if !errors.Is(err, ErrNoSuchTopic) {
+		t.Errorf("Help(no-such-topic): got %v, want ErrNoSuchTopic", err)
+	}
+	if out.String() != "" {
+		t.Errorf("Help wrote %q, want the complaint left to the caller", out.String())
+	}
+}

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -266,3 +266,34 @@ func TestRunner_Help_UnknownTopic(t *testing.T) {
 		t.Errorf("Help wrote %q, want the complaint left to the caller", out.String())
 	}
 }
+
+// Help text is handed to the formatter as its format string -- that is how
+// the colouring in it is read -- so a per-cent sign in the text itself was
+// read as the start of a verb, and a topic that mentions one printed the
+// formatter's complaint in its place.
+func TestRunner_Help_PerCentSignSurvives(t *testing.T) {
+	t.Parallel()
+	r := NewRunner()
+	r.Dispatch("pct", &Help{
+		Summary:     "summary",
+		Usage:       "safe pct --at 50%",
+		Description: "Fills the tank to 100% of capacity.",
+		Type:        NonDestructiveCommand,
+	}, func(cmd string, args ...string) error { return nil })
+
+	var help bytes.Buffer
+	if err := r.Help(&help, "pct"); err != nil {
+		t.Fatalf("Help(pct): %v", err)
+	}
+	for _, want := range []string{"--at 50%", "100% of capacity"} {
+		if !strings.Contains(help.String(), want) {
+			t.Errorf("help = %q, want it to hold %q", help.String(), want)
+		}
+	}
+
+	var usage bytes.Buffer
+	r.PrintUsage(&usage, "pct")
+	if !strings.Contains(usage.String(), "--at 50%") {
+		t.Errorf("usage = %q, want it to hold %q", usage.String(), "--at 50%")
+	}
+}

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -422,7 +422,7 @@ func (c *CLI) cmdEnv(command string, args ...string) error {
 		return err
 	}
 	if opt.Env.ForBash && opt.Env.ForFish && opt.Env.ForJSON {
-		r.Help(os.Stderr, "env")
+		_ = r.Help(os.Stderr, "env")
 		_, _ = fmt.Fprintf(os.Stderr, "@R{Only specify one of --json, --bash OR --fish.}\n")
 		rc.Cleanup()
 		os.Exit(1)

--- a/internal/cli/x509.go
+++ b/internal/cli/x509.go
@@ -18,7 +18,7 @@ import (
 func (c *CLI) cmdX509(command string, args ...string) error {
 	r := c.r
 
-	r.Help(os.Stdout, "x509")
+	_ = r.Help(os.Stdout, "x509")
 	return nil
 }
 


### PR DESCRIPTION
`safe` answers three questions about itself -- what commands are there, what
does this one do, and what did I just mistype -- and it answered all three on
standard error, one of them by printing everything it knows, and one of them
with success.

Everything below was reproduced with the `develop` build.

## A command safe does not have was not a failure

```
$ safe gett secret/handshake
Valid commands are:

    ask         Create or update an insensitive configuration value
    ... 47 more lines ...
$ echo $?
0
```

The word that was wrong is the one thing the output does not mention, and the
run succeeded, so `safe gett secret/handshake || bail` never bailed and a
mistyped command in a script read as one that had done its work.

```
$ safe gett secret/handshake
!! unrecognized command 'gett'
Try 'safe commands' for a list of valid commands
$ echo $?
1
```

Running `safe` with nothing at all still gives the listing and still succeeds:
that is someone asking what safe can do, not a mistake.

## safe commands was not a command

The listing came back only because an unrecognized command fell through to
help, which prints that topic -- the same accident as above. So `safe
commands` had to keep working while `safe gett` stopped, and it is now a
command of its own, named in its own listing.

## safe help had nothing to say about two of its own commands

```
$ safe help envvars
Unrecognized command or help topic 'envvars'
$ echo $?
1
```

`safe commands` ends by pointing at `safe envvars` for what the environment
variables are. Asking for help on it said there was no such thing, and `safe
help help` said the same of `help` itself. Neither was in the listing.

Both now have topics, and the environment variable documentation is the topic
that `safe envvars` prints, so there is one copy of it rather than two. A test
now checks that every command in the listing is one `safe help` can answer for.

## None of it could be piped

```
$ safe commands | grep export
$ safe help get > notes; wc -c notes
0 notes
$ safe -v | cut -d' ' -f2
```

Help, the listing, and the version went to standard error. They are output
that was asked for, and they now go where output goes. A complaint about a
topic safe does not have stays on standard error, where it was, and no longer
prints among the help.

## Two more, found on the way

Looking up a topic ended the process from inside the lookup, which skipped the
cleanup safe does on its way out -- the temporary files and the proxy tunnel a
target may have opened. The lookup reports the topic back now, and `safe help`
decides what to say and when to leave.

Help text is handed to the formatter as its format string, which is how the
`@C{...}` colouring in it is read, so a per-cent sign in the text itself was
read as the start of a verb:

```
USAGE: safe pct --at 50%!
(MISSING)
Fills the tank to 100%!o(MISSING)f capacity.
```

No topic mentions a per-cent sign today. One would print like that, silently,
whenever someone wrote it.

`HelpTopic`, which registered a help topic belonging to no command, had no
callers; every topic safe has comes from a command. It is gone.

## Verification

`make check` (fmt, vet, staticcheck, tests) and `go test -race -count=1 ./...`
pass; each of the nine commits builds and passes `./internal/cli/` on its own.

These commands end in `os.Exit`, so what they say, where they say it, and the
status they leave behind can only be read from outside the process. The tests
build `cmd/safe` once per run and run it. That also means the coverage profile
does not see them: `Help` goes 0.0% -> 96.2% and `PrintUsage` 0.0% -> 100%
because they are also driven in-process, while `cmdHelp`, `cmdCommands`, and
`cmdVersion` stay at 0.0% in the profile although every path through them is
exercised. Across the tree, coverage is unchanged at 67.3%.

Fifteen mutations of the changed code, all killed: dropping the `commands`
command or its help (2), letting an unrecognized command fall through to the
listing, reporting it but succeeding, or not naming the word (3), dropping the
help topic for `envvars`, its documentation, or the one for `help` (3),
printing help or the version on standard error (2), reporting an unknown topic
as no mistake, succeeding on one, or complaining about it on standard output
(3), and leaving per-cent signs unescaped everywhere or in the description
only (2).
