### PR TITLE
Make Strongbox opt-in per target

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -116,10 +116,11 @@ func connect(auth bool) *vault.Vault {
 }
 
 // usesStrongbox reports whether a command should look for Strongbox alongside
-// the Vault it is acting on. A nil target means no Vault is configured and the
-// address came from the environment, where there is no flag to consult.
+// the Vault it is acting on. Strongbox is opt-in: only a target made with
+// --strongbox has one, and a nil target -- an address straight from the
+// environment -- never does.
 func usesStrongbox(target *rc.Vault) bool {
-	return target != nil && !target.NoStrongbox
+	return target != nil && target.Strongbox
 }
 
 // targetAddress is the address the client returned by connect is talking to.
@@ -374,8 +375,6 @@ func Main(version, buildTime, gitCommit string) {
 	opt.Init.Persist = true
 	opt.Rekey.Persist = true
 
-	opt.Target.Strongbox = true
-
 	go Signals()
 
 	r := NewRunner()
@@ -431,8 +430,10 @@ as skipping validation from then on.
 effect if the given URL uses an HTTPS scheme.
 
 -s (--strongbox) specifies that the targeted Vault has a strongbox deployed at
-its IP on port :8484. This is true by default. --no-strongbox will cause commands
-that would otherwise use strongbox to run against only the targeted Vault.
+its IP on port :8484, and the seal-state commands -- status, seal, unseal --
+should ask it about every node in the cluster. Without it, which is the
+default, those commands speak to the targeted Vault alone through Vault's own
+API, which any Vault can answer. --no-strongbox is still accepted.
 
 -n (--namespace) specifies a Vault Enterprise namespace to run commands against
 for this target.
@@ -465,12 +466,11 @@ left alone.
 		Type:    AdministrativeCommand,
 		Usage:   "safe status",
 		Description: `
-Returns the seal status of each node in the Vault cluster.
+Returns the seal status of the targeted Vault, read from its @C{/sys/health}
+endpoint, which any Vault can answer.
 
-If strongbox is configured for this target, then strongbox is queried for seal
-status of all nodes in the cluster. If strongbox is disabled for the target,
-the /sys/health endpoint is queried for the target box to return the health of
-just this Vault instance.
+If the target was made with @B{--strongbox}, strongbox is queried instead for
+the seal status of every node in the cluster.
 
 The following options are recognized:
 

--- a/internal/cli/seal_fake_test.go
+++ b/internal/cli/seal_fake_test.go
@@ -115,7 +115,7 @@ func writeSaferc(t *testing.T, body string) {
 }
 
 // twoTargets renders a config naming both Vaults, with alpha current. Neither
-// uses Strongbox, so the commands take the single-address branch; the
+// opts into Strongbox, so the commands take the single-address branch; the
 // Strongbox flag is exercised on its own in the tests that care about it.
 func twoTargets(alpha, beta *fakeSealVault) string {
 	return `version: 1
@@ -124,10 +124,8 @@ vaults:
   alpha:
     url: ` + alpha.url + `
     token: token-alpha
-    no_strongbox: true
   beta:
     url: ` + beta.url + `
     token: token-beta
-    no_strongbox: true
 `
 }

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -163,9 +163,8 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 	previous := cfg.Current
 
 	_ = cfg.SetTarget(name, rc.Vault{
-		URL:         fmt.Sprintf("http://127.0.0.1:%d", port),
-		SkipVerify:  false,
-		NoStrongbox: true,
+		URL:        fmt.Sprintf("http://127.0.0.1:%d", port),
+		SkipVerify: false,
 	})
 	_ = cfg.Write()
 

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -59,7 +59,7 @@ func (c *CLI) cmdTargets(command string, args ...string) error {
 				URL:       details.URL,
 				Verify:    !details.SkipVerify,
 				Namespace: details.Namespace,
-				Strongbox: !details.NoStrongbox,
+				Strongbox: details.Strongbox,
 			})
 		}
 		b, err := json.MarshalIndent(vaults, "", "  ")
@@ -299,11 +299,11 @@ func (c *CLI) cmdTarget(command string, args ...string) error {
 		}
 
 		err = cfg.SetTarget(alias, rc.Vault{
-			URL:         url,
-			SkipVerify:  skipverify,
-			NoStrongbox: !opt.Target.Strongbox,
-			Namespace:   opt.Target.Namespace,
-			CACerts:     caCerts,
+			URL:        url,
+			SkipVerify: skipverify,
+			Strongbox:  opt.Target.Strongbox,
+			Namespace:  opt.Target.Namespace,
+			CACerts:    caCerts,
 		})
 		if err != nil {
 			return err

--- a/internal/cli/target_flag_test.go
+++ b/internal/cli/target_flag_test.go
@@ -40,7 +40,7 @@ func TestCmdStatusReadsTheStrongboxFlagOfTheDashTTarget(t *testing.T) {
 	isolateHome(t)
 	alpha := newSealFake(t, false)
 	beta := newSealFake(t, true)
-	//alpha uses Strongbox, beta does not. Asking alpha's flag sends the
+	//alpha opted into Strongbox, beta did not. Asking alpha's flag sends the
 	// command down the Strongbox branch, which beta cannot answer.
 	writeSaferc(t, `version: 1
 current: alpha
@@ -48,10 +48,10 @@ vaults:
   alpha:
     url: `+alpha.url+`
     token: token-alpha
+    strongbox: true
   beta:
     url: `+beta.url+`
     token: token-beta
-    no_strongbox: true
 `)
 
 	c := newTestCLI(t)

--- a/internal/cli/target_strongbox_test.go
+++ b/internal/cli/target_strongbox_test.go
@@ -1,0 +1,51 @@
+package cli
+
+// safe target records whether a Vault has Strongbox alongside it. Strongbox
+// is opt-in: a target made without -s speaks to the Vault alone, so the
+// seal-state commands work against any Vault, not only a safe installation.
+
+import (
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/rc"
+)
+
+func targetStrongbox(t *testing.T, c *CLI, alias string) bool {
+	t.Helper()
+	cfg, err := rc.Read()
+	if err != nil {
+		t.Fatalf("rc.Read: %v", err)
+	}
+	tgt, ok := cfg.Vaults[alias]
+	if !ok {
+		t.Fatalf("no %q in the config after targeting it", alias)
+	}
+	return tgt.Strongbox
+}
+
+func TestCmdTargetHasNoStrongboxByDefault(t *testing.T) {
+	isolateHome(t)
+	c := newTestCLI(t)
+	c.opt.Quiet = true
+
+	if err := c.cmdTarget("target", "one", "https://vault.one:8200"); err != nil {
+		t.Fatalf("cmdTarget: %v", err)
+	}
+	if targetStrongbox(t, c, "one") {
+		t.Error("a target made without -s got Strongbox")
+	}
+}
+
+func TestCmdTargetDashSOptsIntoStrongbox(t *testing.T) {
+	isolateHome(t)
+	c := newTestCLI(t)
+	c.opt.Quiet = true
+	c.opt.Target.Strongbox = true
+
+	if err := c.cmdTarget("target", "one", "https://vault.one:8200"); err != nil {
+		t.Fatalf("cmdTarget: %v", err)
+	}
+	if !targetStrongbox(t, c, "one") {
+		t.Error("a target made with -s did not get Strongbox")
+	}
+}

--- a/pkg/rc/config.go
+++ b/pkg/rc/config.go
@@ -27,12 +27,16 @@ type Options struct {
 }
 
 type Vault struct {
-	URL         string   `yaml:"url"`
-	Token       string   `yaml:"token"`
-	CACerts     []string `yaml:"ca_certs,omitempty"`
-	SkipVerify  bool     `yaml:"skip_verify,omitempty"`
-	NoStrongbox bool     `yaml:"no_strongbox,omitempty"`
-	Namespace   string   `yaml:"namespace,omitempty"`
+	URL        string   `yaml:"url"`
+	Token      string   `yaml:"token"`
+	CACerts    []string `yaml:"ca_certs,omitempty"`
+	SkipVerify bool     `yaml:"skip_verify,omitempty"`
+
+	// Strongbox opts a target into the Strongbox seal-state service on port
+	// :8484. Older configs wrote a no_strongbox key instead; it is ignored on
+	// read, and no target has Strongbox unless it says strongbox: true.
+	Strongbox bool   `yaml:"strongbox,omitempty"`
+	Namespace string `yaml:"namespace,omitempty"`
 }
 
 type oldConfig struct {
@@ -368,7 +372,7 @@ func (c *Config) Verified() bool {
 
 func (c *Config) HasStrongbox() bool {
 	if v, ok, _ := c.Find(c.Current); ok {
-		return !v.NoStrongbox
+		return v.Strongbox
 	}
 	return false
 }

--- a/pkg/rc/config_test.go
+++ b/pkg/rc/config_test.go
@@ -87,7 +87,7 @@ vaults:
     url: https://vault.dev:8200
     token: dev-token
     skip_verify: true
-    no_strongbox: true
+    strongbox: true
     namespace: dev-ns
 options:
   manage_vault_token: true
@@ -106,11 +106,37 @@ options:
 			t.Errorf("prod vault wrong: %+v", prod)
 		}
 		dev := c.Vaults["dev"]
-		if dev == nil || !dev.SkipVerify || !dev.NoStrongbox || dev.Namespace != "dev-ns" {
+		if dev == nil || !dev.SkipVerify || !dev.Strongbox || dev.Namespace != "dev-ns" {
 			t.Errorf("dev vault wrong: %+v", dev)
 		}
 		if !c.Options.ManageVaultToken {
 			t.Error("expected ManageVaultToken to be true")
+		}
+	})
+
+	t.Run("ignores the no_strongbox key older configs carry", func(t *testing.T) {
+		home := setHome(t)
+		//Both spellings a pre-opt-in config could hold: true asked for what is
+		// now the default, and false asked for the Strongbox that now takes
+		// strongbox: true to get. Neither target has one.
+		writeFile(t, filepath.Join(home, ".saferc"), `version: 1
+current: prod
+vaults:
+  prod:
+    url: https://vault.prod:8200
+    no_strongbox: false
+  dev:
+    url: https://vault.dev:8200
+    no_strongbox: true
+`)
+		c, err := Read()
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		for name, v := range c.Vaults {
+			if v.Strongbox {
+				t.Errorf("%s: got Strongbox, want none without strongbox: true", name)
+			}
 		}
 	})
 
@@ -551,11 +577,11 @@ func TestConfigAccessors(t *testing.T) {
 		c := Config{
 			Current: "prod",
 			Vaults: map[string]*Vault{"prod": {
-				URL:         "https://vault.prod:8200",
-				SkipVerify:  true,
-				NoStrongbox: true,
-				CACerts:     []string{"ca"},
-				Namespace:   "ns",
+				URL:        "https://vault.prod:8200",
+				SkipVerify: true,
+				Strongbox:  true,
+				CACerts:    []string{"ca"},
+				Namespace:  "ns",
 			}},
 		}
 		if c.URL() != "https://vault.prod:8200" {
@@ -564,8 +590,8 @@ func TestConfigAccessors(t *testing.T) {
 		if c.Verified() {
 			t.Error("Verified: got true, want false (SkipVerify set)")
 		}
-		if c.HasStrongbox() {
-			t.Error("HasStrongbox: got true, want false (NoStrongbox set)")
+		if !c.HasStrongbox() {
+			t.Error("HasStrongbox: got false, want true (Strongbox set)")
 		}
 		if got := c.CACerts(); len(got) != 1 || got[0] != "ca" {
 			t.Errorf("CACerts: got %v", got)


### PR DESCRIPTION
Every target got Strongbox by default, so the seal-state commands --
`status`, `seal`, `unseal` -- asked port :8484 for the cluster's seal
state and failed outright against any Vault that is not a `safe`
installation:

```
$ safe target http://vault.example.com prod
$ safe status
!! Get "http://vault.example.com:8484/strongbox": connect: connection
   refused; are you targeting a `safe' installation?
```

Vault answers for its own seal state these days, so the default is now
the other way around: the seal-state commands read Vault's own API, and
only a target made with `--strongbox` asks Strongbox.

```
$ safe target http://127.0.0.1:8253 plain
Does not use Strongbox

$ safe status
http://127.0.0.1:8253 is unsealed
$ echo $?
0

$ safe target -s http://127.0.0.1:8253 boxy
Uses Strongbox at http://127.0.0.1:8484/strongbox

$ safe status
!! Get "http://127.0.0.1:8484/strongbox": dial tcp 127.0.0.1:8484:
   connect: connection refused; are you targeting a `safe' installation?
```

## The saferc field

The stored field is `strongbox: true` rather than `no_strongbox`. The
old key is ignored on read, and both of its spellings land where they
meant to:

| old config said | old behaviour | behaviour now |
|-----------------|---------------|---------------|
| `no_strongbox: true` | no Strongbox | no Strongbox |
| nothing | Strongbox | no Strongbox |

The second row is the point of the change: a target that never asked
for Strongbox no longer gets one. A `safe` installation's operator adds
`-s` when targeting, or `strongbox: true` in `~/.saferc`.

`--no-strongbox` is still accepted on `safe target`, and `safe local`
drops its explicit opt-out, since off is the default it wanted.

## Verification

`make check` and `go test -race -count=1 ./...` pass.

Checked against a live dev Vault: the transcripts above are the built
binary's output, including a `~/.saferc` written with the old
`no_strongbox` keys, which parses and takes the health path.

New tests pin the flip at every layer: the `strongbox` field parses and
the legacy `no_strongbox` key is ignored (pkg/rc), `HasStrongbox`
answers for the opt-in, `safe target` records no Strongbox without `-s`
and records it with, and the `-T` flag test now opts its Strongbox
target in explicitly.

## Merge note

PR #53 moves `opt.Target.Strongbox = true` into `Main`'s option
defaults verbatim; this branch deletes that line. Whichever lands
second has a one-line conflict, and the line goes away.
