### PR TITLE
Extract command registration out of Main

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -363,24 +363,14 @@ type Options struct {
 	} `cli:"x509"`
 }
 
-func Main(version, buildTime, gitCommit string) {
-	Version = version
-	BuildTime = buildTime
-	GitCommit = gitCommit
-
-	var opt Options
-	opt.Gen.Policy = "a-zA-Z0-9"
-
-	opt.Clobber = true
-
-	opt.Init.Persist = true
-	opt.Rekey.Persist = true
-
-	go Signals()
-
+// newRegisteredRunner builds a Runner with every safe command registered,
+// wired to a CLI that holds opt. This is the whole command table the shipped
+// binary uses: Main calls it, and tests call it to reach the registered help
+// topics without going through os.Exit.
+func newRegisteredRunner(opt *Options) *Runner {
 	r := NewRunner()
 
-	c := &CLI{opt: &opt, r: r}
+	c := &CLI{opt: opt, r: r}
 
 	r.Dispatch("version", &Help{
 		Summary: "Print the version of the safe CLI",
@@ -1596,6 +1586,26 @@ Currently, only the --renew option is supported, and it is required:
                     without modifying the list of revoked certificates.
 `,
 	}, c.cmdX509Crl)
+
+	return r
+}
+
+func Main(version, buildTime, gitCommit string) {
+	Version = version
+	BuildTime = buildTime
+	GitCommit = gitCommit
+
+	var opt Options
+	opt.Gen.Policy = "a-zA-Z0-9"
+
+	opt.Clobber = true
+
+	opt.Init.Persist = true
+	opt.Rekey.Persist = true
+
+	go Signals()
+
+	r := newRegisteredRunner(&opt)
 
 	env.Override(&opt)
 	p, err := gocli.NewParser(&opt, os.Args[1:])

--- a/internal/cli/command_table_test.go
+++ b/internal/cli/command_table_test.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// newTestRunner builds the same fully-registered Runner that Main uses,
+// against a fresh Options, so tests exercise the shipped command table.
+// cmdHelp and cmdVersion call os.Exit, so tests must go through r.Help or
+// inspect the Runner directly, never Execute those handlers.
+func newTestRunner() *Runner {
+	var opt Options
+	return newRegisteredRunner(&opt)
+}
+
+// TestCommandTableComplete pins the shape of the registered command table:
+// every dispatched command has a handler, a help topic, a non-empty Summary
+// and Usage, and one of the Types the help renderer understands.
+func TestCommandTableComplete(t *testing.T) {
+	r := newTestRunner()
+
+	if len(r.Handlers) == 0 {
+		t.Fatal("no commands registered")
+	}
+	if len(r.Handlers) != len(r.Topics) {
+		t.Errorf("handlers (%d) and topics (%d) out of step: every Dispatch passes a Help",
+			len(r.Handlers), len(r.Topics))
+	}
+
+	// AdministrativeCommand and MiscellaneousCommand share a value, so the
+	// set is built rather than written as one literal.
+	validTypes := map[string]bool{}
+	for _, ty := range []string{
+		DestructiveCommand,
+		NonDestructiveCommand,
+		AdministrativeCommand,
+		MiscellaneousCommand,
+		HiddenCommand,
+	} {
+		validTypes[ty] = true
+	}
+
+	for cmd, fn := range r.Handlers {
+		if fn == nil {
+			t.Errorf("command %q registered with a nil handler", cmd)
+		}
+		h, ok := r.Topics[cmd]
+		if !ok || h == nil {
+			t.Errorf("command %q has no help topic", cmd)
+			continue
+		}
+		if h.Summary == "" {
+			t.Errorf("command %q has an empty Summary", cmd)
+		}
+		if h.Usage == "" {
+			t.Errorf("command %q has an empty Usage", cmd)
+		}
+		if !validTypes[h.Type] {
+			t.Errorf("command %q has unrecognized Type %q", cmd, h.Type)
+		}
+	}
+}
+
+// TestCommandTableKnownCommands checks that the commands safe has always
+// shipped are all present, including the x509 sub-commands.
+func TestCommandTableKnownCommands(t *testing.T) {
+	r := newTestRunner()
+
+	for _, cmd := range []string{
+		"version", "help", "commands", "envvars",
+		"targets", "target", "target delete", "status", "local", "init",
+		"unseal", "seal", "env", "auth", "logout", "renew",
+		"ask", "set", "paste", "exists", "get", "versions",
+		"ls", "tree", "paths", "values",
+		"delete", "undelete", "revert", "export", "import", "move", "copy",
+		"gen", "uuid", "option", "ssh", "rsa", "dhparam", "prompt",
+		"vault", "rekey", "fmt", "curl",
+		"x509", "x509 validate", "x509 issue", "x509 reissue",
+		"x509 renew", "x509 revoke", "x509 show", "x509 crl",
+	} {
+		if _, ok := r.Handlers[cmd]; !ok {
+			t.Errorf("command %q is not registered", cmd)
+		}
+	}
+}
+
+// TestHelpRendersEveryTopic renders every registered topic through r.Help
+// and checks nothing errors and nothing comes out empty.
+func TestHelpRendersEveryTopic(t *testing.T) {
+	r := newTestRunner()
+
+	for topic := range r.Topics {
+		var buf bytes.Buffer
+		if err := r.Help(&buf, topic); err != nil {
+			t.Errorf("Help(%q) returned error: %s", topic, err)
+			continue
+		}
+		if buf.Len() == 0 {
+			t.Errorf("Help(%q) rendered nothing", topic)
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := r.Help(&buf, "commands"); err != nil {
+		t.Fatalf("Help(commands) returned error: %s", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Valid commands are:") {
+		t.Errorf("commands listing missing its header:\n%s", out)
+	}
+	for _, cmd := range []string{"target", "curl", "x509"} {
+		if !strings.Contains(out, cmd) {
+			t.Errorf("commands listing missing %q:\n%s", cmd, out)
+		}
+	}
+
+	if err := r.Help(&buf, "no such topic"); !errors.Is(err, ErrNoSuchTopic) {
+		t.Errorf("Help on an unregistered topic returned %v, want ErrNoSuchTopic", err)
+	}
+}
+
+// TestHelpSpotChecks pins fragments of shipped help text that users and
+// scripts rely on.
+func TestHelpSpotChecks(t *testing.T) {
+	r := newTestRunner()
+
+	render := func(topic string) string {
+		t.Helper()
+		var buf bytes.Buffer
+		if err := r.Help(&buf, topic); err != nil {
+			t.Fatalf("Help(%q) returned error: %s", topic, err)
+		}
+		return buf.String()
+	}
+
+	curl := render("curl")
+	if !strings.Contains(curl, "/v1 that every Vault API path begins with: safe adds it for you.") {
+		t.Errorf("curl help no longer explains the /v1 prefix:\n%s", curl)
+	}
+	if !strings.Contains(curl, "safe curl [OPTIONS] METHOD REL-URI [DATA]") {
+		t.Errorf("curl help usage line changed:\n%s", curl)
+	}
+
+	envvars := render("envvars")
+	if !strings.Contains(envvars, "SAFE_TARGET") {
+		t.Errorf("envvars help does not mention SAFE_TARGET:\n%s", envvars)
+	}
+
+	version := render("version")
+	if !strings.Contains(version, "safe version") {
+		t.Errorf("version help missing its usage line:\n%s", version)
+	}
+}


### PR DESCRIPTION
## What moved

`Main` in `internal/cli/cli.go` built the Runner, registered every command
with `r.Dispatch(...)`, and went straight into argument parsing and
`os.Exit`, so no test could reach the shipped command table or its help
text.

The `NewRunner()` call, the `CLI` wiring, and the entire block of
`r.Dispatch` calls now live verbatim in:

```go
func newRegisteredRunner(opt *Options) *Runner
```

`Main` calls it and is otherwise unchanged: option defaults
(`opt.Gen.Policy`, `opt.Clobber`, `opt.Init.Persist`, `opt.Rekey.Persist`,
`opt.Target.Strongbox`), `env.Override`, the parser loop, and every exit
path stay in `Main` exactly where they were. No help string was touched;
registration order is identical.

## Proof the output is byte-identical

Built `./cmd/safe` from develop (9dc6dbc) and from this branch, then
captured `safe help`, `safe commands`, and `safe help <topic>` for all 51
dispatched topics (1212 lines total) from each binary:

```
$ diff dev-all-help.txt branch-all-help.txt && echo IDENTICAL
IDENTICAL
```

## What the new tests pin down

`internal/cli/command_table_test.go` runs against the real registered
table via `newRegisteredRunner`:

- every dispatched command has a handler, a help topic, a non-empty
  `Summary` and `Usage`, and a `Type` the help renderer understands
- the full shipped command set is registered, x509 sub-commands included
- `r.Help` renders every registered topic without error and never empty,
  the `commands` listing keeps its header, and an unregistered topic
  returns `ErrNoSuchTopic`
- spot checks on shipped text: the curl help still says safe adds the
  `/v1` prefix and keeps its usage line, envvars mentions `SAFE_TARGET`,
  version keeps its usage line

The tests go through `r.Help` and the Runner maps only; `cmdHelp` and
`cmdVersion` call `os.Exit` and are never invoked.

## Verification

- `make check` — passes
- `go test -race -count=1 ./...` — passes
- `go build ./cmd/safe` at HEAD, output of `help`, `commands`, and every
  `help <topic>` diffed clean against a develop build
