### PR TITLE
Quote what safe env writes for the shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,12 +818,21 @@ shell in order to use the Vault CLI directly:
 
 ```
 safe env --bash
-\export VAULT_ADDR=http://localhost:8200;
-\export VAULT_TOKEN=$SOME_UUID;
+\export VAULT_ADDR='http://localhost:8200';
+\export VAULT_TOKEN='$SOME_UUID';
 \unset VAULT_SKIP_VERIFY;
+\unset VAULT_NAMESPACE;
 
-eval $(safe env --bash)
+eval "$(safe env --bash)"
 ```
+
+The values are quoted for the shell they are written for, so a namespace or
+an address holding a space, a quote, or a semicolon arrives whole. Quote the
+command substitution as shown, or the shell will split the output on
+whitespace before `eval` ever sees it.
+
+`--fish` writes the same thing for fish, and `--json` writes it as JSON. Give
+one of them: naming two is an error.
 
 Testing
 -------

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -595,6 +595,13 @@ Print the environment variables representing the current target.
 
  --json   Format the environment variables in json format.
 
+Give one of them: naming two is an error.
+
+Values written for a shell are quoted for that shell, so quote the command
+substitution that reads them back:
+
+    eval "$(safe env --bash)"
+
 Please note that if you specify --json, --bash or --fish then the output will be
 written to STDOUT instead of STDERR to make it easier to consume.
 		`,

--- a/internal/cli/env_render_test.go
+++ b/internal/cli/env_render_test.go
@@ -123,6 +123,36 @@ func TestCmdEnv_Bash_AllUnset(t *testing.T) {
 	}
 }
 
+// The variables were held in a map, so safe env printed them in a different
+// order on each run and safe env --bash > env.sh gave a different file every
+// time.
+func TestCmdEnv_Bash_FixedOrder(t *testing.T) {
+	isolateHome(t)
+	t.Setenv("VAULT_ADDR", "https://vault.example.com")
+	t.Setenv("VAULT_TOKEN", "s.testtoken")
+	t.Setenv("VAULT_SKIP_VERIFY", "1")
+	t.Setenv("VAULT_NAMESPACE", "ns/dev")
+
+	c := newEnvCLI(t)
+	c.opt.Env.ForBash = true
+
+	want := `\export VAULT_ADDR=https://vault.example.com;
+\export VAULT_TOKEN=s.testtoken;
+\export VAULT_SKIP_VERIFY=1;
+\export VAULT_NAMESPACE=ns/dev;
+`
+	for i := range 8 {
+		out := captureStdout(t, func() {
+			if err := c.cmdEnv("env"); err != nil {
+				t.Errorf("cmdEnv bash: unexpected error: %v", err)
+			}
+		})
+		if out != want {
+			t.Fatalf("run %d printed:\n%s\nwant:\n%s", i, out, want)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // fish branch
 // ---------------------------------------------------------------------------
@@ -179,6 +209,33 @@ func TestCmdEnv_Fish_AllUnset(t *testing.T) {
 		want := "set -u " + key + ";"
 		if !strings.Contains(out, want) {
 			t.Errorf("fish all-unset: missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestCmdEnv_Fish_FixedOrder(t *testing.T) {
+	isolateHome(t)
+	t.Setenv("VAULT_ADDR", "https://vault.example.com")
+	t.Setenv("VAULT_TOKEN", "s.fishtoken")
+	t.Setenv("VAULT_SKIP_VERIFY", "")
+	t.Setenv("VAULT_NAMESPACE", "ns/dev")
+
+	c := newEnvCLI(t)
+	c.opt.Env.ForFish = true
+
+	want := `set -x VAULT_ADDR https://vault.example.com;
+set -x VAULT_TOKEN s.fishtoken;
+set -u VAULT_SKIP_VERIFY;
+set -x VAULT_NAMESPACE ns/dev;
+`
+	for i := range 8 {
+		out := captureStdout(t, func() {
+			if err := c.cmdEnv("env"); err != nil {
+				t.Errorf("cmdEnv fish: unexpected error: %v", err)
+			}
+		})
+		if out != want {
+			t.Fatalf("run %d printed:\n%s\nwant:\n%s", i, out, want)
 		}
 	}
 }

--- a/internal/cli/env_render_test.go
+++ b/internal/cli/env_render_test.go
@@ -12,6 +12,7 @@ package cli
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -84,10 +85,10 @@ func TestCmdEnv_Bash_SetVars(t *testing.T) {
 	})
 
 	// Variables with values use \export KEY=VALUE;
-	if !strings.Contains(out, `\export VAULT_ADDR=https://vault.example.com;`) {
+	if !strings.Contains(out, `\export VAULT_ADDR='https://vault.example.com';`) {
 		t.Errorf("bash: VAULT_ADDR export missing; got:\n%s", out)
 	}
