### PR TITLE
Fix what safe curl sends and reports

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1145,15 +1145,21 @@ The following OPTIONS are recognized:
 
   --data-only         Show only the response body, hiding the response headers.
 
-METHOD must be one of GET, LIST, POST, or PUT.
+METHOD must be one of GET, LIST, POST, PUT, PATCH, DELETE, HEAD or OPTIONS.
+Given on its own, without a REL-URI to ask for, it is an error.
 
-REL-URI is the relative URI (the path component, starting with the first
-forward slash) of the resource you wish to access.
+REL-URI names the resource you wish to access, and does @B{not} carry the
+@C{/v1} that every Vault API path begins with: safe adds it for you.  Ask for
+@C{/sys/health}, not @C{/v1/sys/health}, which reaches @C{/v1/v1/sys/health} and is
+not there.
 
 DATA should be a JSON string, since almost all of the Vault API handlers
 deal exclusively in JSON payloads.  GET requests should not have DATA.
 Query string parameters should be appended to REL-URI, instead of being
 sent as DATA.
+
+A response the Vault refused is printed as it arrived, and safe exits
+non-zero for it.
 `,
 	}, c.cmdCurl)
 

--- a/internal/cli/curl_cmd_test.go
+++ b/internal/cli/curl_cmd_test.go
@@ -101,6 +101,62 @@ func TestCmdCurlTakesALoneURIAsAGet(t *testing.T) {
 	}
 }
 
+// A refused request used to leave safe exiting 0, so a script could not tell
+// it from one that worked.
+func TestCmdCurlFailsWhenTheVaultRefuses(t *testing.T) {
+	c, _ := newCurlCLI(t)
+
+	var err error
+	out := captureStdout(t, func() { err = c.cmdCurl("curl", "GET", "/nowhere") })
+
+	if err == nil {
+		t.Fatal("a 404 from the Vault returned no error")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error was %q, want it to name the status", err)
+	}
+	//What the Vault said is the answer to the question that was asked, and it
+	// is printed whether or not the status was one safe reports as a failure.
+	if !strings.Contains(out, "404") {
+		t.Errorf("printed %q, want the response the Vault sent", out)
+	}
+}
+
+// --data-only hides the status line, so without an exit code there is nothing
+// left to say the request was refused.
+func TestCmdCurlDataOnlyFailsWhenTheVaultRefuses(t *testing.T) {
+	c, _ := newCurlCLI(t)
+	c.opt.Curl.DataOnly = true
+
+	var err error
+	out := captureStdout(t, func() { err = c.cmdCurl("curl", "GET", "/nowhere") })
+
+	if err == nil {
+		t.Fatal("a 404 from the Vault returned no error")
+	}
+	if !strings.Contains(out, `"errors"`) {
+		t.Errorf("printed %q, want the body the Vault sent", out)
+	}
+	if strings.Contains(out, "HTTP/") {
+		t.Errorf("printed %q, want the body alone under --data-only", out)
+	}
+}
+
+// A request the Vault answered is a success, and stays one.
+func TestCmdCurlSucceedsWhenTheVaultAnswers(t *testing.T) {
+	c, _ := newCurlCLI(t)
+
+	var err error
+	out := captureStdout(t, func() { err = c.cmdCurl("curl", "GET", "/secret/handshake") })
+
+	if err != nil {
+		t.Fatalf("cmdCurl: %v", err)
+	}
+	if !strings.Contains(out, "200 OK") {
+		t.Errorf("printed %q, want the status line", out)
+	}
+}
+
 // A method is sent as it is named, whatever case it was written in.
 func TestCmdCurlUppercasesTheMethod(t *testing.T) {
 	c, fv := newCurlCLI(t)

--- a/internal/cli/curl_cmd_test.go
+++ b/internal/cli/curl_cmd_test.go
@@ -1,0 +1,118 @@
+package cli
+
+// safe curl hands whatever it is given to the Vault API. What it makes of its
+// arguments, and what it does with the answer, are the two things it is for.
+//
+// captureStdout mutates the process-global os.Stdout — do NOT add t.Parallel
+// to any test in this file.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// newCurlCLI builds a CLI with curl registered, so r.Usage("curl") returns a
+// properly-typed error, and points it at a fake Vault holding one secret.
+func newCurlCLI(t *testing.T) (*CLI, *cliFakeVault) {
+	t.Helper()
+	isolateHome(t)
+	fv := newCLIFake(t)
+	fv.set("secret/handshake", map[string]string{"k": "v"})
+
+	r := NewRunner()
+	r.Dispatch("curl", &Help{
+		Summary: "curl",
+		Usage:   "safe curl [OPTIONS] METHOD REL-URI [DATA]",
+		Type:    DestructiveCommand,
+	}, func(cmd string, args ...string) error { return nil })
+
+	return &CLI{opt: &Options{}, r: r}, fv
+}
+
+// A lone argument naming a method has no URI with it. It used to be taken for
+// the URI, so safe curl GET asked the Vault for /v1/GET.
+func TestCmdCurlRefusesAMethodWithNoURI(t *testing.T) {
+	for _, arg := range []string{"GET", "get", "LIST", "delete"} {
+		t.Run(arg, func(t *testing.T) {
+			c, fv := newCurlCLI(t)
+
+			err := c.cmdCurl("curl", arg)
+			if err == nil {
+				t.Fatalf("safe curl %s returned no error", arg)
+			}
+			if !strings.Contains(err.Error(), "REL-URI") {
+				t.Errorf("error was %q, want it to name the missing REL-URI", err)
+			}
+			if reqs := fv.requests(); len(reqs) != 0 {
+				t.Errorf("asked the Vault %v, want nothing asked at all", reqs)
+			}
+		})
+	}
+}
+
+// A first argument that is not a method means the arguments are in the wrong
+// order or one too many, and the request that used to go out named the URI as
+// its method.
+func TestCmdCurlRefusesSomethingThatIsNotAMethod(t *testing.T) {
+	c, fv := newCurlCLI(t)
+
+	err := c.cmdCurl("curl", "/secret/handshake", `{"k":"v"}`)
+	if err == nil {
+		t.Fatal("expected an error for a URI where a method belongs")
+	}
+	if !strings.Contains(err.Error(), "not an HTTP method") {
+		t.Errorf("error was %q, want it to say what is wrong", err)
+	}
+	if !strings.Contains(err.Error(), "GET") {
+		t.Errorf("error was %q, want it to name the methods that work", err)
+	}
+	if reqs := fv.requests(); len(reqs) != 0 {
+		t.Errorf("asked the Vault %v, want nothing asked at all", reqs)
+	}
+}
+
+func TestCmdCurlWithNoArgumentsIsAUsageError(t *testing.T) {
+	c, _ := newCurlCLI(t)
+
+	var usage *UsageError
+	if err := c.cmdCurl("curl"); !errors.As(err, &usage) {
+		t.Fatalf("error was %v, want a UsageError", err)
+	}
+}
+
+// A lone URI is a GET, which is the form that made a method with no URI look
+// like a URI in the first place.
+func TestCmdCurlTakesALoneURIAsAGet(t *testing.T) {
+	c, fv := newCurlCLI(t)
+
+	out := captureStdout(t, func() {
+		if err := c.cmdCurl("curl", "/secret/handshake"); err != nil {
+			t.Fatalf("cmdCurl: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, `"k":"v"`) {
+		t.Errorf("printed %q, want the secret the Vault answered with", out)
+	}
+	want := "GET /v1/secret/handshake"
+	if reqs := fv.requests(); len(reqs) != 1 || reqs[0] != want {
+		t.Errorf("asked the Vault %v, want [%s]", reqs, want)
+	}
+}
+
+// A method is sent as it is named, whatever case it was written in.
+func TestCmdCurlUppercasesTheMethod(t *testing.T) {
+	c, fv := newCurlCLI(t)
+
+	captureStdout(t, func() {
+		if err := c.cmdCurl("curl", "get", "/secret/handshake"); err != nil {
+			t.Fatalf("cmdCurl: %v", err)
+		}
+	})
+
+	want := "GET /v1/secret/handshake"
+	if reqs := fv.requests(); len(reqs) != 1 || reqs[0] != want {
+		t.Errorf("asked the Vault %v, want [%s]", reqs, want)
+	}
+}

--- a/internal/cli/misc.go
+++ b/internal/cli/misc.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"io"
+	"net/http"
 	"net/http/httputil"
 	"os"
 	"slices"
@@ -228,8 +229,20 @@ func (c *CLI) cmdCurl(command string, args ...string) error {
 		_, _ = fmt.Fprintf(os.Stdout, "%s\n", string(b))
 
 	} else {
-		r, _ := httputil.DumpResponse(res, true)
-		_, _ = fmt.Fprintf(os.Stdout, "%s\n", r)
+		dump, err := httputil.DumpResponse(res, true)
+		if err != nil {
+			return fmt.Errorf("could not read the response to %s %s: %w", method, url, err)
+		}
+		_, _ = fmt.Fprintf(os.Stdout, "%s\n", dump)
+	}
+
+	//A request the Vault refused left safe exiting 0, so a script asking for
+	// a path it may not read, or one that is not there, could not tell that
+	// apart from a request that worked. Under --data-only, where the status
+	// line is not printed either, nothing at all said so. What Vault answered
+	// is printed either way: reading it is what the command is for.
+	if res.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("%s %s: %s", method, url, res.Status)
 	}
 	return nil
 }

--- a/internal/cli/misc.go
+++ b/internal/cli/misc.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http/httputil"
 	"os"
+	"slices"
 	"strings"
 
 	fmt "github.com/jhunt/go-ansi"
@@ -167,6 +168,15 @@ func (c *CLI) cmdFmt(command string, args ...string) error {
 	return v.Write(path, s)
 }
 
+// curlMethods are the methods safe curl will send. LIST is Vault's own; the
+// rest are the ones a Vault endpoint answers to.
+var curlMethods = []string{"GET", "LIST", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}
+
+// isCurlMethod reports whether s names an HTTP method, whatever its case.
+func isCurlMethod(s string) bool {
+	return slices.Contains(curlMethods, strings.ToUpper(s))
+}
+
 func (c *CLI) cmdCurl(command string, args ...string) error {
 	opt := c.opt
 	r := c.r
@@ -180,13 +190,25 @@ func (c *CLI) cmdCurl(command string, args ...string) error {
 		data        []byte
 	)
 
+	//Whatever was given first was taken for the method and whatever was given
+	// alone was taken for the URI, neither of them read. So safe curl GET
+	// asked the Vault for /v1/GET, and safe curl /sys/health '{}' sent a
+	// request whose method was /SYS/HEALTH.
 	method = "GET"
-	if len(args) < 1 {
+	switch {
+	case len(args) < 1:
 		return r.Usage("curl")
-	} else if len(args) == 1 {
+	case len(args) == 1:
+		if isCurlMethod(args[0]) {
+			return fmt.Errorf("no REL-URI given to %s", strings.ToUpper(args[0]))
+		}
 		url = args[0]
-	} else {
+	default:
 		method = strings.ToUpper(args[0])
+		if !isCurlMethod(method) {
+			return fmt.Errorf("%s is not an HTTP method: give one of %s",
+				args[0], strings.Join(curlMethods, ", "))
+		}
 		url = args[1]
 		data = []byte(strings.Join(args[2:], " "))
 	}

--- a/pkg/vault/curl_test.go
+++ b/pkg/vault/curl_test.go
@@ -1,0 +1,160 @@
+package vault_test
+
+// Curl hands a request straight to the Vault API, so what it sends is the
+// whole of its behaviour. These tests stand up a server that records the
+// request line and read it back, rather than asserting on the response.
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// recorded is one request a curlServer received.
+type recorded struct {
+	method string
+	path   string
+	query  url.Values
+	body   string
+}
+
+// newCurlVault starts a server that records every request and answers 200,
+// and returns a Vault pointed at it alongside the recording.
+func newCurlVault(t *testing.T) (*vault.Vault, *recorded) {
+	t.Helper()
+	got := &recorded{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		got.method = r.Method
+		got.path = r.URL.Path
+		got.query = r.URL.Query()
+		got.body = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	v, err := vault.NewVault(vault.VaultConfig{URL: srv.URL, Token: "test-token"})
+	if err != nil {
+		t.Fatalf("NewVault: %v", err)
+	}
+	if err := v.SetURL(srv.URL); err != nil {
+		t.Fatalf("SetURL: %v", err)
+	}
+	return v, got
+}
+
+// A query value that is itself a URL holds a pair of slashes that the path
+// rules would collapse, and it has to arrive as it was written.
+func TestCurlKeepsSlashesInAQueryValue(t *testing.T) {
+	t.Parallel()
+	v, got := newCurlVault(t)
+
+	res, err := v.Curl("GET", "/sys/x?u=http://example.com/a/b", nil)
+	if err != nil {
+		t.Fatalf("Curl: %v", err)
+	}
+	_ = res.Body.Close()
+
+	if u := got.query.Get("u"); u != "http://example.com/a/b" {
+		t.Errorf("u = %q, want the URL as written", u)
+	}
+}
+
+// A trailing slash is dropped from a path and has to be kept in a query.
+func TestCurlKeepsATrailingSlashInAQueryValue(t *testing.T) {
+	t.Parallel()
+	v, got := newCurlVault(t)
+
+	res, err := v.Curl("GET", "/sys/x?dir=foo/", nil)
+	if err != nil {
+		t.Fatalf("Curl: %v", err)
+	}
+	_ = res.Body.Close()
+
+	if d := got.query.Get("dir"); d != "foo/" {
+		t.Errorf("dir = %q, want foo/", d)
+	}
+}
+
+// The path is still canonicalized: repeated slashes collapse and a trailing
+// one is dropped, whether or not a query follows it.
+func TestCurlCanonicalizesThePath(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{"a plain path", "/secret/handshake", "/v1/secret/handshake"},
+		{"repeated slashes", "/secret//deep///thing", "/v1/secret/deep/thing"},
+		{"a trailing slash", "/secret/dir/", "/v1/secret/dir"},
+		{"no leading slash", "secret/handshake", "/v1/secret/handshake"},
+		{"a path before a query", "/secret/dir/?list=true", "/v1/secret/dir"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			v, got := newCurlVault(t)
+
+			res, err := v.Curl("GET", tc.uri, nil)
+			if err != nil {
+				t.Fatalf("Curl: %v", err)
+			}
+			_ = res.Body.Close()
+
+			if got.path != tc.want {
+				t.Errorf("asked for %q, want %q", got.path, tc.want)
+			}
+		})
+	}
+}
+
+// The query survives the path being canonicalized alongside it.
+func TestCurlSendsTheQueryWithACanonicalizedPath(t *testing.T) {
+	t.Parallel()
+	v, got := newCurlVault(t)
+
+	res, err := v.Curl("GET", "/secret//dir/?list=true", nil)
+	if err != nil {
+		t.Fatalf("Curl: %v", err)
+	}
+	_ = res.Body.Close()
+
+	if got.path != "/v1/secret/dir" {
+		t.Errorf("asked for %q, want /v1/secret/dir", got.path)
+	}
+	if l := got.query.Get("list"); l != "true" {
+		t.Errorf("list = %q, want true", l)
+	}
+}
+
+func TestCurlSendsTheMethodAndBody(t *testing.T) {
+	t.Parallel()
+	v, got := newCurlVault(t)
+
+	res, err := v.Curl("PUT", "/secret/handshake", []byte(`{"k":"v"}`))
+	if err != nil {
+		t.Fatalf("Curl: %v", err)
+	}
+	_ = res.Body.Close()
+
+	if got.method != "PUT" {
+		t.Errorf("method = %q, want PUT", got.method)
+	}
+	if got.body != `{"k":"v"}` {
+		t.Errorf("body = %q, want the JSON it was given", got.body)
+	}
+}
+
+func TestCurlRejectsAQueryItCannotParse(t *testing.T) {
+	t.Parallel()
+	v, _ := newCurlVault(t)
+
+	if _, err := v.Curl("GET", "/sys/x?%zz=1", nil); err == nil {
+		t.Fatal("expected an error for a query that does not parse")
+	}
+}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -121,8 +121,12 @@ func shouldDebug() bool {
 	return d != "" && d != "false" && d != "0" && d != "no" && d != "off"
 }
 
+// Curl sends one request to the Vault API. Only the path of the URI is
+// canonicalized: the rules for a secret path -- collapse repeated slashes,
+// drop a trailing one -- were run over the whole string, query and all, so a
+// query carrying a URL was sent with its slashes collapsed, ?u=http://a/b
+// arriving as ?u=http:/a/b, and a value ending in a slash arrived without it.
 func (v *Vault) Curl(method string, path string, body []byte) (*http.Response, error) {
-	path = Canonicalize(path)
 	u, err := url.Parse(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse input path: %w", err)
@@ -133,7 +137,7 @@ func (v *Vault) Curl(method string, path string, body []byte) (*http.Response, e
 		return nil, fmt.Errorf("could not parse query: %w", err)
 	}
 
-	return v.client.Client.Curl(method, u.Path, query, bytes.NewBuffer(body))
+	return v.client.Client.Curl(method, Canonicalize(u.Path), query, bytes.NewBuffer(body))
 }
 
 // Read checks the Vault for a Secret at the specified path, and returns it.


### PR DESCRIPTION
`safe curl` sends a request to the Vault API and prints what comes back. It
did not read the arguments it was given, altered the URI it was asked for,
and reported every answer as a success.

## A refused request exited 0

```
$ safe curl --data-only GET /secret/nope
{"errors":["permission denied"]}
$ echo $?
0
```

`--data-only` hides the status line, so nothing at all said the request was
refused. A script asking for a path it may not read, or one that is not
there, could not tell that apart from a request that worked.

The status is reported as an error now, and what the Vault answered is
printed either way -- reading it is what the command is for.

```
$ safe curl --data-only GET /v1/sys/health
{"errors":["no handler for route \"v1/sys/health\". route entry not found."]}
!! GET /v1/sys/health: 404 Not Found
$ echo $?
1
```

## The arguments were not read

Whatever came first was taken for the method and whatever came alone was
taken for the URI:

```
$ safe curl GET                       # asked for /v1/GET, exit 0
$ safe curl /sys/health '{}'          # sent a request whose method was /SYS/HEALTH
```

```
$ safe curl GET
!! no REL-URI given to GET

