### PR TITLE
Walk the mounts a token can read

### DIFF
--- a/pkg/vault/httptest_helper_test.go
+++ b/pkg/vault/httptest_helper_test.go
@@ -1,16 +1,23 @@
 // Package vault_test provides a fake Vault HTTP server for black-box tests.
-// The helper stands up a KV v1 backend (all secrets live under /secret/)
-// and wires a *Vault to it via the vaultkv client's VaultURL field.
+// The helper stands up a KV v1 backend at /secret/ and wires a *Vault to it
+// via the vaultkv client's VaultURL field. Further mounts can be added with
+// mount(), which is what the mount listing and the walk of a whole Vault are
+// tested against.
 //
 // Endpoints handled:
 //
-//	GET  /v1/sys/internal/ui/mounts — mount discovery (returns /secret/ as KV v1)
+//	GET  /v1/sys/internal/ui/mounts — mount discovery, with each mount's version
 //	GET  /v1/auth/token/lookup-self — token validity check (200 OK)
 //	GET  /v1/sys/mounts            — list mounts (used by IsMounted/PKI checks)
-//	GET  /v1/secret/*              — read secret
-//	POST /v1/secret/*              — write secret
-//	DELETE /v1/secret/*            — delete secret
-//	LIST /v1/secret/*              — list secrets (uses X-List-Method or PROPFIND-style)
+//	POST /v1/sys/mounts/<path>     — enable a mount (used by AddMount)
+//	GET  /v1/<mount>/*             — read secret
+//	POST /v1/<mount>/*             — write secret
+//	DELETE /v1/<mount>/*           — delete secret
+//	LIST /v1/<mount>/*             — list secrets (uses X-List-Method or PROPFIND-style)
+//
+// Every KV mount the fake serves is version 1. A version 2 mount answers on
+// different paths again -- data/, metadata/, delete/, undelete/, destroy/ --
+// and is not modelled here.
 package vault_test
 
 import (
@@ -19,6 +26,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -27,10 +35,22 @@ import (
 	"github.com/cloudfoundry-community/vaultkv"
 )
 
+// fakeMount is a secrets backend the fake serves. Version is the KV version,
+// and is 1 for every mount the fake can actually answer for.
+type fakeMount struct {
+	typ     string
+	version int
+}
+
 // fakeVault is an in-memory key-value store that mimics a Vault KV v1 backend.
 type fakeVault struct {
 	mu   sync.RWMutex
 	data map[string]map[string]string // path → key → value
+
+	// mounts holds the KV mounts the fake serves, keyed by mount name with no
+	// slashes. A Vault has more than one mount and safe reaches all of them
+	// when it is asked to walk the whole thing.
+	mounts map[string]fakeMount
 
 	// forbidden marks secret paths whose list and get requests return 403,
 	// modeling a token whose policy denies part of the tree.
@@ -66,11 +86,34 @@ type fakeVault struct {
 
 func newFakeVault() *fakeVault {
 	return &fakeVault{
-		data:        make(map[string]map[string]string),
-		forbidden:   make(map[string]bool),
-		pki:         make(map[string]bool),
+		data:      make(map[string]map[string]string),
+		mounts:    map[string]fakeMount{"secret": {typ: "kv", version: 1}},
+		forbidden: make(map[string]bool),
+		pki:       make(map[string]bool),
+
 		initialized: true,
 	}
+}
+
+// mount adds a KV mount of the given type ("kv" or "generic"). Secrets are
+// stored under it by their full path, the same as for the default mount.
+func (f *fakeVault) mount(name, typ string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.mounts[strings.Trim(name, "/")] = fakeMount{typ: typ, version: 1}
+}
+
+// mountFor returns the mount a request path belongs to, and the path within
+// it. The path given is what follows /v1/.
+func (f *fakeVault) mountFor(path string) (name string, sub string, ok bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	path = strings.TrimLeft(path, "/")
+	name, sub, _ = strings.Cut(path, "/")
+	if _, ok = f.mounts[name]; !ok {
+		return "", "", false
+	}
+	return name, strings.Trim(sub, "/"), true
 }
 
 // forbid makes list and get requests for a secret path return 403.
@@ -152,13 +195,17 @@ func (f *fakeVault) sysMountsForListJSON() []byte {
 		Description string `json:"description"`
 		Config      any    `json:"config"`
 	}
-	mounts := map[string]mountEntry{
-		"secret/": {Type: "kv", Config: map[string]any{}},
+	mounts := map[string]mountEntry{}
+	for name, m := range f.mounts {
+		mounts[name+"/"] = mountEntry{Type: m.typ, Config: map[string]any{}}
 	}
 	for name := range f.pki {
 		mounts[name+"/"] = mountEntry{Type: "pki", Config: map[string]any{}}
 	}
-	b, _ := json.Marshal(mounts)
+	//Vault 1.10 and later repeat the mounts under a data key, with other
+	// metadata beside them at the top level. The client reads the data key
+	// and gives back nothing at all for the older shape.
+	b, _ := json.Marshal(map[string]any{"data": mounts})
 	return b
 }
 
@@ -173,8 +220,12 @@ func (f *fakeVault) uiMountsJSON() []byte {
 		Type    string   `json:"type"`
 		Options optEntry `json:"options"`
 	}
-	secretMap := map[string]secretMount{
-		"secret/": {Type: "kv", Options: optEntry{Version: "1"}},
+	secretMap := map[string]secretMount{}
+	for name, m := range f.mounts {
+		secretMap[name+"/"] = secretMount{
+			Type:    m.typ,
+			Options: optEntry{Version: strconv.Itoa(m.version)},
+		}
 	}
 	for name := range f.pki {
 		secretMap[name+"/"] = secretMount{Type: "pki"}
@@ -211,6 +262,9 @@ func (f *fakeVault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(f.sysMountsForListJSON())
 
+	case strings.HasPrefix(p, "/v1/sys/mounts/") && r.Method == http.MethodPost:
+		f.handleEnableMount(w, r)
+
 	case p == "/v1/sys/health",
 		p == "/v1/sys/seal-status",
 		p == "/v1/sys/init",
@@ -220,27 +274,58 @@ func (f *fakeVault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		p == "/v1/sys/rekey/update":
 		f.handleSys(w, r)
 
-	case strings.HasPrefix(p, "/v1/secret/") || p == "/v1/secret":
-		f.handleKV(w, r)
-
 	default:
+		if mount, subpath, ok := f.mountFor(strings.TrimPrefix(p, "/v1/")); ok {
+			f.handleKV(w, r, mount, subpath)
+			return
+		}
 		// PKI issue / revoke
 		f.handlePKI(w, r)
 	}
 }
 
-func (f *fakeVault) handleKV(w http.ResponseWriter, r *http.Request) {
-	// Strip /v1/secret prefix to get the subpath.
-	subpath := strings.TrimPrefix(r.URL.Path, "/v1/secret")
-	subpath = strings.Trim(subpath, "/")
+// handleEnableMount records the mount a POST to sys/mounts/<path> asks for,
+// which is what AddMount sends.
+func (f *fakeVault) handleEnableMount(w http.ResponseWriter, r *http.Request) {
+	name := strings.Trim(strings.TrimPrefix(r.URL.Path, "/v1/sys/mounts/"), "/")
+	if name == "" {
+		jsonErr(w, http.StatusBadRequest, "no mount path given")
+		return
+	}
 
+	var body struct {
+		Type    string `json:"type"`
+		Options struct {
+			Version string `json:"version"`
+		} `json:"options"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonErr(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, taken := f.mounts[name]; taken {
+		jsonErr(w, http.StatusBadRequest, "path is already in use at "+name+"/")
+		return
+	}
+	version, err := strconv.Atoi(body.Options.Version)
+	if err != nil || version == 0 {
+		version = 1
+	}
+	f.mounts[name] = fakeMount{typ: body.Type, version: version}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (f *fakeVault) handleKV(w http.ResponseWriter, r *http.Request, mount, subpath string) {
 	// LIST is sent as GET with ?list=true or as PROPFIND-alike.
 	// vaultkv sends it as a GET with ?list=true query param for v1.
 	isList := r.Method == "LIST" || r.URL.Query().Get("list") == "true"
 
 	switch {
 	case isList:
-		prefix := "secret/" + subpath
+		prefix := mount + "/" + subpath
 		if f.isForbidden(strings.TrimRight(prefix, "/")) {
 			jsonErr(w, http.StatusForbidden, "permission denied")
 			return
@@ -258,7 +343,7 @@ func (f *fakeVault) handleKV(w http.ResponseWriter, r *http.Request) {
 		})
 
 	case r.Method == http.MethodGet:
-		secretPath := "secret/" + subpath
+		secretPath := strings.TrimRight(mount+"/"+subpath, "/")
 		if f.isForbidden(secretPath) {
 			jsonErr(w, http.StatusForbidden, "permission denied")
 			return
@@ -274,7 +359,7 @@ func (f *fakeVault) handleKV(w http.ResponseWriter, r *http.Request) {
 		})
 
 	case r.Method == http.MethodPost || r.Method == http.MethodPut:
-		secretPath := "secret/" + subpath
+		secretPath := strings.TrimRight(mount+"/"+subpath, "/")
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			jsonErr(w, http.StatusBadRequest, "invalid json")
@@ -295,7 +380,7 @@ func (f *fakeVault) handleKV(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 
 	case r.Method == http.MethodDelete:
-		secretPath := "secret/" + subpath
+		secretPath := strings.TrimRight(mount+"/"+subpath, "/")
 		f.del(secretPath)
 		w.WriteHeader(http.StatusNoContent)
 

--- a/pkg/vault/mount_test.go
+++ b/pkg/vault/mount_test.go
@@ -1,0 +1,152 @@
+package vault_test
+
+import (
+	"slices"
+	"testing"
+)
+
+// A Vault holds more than the one mount safe starts with, and the mount
+// listing is what every command that reaches past a single tree is built on.
+func TestListMountsNamesEveryMount(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mount("kv", "kv")
+	fv.mount("legacy", "generic")
+
+	mounts, err := v.ListMounts()
+	if err != nil {
+		t.Fatalf("ListMounts: %v", err)
+	}
+
+	for _, want := range []string{"secret", "kv", "legacy"} {
+		if !slices.Contains(mounts, want) {
+			t.Errorf("ListMounts left out %q: %v", want, mounts)
+		}
+	}
+}
+
+func TestMountExists(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mount("kv", "kv")
+
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"secret", true},
+		{"secret/", true},
+		{"/secret/", true},
+		{"kv", true},
+		{"nowhere", false},
+		//A mount is named by its own path, not by what lives under it.
+		{"secret/handshake", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got, err := v.MountExists(tc.path)
+		if err != nil {
+			t.Fatalf("MountExists(%q): %v", tc.path, err)
+		}
+		if got != tc.want {
+			t.Errorf("MountExists(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+// safe local mounts its own KV backend before it writes anything to it.
+func TestAddMountMakesTheMountExist(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+
+	if exists, err := v.MountExists("fresh"); err != nil || exists {
+		t.Fatalf("MountExists(fresh) = %v, %v before it is added", exists, err)
+	}
+	if err := v.AddMount("fresh", 2); err != nil {
+		t.Fatalf("AddMount: %v", err)
+	}
+
+	exists, err := v.MountExists("fresh")
+	if err != nil {
+		t.Fatalf("MountExists after AddMount: %v", err)
+	}
+	if !exists {
+		t.Errorf("the mount AddMount made does not exist")
+	}
+
+	//The version asked for is the version the mount is made with: safe local
+	// asks for 2, and a v1 mount would answer on other paths entirely.
+	fv.mu.RLock()
+	defer fv.mu.RUnlock()
+	if got := fv.mounts["fresh"]; got.version != 2 || got.typ != "kv" {
+		t.Errorf("mount made as %+v, want a version 2 kv mount", got)
+	}
+}
+
+func TestAddMountOnAPathAlreadyTakenFails(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+
+	if err := v.AddMount("secret", 2); err == nil {
+		t.Errorf("AddMount over an existing mount gave no error")
+	}
+}
+
+// Mounts answers by backend type, which is how the walk of a whole Vault
+// finds the trees to walk: kv and generic are the two names the key-value
+// backend has had.
+func TestMountsSelectsByType(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mount("kv", "kv")
+	fv.mount("legacy", "generic")
+	fv.pki["ca"] = true
+
+	cases := []struct {
+		typ  string
+		want []string
+	}{
+		{"kv", []string{"kv/", "secret/"}},
+		{"generic", []string{"legacy/"}},
+		{"pki", []string{"ca/"}},
+		{"nosuchtype", []string{}},
+	}
+	for _, tc := range cases {
+		got, err := v.Mounts(tc.typ)
+		if err != nil {
+			t.Fatalf("Mounts(%q): %v", tc.typ, err)
+		}
+		slices.Sort(got)
+		if !slices.Equal(got, tc.want) {
+			t.Errorf("Mounts(%q) = %v, want %v", tc.typ, got, tc.want)
+		}
+	}
+}
+
+func TestIsMounted(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mount("kv", "kv")
+
+	cases := []struct {
+		typ, path string
+		want      bool
+	}{
+		{"kv", "secret", true},
+		{"kv", "secret/", true},
+		{"kv", "kv", true},
+		{"kv", "nowhere", false},
+		//The type has to match too, or safe would take any mount for a PKI
+		// backend and issue certificates against it.
+		{"pki", "secret", false},
+	}
+	for _, tc := range cases {
+		got, err := v.IsMounted(tc.typ, tc.path)
+		if err != nil {
+			t.Fatalf("IsMounted(%q, %q): %v", tc.typ, tc.path, err)
+		}
+		if got != tc.want {
+			t.Errorf("IsMounted(%q, %q) = %v, want %v", tc.typ, tc.path, got, tc.want)
+		}
+	}
+}

--- a/pkg/vault/tree.go
+++ b/pkg/vault/tree.go
@@ -941,12 +941,23 @@ func (w *treeWorker) workMounts(_ secretTree) ([]secretTree, error) {
 	ret := []secretTree{}
 	for _, mount := range mounts {
 		//Handle the case in which a mount has a secret at its root
-		if _, err = w.vault.Read(mount); err == nil {
+		_, err = w.vault.Read(mount)
+		switch {
+		case err == nil:
 			ret = append(ret, secretTree{
 				Name: mount,
 				Type: treeTypeSecret,
 			})
-		} else if !IsNotFound(err) {
+		case IsNotFound(err):
+		case vaultkv.IsForbidden(err):
+			//A token holding no read on a mount ended the walk of the whole
+			// Vault, so a Vault with one mount the token could not read had
+			// nothing safe could say about the mounts it could. The walk skips
+			// what it cannot read everywhere else, and this read is a question
+			// about a secret that most likely is not there at all, so it is not
+			// counted as a skip: the mount is counted where its listing is
+			// denied, once, rather than twice for the one mount.
+		default:
 			return nil, err
 		}
 

--- a/pkg/vault/tree_mounts_test.go
+++ b/pkg/vault/tree_mounts_test.go
@@ -1,0 +1,117 @@
+package vault_test
+
+import (
+	"slices"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// safe tree /, safe paths /, and safe export / all start from the root of the
+// Vault, where there is no path to list -- only mounts to find and walk in
+// turn.
+func TestConstructSecretsAtRootReachesEveryMount(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mount("kv", "kv")
+	fv.mount("legacy", "generic")
+
+	fv.set("secret/handshake", map[string]string{"k": "v"})
+	fv.set("kv/deploy/creds", map[string]string{"k": "v"})
+	fv.set("legacy/old", map[string]string{"k": "v"})
+
+	s, err := v.ConstructSecrets("/", vault.TreeOpts{FetchKeys: true})
+	if err != nil {
+		t.Fatalf("ConstructSecrets: %v", err)
+	}
+
+	got := paths(s)
+	slices.Sort(got)
+	want := []string{"kv/deploy/creds", "legacy/old", "secret/handshake"}
+	if !slices.Equal(got, want) {
+		t.Errorf("walking the root gave %v, want %v", got, want)
+	}
+}
+
+// A mount with a secret at its own root is both a secret and a folder, and
+// the walk has to report it as both rather than picking one.
+func TestConstructSecretsAtRootFindsASecretOnAMountRoot(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mount("kv", "kv")
+
+	fv.set("kv", map[string]string{"k": "v"})
+	fv.set("kv/below", map[string]string{"k": "v"})
+
+	s, err := v.ConstructSecrets("/", vault.TreeOpts{FetchKeys: true})
+	if err != nil {
+		t.Fatalf("ConstructSecrets: %v", err)
+	}
+
+	got := paths(s)
+	slices.Sort(got)
+	want := []string{"kv", "kv/below"}
+	if !slices.Equal(got, want) {
+		t.Errorf("walking the root gave %v, want %v", got, want)
+	}
+}
+
+// An empty mount contributes nothing, and must not stop the walk of the ones
+// that hold something.
+func TestConstructSecretsAtRootSkipsAnEmptyMount(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mount("empty", "kv")
+
+	fv.set("secret/handshake", map[string]string{"k": "v"})
+
+	s, err := v.ConstructSecrets("/", vault.TreeOpts{FetchKeys: true})
+	if err != nil {
+		t.Fatalf("ConstructSecrets: %v", err)
+	}
+
+	got := paths(s)
+	if !slices.Equal(got, []string{"secret/handshake"}) {
+		t.Errorf("walking the root gave %v, want just secret/handshake", got)
+	}
+}
+
+// A mount whose whole tree the token cannot list is skipped and counted, and
+// the mounts it can read still come back.
+func TestConstructSecretsAtRootCountsAForbiddenMount(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mount("locked", "kv")
+
+	fv.set("secret/handshake", map[string]string{"k": "v"})
+	fv.set("locked/away", map[string]string{"k": "v"})
+	fv.forbid("locked")
+
+	var skipped atomic.Uint64
+	s, err := v.ConstructSecrets("/", vault.TreeOpts{
+		FetchKeys:        true,
+		SkippedForbidden: &skipped,
+	})
+	if err != nil {
+		t.Fatalf("ConstructSecrets: %v", err)
+	}
+
+	got := paths(s)
+	if !slices.Equal(got, []string{"secret/handshake"}) {
+		t.Errorf("walking the root gave %v, want just secret/handshake", got)
+	}
+	if n := skipped.Load(); n != 1 {
+		t.Errorf("skipped = %d, want 1 (the mount the token cannot read)", n)
+	}
+}
+
+// paths is the path of every secret the walk returned, without the keys that
+// Paths() names alongside them.
+func paths(s vault.Secrets) []string {
+	out := make([]string, 0, len(s))
+	for _, entry := range s {
+		out = append(out, entry.Path)
+	}
+	return out
+}


### PR DESCRIPTION
`safe tree /`, `safe paths /`, and `safe export /` walk every mount in a
Vault. One mount the token could not read ended the walk, and safe said
nothing at all about the mounts it could.

Reproduced against Vault with three KV mounts -- `secret/`, `open/`, and
`locked/` -- and a token holding read and list on the first two:

```
$ safe tree /
!! 403 Forbidden: 1 error occurred:
	* permission denied

$ echo $?
1
```

`safe paths /` and `safe export /` gave the same. There is nothing wrong
with the token: it can read what it was given, and safe walks the tree it
was pointed at happily. It is walking the whole Vault that fails.

Walking the root reads each mount's own path first, to find a secret sitting
at the root of the mount, and that read went out for every mount including
the ones the token has nothing on. Every other unreadable node in a walk is
skipped and counted -- a subtree whose listing is denied, a secret whose
value is denied -- and this one read was the exception.

```
$ safe tree /
.
└── /
    ├── open/
    │   └── thing
    └── secret/
        └── handshake

$ safe values -p / v
open/thing
secret/handshake
warning: skipped 1 subtree(s) due to insufficient permissions; results may be incomplete
```

The skip is not counted where the read fails. The read asks whether a secret
sits at the root of the mount, which most likely it does not, so counting it
would report one denied mount as two skipped subtrees. The mount is counted
once, where its listing is denied. Walking as a token that can read
everything gives byte-identical output before and after.

## The fake Vault serves more than one mount

None of this could be tested. The fake stood up a single KV v1 mount at
`secret/`, so `ListMounts`, `MountExists`, `AddMount`, `Mounts`, `IsMounted`,
and the mount walk itself had nothing to run against -- all of them sat at
0% under `-coverpkg`.

It holds a set of mounts now, serves reads and lists for each, and records
the mount a POST to `sys/mounts` asks for, which is what `AddMount` sends and
what `safe local` does before it writes anything.

Its mount listing also had to move to the shape Vault 1.10 and later return,
with the mounts repeated under a `data` key. The client reads that key and
gives back an empty list for the older shape, so every mount test passed
against nothing until the fake sent what a current Vault sends.

Mounts the fake serves are version 1. A version 2 mount answers on other
paths again -- `data/`, `metadata/`, `delete/`, `undelete/`, `destroy/` --
and modelling it is its own piece of work.

## Verification

`make check` (fmt, vet, staticcheck, tests) and `go test -race -count=1
./...` pass; both commits build and pass `./pkg/vault/` on their own.

Coverage, all previously at 0.0%: `AddMount` 100%, `Mounts` 87.5%,
`ListMounts` 85.7%, `MountExists` 85.7%, `IsMounted` 85.7%, `workMounts`
80.0%. Across the tree, 67.5% -> 68.4%.

Twelve mutations of the changed code, all killed: the forbidden mount ending
the walk again or being counted twice (2); a secret at a mount root not
reported, a mount not walked as a folder, or the kv or the generic mounts
left out of the walk (4); `Mounts` answering for every type alike or
dropping the trailing slash (2); `MountExists` comparing untrimmed (1);
`AddMount` ignoring the version asked for (1); `ListMounts` giving back
nothing (1); and `IsMounted` ignoring the path (1).