-	if !strings.Contains(out, `\export VAULT_TOKEN=s.testtoken;`) {
+	if !strings.Contains(out, `\export VAULT_TOKEN='s.testtoken';`) {
 		t.Errorf("bash: VAULT_TOKEN export missing; got:\n%s", out)
 	}
 	// Empty vars use \unset KEY;
@@ -136,10 +137,10 @@ func TestCmdEnv_Bash_FixedOrder(t *testing.T) {
 	c := newEnvCLI(t)
 	c.opt.Env.ForBash = true
 
-	want := `\export VAULT_ADDR=https://vault.example.com;
-\export VAULT_TOKEN=s.testtoken;
-\export VAULT_SKIP_VERIFY=1;
-\export VAULT_NAMESPACE=ns/dev;
+	want := `\export VAULT_ADDR='https://vault.example.com';
+\export VAULT_TOKEN='s.testtoken';
+\export VAULT_SKIP_VERIFY='1';
+\export VAULT_NAMESPACE='ns/dev';
 `
 	for i := range 8 {
 		out := captureStdout(t, func() {
@@ -174,10 +175,10 @@ func TestCmdEnv_Fish_SetVars(t *testing.T) {
 	})
 
 	// Set variables use: set -x KEY VALUE;
-	if !strings.Contains(out, "set -x VAULT_ADDR https://vault.example.com;") {
+	if !strings.Contains(out, "set -x VAULT_ADDR 'https://vault.example.com';") {
 		t.Errorf("fish: VAULT_ADDR set missing; got:\n%s", out)
 	}
-	if !strings.Contains(out, "set -x VAULT_TOKEN s.fishtoken;") {
+	if !strings.Contains(out, "set -x VAULT_TOKEN 's.fishtoken';") {
 		t.Errorf("fish: VAULT_TOKEN set missing; got:\n%s", out)
 	}
 	// Unset variables use: set -u KEY;
@@ -223,10 +224,10 @@ func TestCmdEnv_Fish_FixedOrder(t *testing.T) {
 	c := newEnvCLI(t)
 	c.opt.Env.ForFish = true
 
-	want := `set -x VAULT_ADDR https://vault.example.com;
-set -x VAULT_TOKEN s.fishtoken;
+	want := `set -x VAULT_ADDR 'https://vault.example.com';
+set -x VAULT_TOKEN 's.fishtoken';
 set -u VAULT_SKIP_VERIFY;
-set -x VAULT_NAMESPACE ns/dev;
+set -x VAULT_NAMESPACE 'ns/dev';
 `
 	for i := range 8 {
 		out := captureStdout(t, func() {
@@ -237,6 +238,135 @@ set -x VAULT_NAMESPACE ns/dev;
 		if out != want {
 			t.Fatalf("run %d printed:\n%s\nwant:\n%s", i, out, want)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// quoting
+// ---------------------------------------------------------------------------
+
+// oddValues are values a shell would read as something other than a value if
+// they were written bare.
+var oddValues = []struct {
+	name  string
+	value string
+}{
+	{"a space and another command", "prod dev; echo PWNED"},
+	{"a single quote", "it's"},
+	{"a backslash", `back\slash`},
+	{"a command substitution", "$(echo PWNED)"},
+	{"a backquoted command", "`echo PWNED`"},
+	{"a glob", "*"},
+	{"a newline", "one\ntwo"},
+	{"a quote closing the quoting", `'; echo PWNED; '`},
+}
+
+// safe env --bash is written to be handed to eval -- the help says so -- and
+// the values went in bare, so a namespace of "prod dev; echo PWNED" printed
+// \export VAULT_NAMESPACE=prod dev; echo PWNED;, which eval ran, setting the
+// namespace to "prod".
+func TestCmdEnv_Bash_ValuesSurviveEval(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("no sh to read the output back with: %v", err)
+	}
+
+	for _, tc := range oddValues {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			t.Setenv("VAULT_ADDR", "https://vault.example.com")
+			t.Setenv("VAULT_TOKEN", "")
+			t.Setenv("VAULT_SKIP_VERIFY", "")
+			t.Setenv("VAULT_NAMESPACE", tc.value)
+
+			c := newEnvCLI(t)
+			c.opt.Env.ForBash = true
+			out := captureStdout(t, func() {
+				if err := c.cmdEnv("env"); err != nil {
+					t.Errorf("cmdEnv bash: unexpected error: %v", err)
+				}
+			})
+
+			//The script says what it was given and nothing else: anything the
+			// shell ran on its own way through would print too.
+			script := out + "\nprintf '%s' \"$VAULT_NAMESPACE\"\n"
+			read, err := exec.Command(sh, "-c", script).CombinedOutput()
+			if err != nil {
+				t.Fatalf("sh refused the output: %v\nscript:\n%s", err, script)
+			}
+			if string(read) != tc.value {
+				t.Errorf("the shell read back %q, want %q\nscript:\n%s",
+					read, tc.value, script)
+			}
+		})
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", `''`},
+		{"plain", `'plain'`},
+		{"a b", `'a b'`},
+		{`back\slash`, `'back\slash'`},
+		{"it's", `'it'\''s'`},
+	}
+	for _, tc := range cases {
+		if got := shellQuote(tc.in); got != tc.want {
+			t.Errorf("shellQuote(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// fish reads a backslash inside single quotes as an escape, where sh does not,
+// so it needs quoting of its own.
+func TestFishQuote(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", `''`},
+		{"plain", `'plain'`},
+		{"a b", `'a b'`},
+		{`back\slash`, `'back\\slash'`},
+		{"it's", `'it\'s'`},
+		{`\'`, `'\\\''`},
+	}
+	for _, tc := range cases {
+		if got := fishQuote(tc.in); got != tc.want {
+			t.Errorf("fishQuote(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCmdEnv_Fish_ValuesSurviveEval(t *testing.T) {
+	fish, err := exec.LookPath("fish")
+	if err != nil {
+		t.Skipf("no fish to read the output back with: %v", err)
+	}
+
+	for _, tc := range oddValues {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			t.Setenv("VAULT_ADDR", "https://vault.example.com")
+			t.Setenv("VAULT_TOKEN", "")
+			t.Setenv("VAULT_SKIP_VERIFY", "")
+			t.Setenv("VAULT_NAMESPACE", tc.value)
+
+			c := newEnvCLI(t)
+			c.opt.Env.ForFish = true
+			out := captureStdout(t, func() {
+				if err := c.cmdEnv("env"); err != nil {
+					t.Errorf("cmdEnv fish: unexpected error: %v", err)
+				}
+			})
+
+			script := out + "\nprintf '%s' \"$VAULT_NAMESPACE\"\n"
+			read, err := exec.Command(fish, "-c", script).CombinedOutput()
+			if err != nil {
+				t.Fatalf("fish refused the output: %v\nscript:\n%s", err, script)
+			}
+			if string(read) != tc.value {
+				t.Errorf("fish read back %q, want %q\nscript:\n%s",
+					read, tc.value, script)
+			}
+		})
 	}
 }
 

--- a/internal/cli/env_render_test.go
+++ b/internal/cli/env_render_test.go
@@ -242,6 +242,66 @@ set -x VAULT_NAMESPACE 'ns/dev';
 }
 
 // ---------------------------------------------------------------------------
+// conflicting formats
+// ---------------------------------------------------------------------------
+
+// Naming two formats was a mistake only when all three were given, so safe
+// env --bash --fish printed the bash form and succeeded without saying which
+// of the two it had chosen.
+func TestCmdEnv_TwoFormatsIsAnError(t *testing.T) {
+	cases := []struct {
+		name                string
+		bash, fish, jsonFmt bool
+		wantErr             bool
+	}{
+		{name: "bash", bash: true},
+		{name: "fish", fish: true},
+		{name: "json", jsonFmt: true},
+		{name: "none"},
+		{name: "bash and fish", bash: true, fish: true, wantErr: true},
+		{name: "bash and json", bash: true, jsonFmt: true, wantErr: true},
+		{name: "fish and json", fish: true, jsonFmt: true, wantErr: true},
+		{name: "all three", bash: true, fish: true, jsonFmt: true, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			t.Setenv("VAULT_ADDR", "https://vault.example.com")
+			t.Setenv("VAULT_TOKEN", "")
+			t.Setenv("VAULT_SKIP_VERIFY", "")
+			t.Setenv("VAULT_NAMESPACE", "")
+
+			c := newEnvCLI(t)
+			c.opt.Env.ForBash = tc.bash
+			c.opt.Env.ForFish = tc.fish
+			c.opt.Env.ForJSON = tc.jsonFmt
+
+			var err error
+			out := captureStdout(t, func() { err = c.cmdEnv("env") })
+
+			if !tc.wantErr {
+				if err != nil {
+					t.Fatalf("cmdEnv: unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("cmdEnv gave no error and printed:\n%s", out)
+			}
+			if !strings.Contains(err.Error(), "one of") {
+				t.Errorf("error = %q, want it to say only one format may be given", err)
+			}
+			//Nothing is printed: a caller reading the output cannot tell one
+			// format from another once it is written.
+			if out != "" {
+				t.Errorf("cmdEnv printed a format anyway:\n%s", out)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // quoting
 // ---------------------------------------------------------------------------
 

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -414,6 +414,28 @@ func (c *CLI) cmdStatus(command string, args ...string) error {
 	return nil
 }
 
+// shellQuote wraps s in single quotes, where a shell takes every character
+// for itself, and ends and reopens the quoting around any single quote in s.
+// safe env --bash is meant to be handed to eval, and a value written bare was
+// read as shell source rather than as a value: a namespace of
+// "prod dev; rm -rf x" printed
+//
+//	\export VAULT_NAMESPACE=prod dev; rm -rf x;
+//
+// which eval ran, setting the namespace to "prod" and doing the rest.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// fishQuote is shellQuote for fish, which reads a backslash inside single
+// quotes as an escape where sh does not, so a backslash has to be doubled and
+// a single quote is escaped in place rather than by leaving the quoting.
+func fishQuote(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "'", `\'`)
+	return "'" + s + "'"
+}
+
 // envVar is one of the variables safe env reports. They are held in a slice
 // rather than a map because a map is walked in a different order every time,
 // and safe env --bash written to a file gave a different file on each run.
@@ -450,7 +472,7 @@ func (c *CLI) cmdEnv(command string, args ...string) error {
 	case opt.Env.ForBash:
 		for _, v := range vars {
 			if v.value != "" {
-				_, _ = fmt.Fprintf(os.Stdout, "\\export %s=%s;\n", v.name, v.value)
+				_, _ = fmt.Fprintf(os.Stdout, "\\export %s=%s;\n", v.name, shellQuote(v.value))
 			} else {
 				_, _ = fmt.Fprintf(os.Stdout, "\\unset %s;\n", v.name)
 			}
@@ -460,7 +482,7 @@ func (c *CLI) cmdEnv(command string, args ...string) error {
 			if v.value == "" {
 				_, _ = fmt.Fprintf(os.Stdout, "set -u %s;\n", v.name)
 			} else {
-				_, _ = fmt.Fprintf(os.Stdout, "set -x %s %s;\n", v.name, v.value)
+				_, _ = fmt.Fprintf(os.Stdout, "set -x %s %s;\n", v.name, fishQuote(v.value))
 			}
 		}
 	case opt.Env.ForJSON:

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -414,6 +414,14 @@ func (c *CLI) cmdStatus(command string, args ...string) error {
 	return nil
 }
 
+// envVar is one of the variables safe env reports. They are held in a slice
+// rather than a map because a map is walked in a different order every time,
+// and safe env --bash written to a file gave a different file on each run.
+type envVar struct {
+	name  string
+	value string
+}
+
 func (c *CLI) cmdEnv(command string, args ...string) error {
 	opt := c.opt
 	r := c.r
@@ -427,28 +435,32 @@ func (c *CLI) cmdEnv(command string, args ...string) error {
 		rc.Cleanup()
 		os.Exit(1)
 	}
-	vars := map[string]string{
-		"VAULT_ADDR":        os.Getenv("VAULT_ADDR"),
-		"VAULT_TOKEN":       os.Getenv("VAULT_TOKEN"),
-		"VAULT_SKIP_VERIFY": os.Getenv("VAULT_SKIP_VERIFY"),
-		"VAULT_NAMESPACE":   os.Getenv("VAULT_NAMESPACE"),
+	addr := os.Getenv("VAULT_ADDR")
+	token := os.Getenv("VAULT_TOKEN")
+	skipVerify := os.Getenv("VAULT_SKIP_VERIFY")
+	namespace := os.Getenv("VAULT_NAMESPACE")
+	vars := []envVar{
+		{"VAULT_ADDR", addr},
+		{"VAULT_TOKEN", token},
+		{"VAULT_SKIP_VERIFY", skipVerify},
+		{"VAULT_NAMESPACE", namespace},
 	}
 
 	switch {
 	case opt.Env.ForBash:
-		for name, value := range vars {
-			if value != "" {
-				_, _ = fmt.Fprintf(os.Stdout, "\\export %s=%s;\n", name, value)
+		for _, v := range vars {
+			if v.value != "" {
+				_, _ = fmt.Fprintf(os.Stdout, "\\export %s=%s;\n", v.name, v.value)
 			} else {
-				_, _ = fmt.Fprintf(os.Stdout, "\\unset %s;\n", name)
+				_, _ = fmt.Fprintf(os.Stdout, "\\unset %s;\n", v.name)
 			}
 		}
 	case opt.Env.ForFish:
-		for name, value := range vars {
-			if value == "" {
-				_, _ = fmt.Fprintf(os.Stdout, "set -u %s;\n", name)
+		for _, v := range vars {
+			if v.value == "" {
+				_, _ = fmt.Fprintf(os.Stdout, "set -u %s;\n", v.name)
 			} else {
-				_, _ = fmt.Fprintf(os.Stdout, "set -x %s %s;\n", name, value)
+				_, _ = fmt.Fprintf(os.Stdout, "set -x %s %s;\n", v.name, v.value)
 			}
 		}
 	case opt.Env.ForJSON:
@@ -458,10 +470,10 @@ func (c *CLI) cmdEnv(command string, args ...string) error {
 			Skip  string `json:"VAULT_SKIP_VERIFY,omitempty"`
 			NS    string `json:"VAULT_NAMESPACE,omitempty"`
 		}{
-			Addr:  vars["VAULT_ADDR"],
-			Token: vars["VAULT_TOKEN"],
-			Skip:  vars["VAULT_SKIP_VERIFY"],
-			NS:    vars["VAULT_NAMESPACE"],
+			Addr:  addr,
+			Token: token,
+			Skip:  skipVerify,
+			NS:    namespace,
 		}
 		b, err := json.Marshal(jsonEnv)
 		if err != nil {
@@ -471,9 +483,9 @@ func (c *CLI) cmdEnv(command string, args ...string) error {
 		return nil
 
 	default:
-		for name, value := range vars {
-			if value != "" {
-				_, _ = fmt.Fprintf(os.Stderr, "  @B{%s}  @G{%s}\n", name, value)
+		for _, v := range vars {
+			if v.value != "" {
+				_, _ = fmt.Fprintf(os.Stderr, "  @B{%s}  @G{%s}\n", v.name, v.value)
 			}
 		}
 	}

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -446,16 +446,21 @@ type envVar struct {
 
 func (c *CLI) cmdEnv(command string, args ...string) error {
 	opt := c.opt
-	r := c.r
 
 	if _, err := rc.Apply(opt.UseTarget); err != nil {
 		return err
 	}
-	if opt.Env.ForBash && opt.Env.ForFish && opt.Env.ForJSON {
-		_ = r.Help(os.Stderr, "env")
-		_, _ = fmt.Fprintf(os.Stderr, "@R{Only specify one of --json, --bash OR --fish.}\n")
-		rc.Cleanup()
-		os.Exit(1)
+	//Two formats were a mistake only when all three were named, so safe env
+	// --bash --fish printed one of them and said nothing about the other,
+	// leaving the caller to find out which it had picked.
+	formats := 0
+	for _, named := range []bool{opt.Env.ForBash, opt.Env.ForFish, opt.Env.ForJSON} {
+		if named {
+			formats++
+		}
+	}
+	if formats > 1 {
+		return fmt.Errorf("Only specify one of --json, --bash OR --fish")
 	}
 	addr := os.Getenv("VAULT_ADDR")
 	token := os.Getenv("VAULT_TOKEN")


### PR DESCRIPTION
`safe env --bash` writes shell source to be handed to `eval` -- the help says
so and the README shows it -- and it wrote the values into that source bare.

Everything below was reproduced with the `develop` build.

## A value went into the shell as source, not as a value

```
$ safe target -n 'prod dev; echo PWNED' https://vault.example.com odd
$ safe env --bash
\export VAULT_ADDR=https://vault.example.com;
\unset VAULT_TOKEN;
\unset VAULT_SKIP_VERIFY;
\export VAULT_NAMESPACE=prod dev; echo PWNED;
$ eval "$(safe env --bash)"
PWNED
$ echo "$VAULT_NAMESPACE"
prod
```

The namespace came from safe's own target configuration, written by `safe
target -n`, which takes it as given. Nothing about the value has to be
hostile for this to bite: a space is enough to lose everything after the
first word, which is the more likely way to meet it. What follows a
semicolon runs.

The values are quoted now, for the shell they are written for:

```
$ safe env --bash
\export VAULT_NAMESPACE='prod dev; echo PWNED';
$ eval "$(safe env --bash)"; echo "$VAULT_NAMESPACE"
prod dev; echo PWNED
```

sh reads every character inside single quotes literally, so a quote in the
value ends the quoting, escapes, and reopens it. fish reads a backslash
inside single quotes as an escape, so it gets a backslash and a quote
escaped in place instead. The tests hand the output to `sh` and to `fish`
and read the value back, so what a shell makes of it is what is checked
rather than what the string looks like. The fish half skips where fish is
not installed; it was run against fish 4.8.1 here.

## Two formats were a mistake only when all three were given

```
$ safe env --bash --fish
\export VAULT_ADDR=https://vault.example.com;
...
$ echo $?
0
```

The guard was `--bash AND --fish AND --json`, so any two of them printed one
of the two and succeeded without saying which it had chosen. Any two is the
mistake the message already described:

```
$ safe env --bash --fish
!! Only specify one of --json, --bash OR --fish
$ echo $?
1
```

The command reports it rather than exiting from inside itself, which is how
the rest of the commands report a misuse, and which lets it be tested in
process.

## The variables came out in a different order every time

They were held in a map, and Go walks a map in a different order on each
run. Six runs of `safe env --bash`, hashed: three distinct orderings before,
one after. Written to a file and compared, the same environment looked
different each time.

## Verification

`make check` (fmt, vet, staticcheck, tests) and `go test -race -count=1
./...` pass; each of the four commits builds and passes `./internal/cli/` on
its own.

`cmdEnv` goes 69.0% -> 93.9%, `shellQuote` and `fishQuote` are at 100%.
Across the tree, coverage goes 67.3% -> 67.5%.

Fifteen mutations of the changed code, all killed: quoting dropped, applied
without escaping the inner quote, or done with double quotes (3); fish
quoting dropped, either escape dropped, or the two applied in the wrong
order (4); the bash or the fish branch writing its values bare (2); the
variables walked as a map or two of them swapped (2); the conflict check
requiring all three, never firing, or reported without stopping (3); and the
JSON form reporting the token as the address (1).

Unchanged on purpose: `safe env` with no format still writes to standard
error, which the help documents as the difference between it and the three
format flags.