$ safe curl /sys/health GET
!! /sys/health is not an HTTP method: give one of GET, LIST, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
```

A lone URI is still a GET, which is the form that made a lone method look
like a URI to begin with.

## The query was canonicalized as though it were a path

The rules for a secret path -- collapse repeated slashes, drop a trailing
one -- were run over the whole URI, query and all:

| given | sent | wanted |
|-------|------|--------|
| `/sys/x?u=http://a/b` | `?u=http:/a/b` | `?u=http://a/b` |
| `/sys/x?dir=foo/` | `?dir=foo` | `?dir=foo/` |

The path is still canonicalized: `/secret/a//b/` reaches `/v1/secret/a/b`.

## The help described a URI that does not work

It called REL-URI "the relative URI (the path component, starting with the
first forward slash)", which is what a Vault API path copied out of its own
documentation looks like. Given one, safe asks for `/v1/v1/sys/health` and
reported the 404 as a success. The help says the `/v1` is added, names the
methods that can be sent, and says what happens to a refused response.

## Verification

`make check` (fmt, vet, staticcheck, tests) and `go test -race -count=1
./...` pass; all four commits build and pass `./internal/cli/` and
`./pkg/vault/` on their own.

Checked against a Vault: every case above is the output of the built binary,
and the query cases are the request lines a recording server received.

Coverage: `cmdCurl` 0.0% -> 88.2%, `isCurlMethod` 100%, `Vault.Curl` 0.0% ->
85.7%. Across `internal/cli`, 57.6% -> 58.3%.

Fourteen mutations of the changed code, all killed: the URI canonicalized
whole again, the path not canonicalized, the query or the body dropped, a
bad query not reported (5); a lone method taken for a URI, the first
argument not read as a method, every word a method, the method not
uppercased, no arguments not a usage error (5); a refused request reported
as a success, a successful one reported as refused, nothing printed when the
Vault refuses, `--data-only` printing headers (4).

## Noted, not in this change

`safe status` asks Strongbox for the seal state of the cluster and fails
outright when it is not there, which is every Vault that is not a `safe`
installation:

```
$ safe target http://vault.example.com prod
$ safe status
!! Get "http://vault.example.com:8484/strongbox": connect: connection
   refused; are you targeting a `safe' installation?
```

`safe target --no-strongbox` reads `/sys/health` instead and works. Every
target gets Strongbox by default, though, so the default is the broken one.
Changing it is a decision about the default rather than a fix, so it is left
alone here.

Registering the command table happens inside `Main`, which ends in
`os.Exit`, so no test can reach the help text that ships. Pulling the
dispatch calls out of `Main` would make every command's help and summary
testable; it is a large mechanical move and belongs on its own.
