### PR TITLE
Cover safe local, vault, and rekey commands

### DIFF
--- a/internal/cli/server_local_run_test.go
+++ b/internal/cli/server_local_run_test.go
@@ -1,0 +1,208 @@
+package cli
+
+// Full-lifecycle tests for cmdLocal (server.go). The fake `vault` on PATH
+// answers `vault version` directly; for `vault server -config <file>` it
+// re-executes this test binary, where TestFakeLocalVaultHelper reads the
+// listener port out of the rendered config and serves just enough of the
+// Vault API for cmdLocal to initialize, unseal, mount, and write the
+// handshake. The helper exits shortly after the handshake write lands, which
+// is what a real `safe local` sees when its Vault shuts down, so the test
+// drives the whole path: startup wait, init, unseal, mount creation, target
+// bookkeeping, and the cleanup that removes the temporary target again.
+//
+// captureStderr mutates os.Stderr — do NOT add t.Parallel to any test in
+// this file.
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestFakeLocalVaultHelper is not a test: it is the body of the fake `vault
+// server` process. It only runs when the fake vault script re-executes the
+// test binary with SAFE_FAKE_VAULT_HELPER=1; otherwise it skips.
+func TestFakeLocalVaultHelper(t *testing.T) {
+	if os.Getenv("SAFE_FAKE_VAULT_HELPER") != "1" {
+		t.Skip("helper process body, not a test")
+	}
+
+	cfg, err := os.ReadFile(os.Getenv("SAFE_FAKE_VAULT_CONFIG")) // #nosec G304 -- path written by the test that spawned us
+	if err != nil {
+		os.Exit(9)
+	}
+	m := regexp.MustCompile(`address\s*=\s*"127\.0\.0\.1:(\d+)"`).FindSubmatch(cfg)
+	if m == nil {
+		os.Exit(9)
+	}
+
+	var (
+		mu          sync.Mutex
+		initialized bool
+		exitOnce    sync.Once
+	)
+	done := make(chan struct{})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/v1/sys/health":
+			mu.Lock()
+			ready := initialized
+			mu.Unlock()
+			if !ready {
+				// 501 is how Vault reports "not initialized", which safe
+				// reads as "listening but sealed" — enough to end the
+				// startup wait.
+				w.WriteHeader(http.StatusNotImplemented)
+			}
+			_, _ = w.Write([]byte(`{}`))
+
+		case r.URL.Path == "/v1/sys/init" && r.Method == http.MethodPut:
+			mu.Lock()
+			initialized = true
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{"keys":["local-seal-key"],"keys_base64":["local-seal-key"],"root_token":"local-root-token"}`))
+
+		case r.URL.Path == "/v1/sys/unseal" && r.Method == http.MethodPut:
+			_, _ = w.Write([]byte(`{"sealed":false}`))
+
+		case r.URL.Path == "/v1/sys/mounts" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"data":{}}`))
+
+		case strings.HasPrefix(r.URL.Path, "/v1/sys/mounts/") && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusNoContent)
+
+		case strings.HasPrefix(r.URL.Path, "/v1/sys/internal/ui/mounts"):
+			_, _ = w.Write([]byte(`{"data":{"secret":{"secret/":{"type":"kv","options":{"version":"1"}}}}}`))
+
+		case r.URL.Path == "/v1/secret/handshake" &&
+			(r.Method == http.MethodPut || r.Method == http.MethodPost):
+			w.WriteHeader(http.StatusNoContent)
+			// The handshake write is the last thing cmdLocal asks of the
+			// Vault; shut down shortly after so the response gets out first.
+			exitOnce.Do(func() {
+				go func() {
+					time.Sleep(150 * time.Millisecond)
+					close(done)
+				}()
+			})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errors":[]}`))
+		}
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:"+string(m[1]))
+	if err != nil {
+		os.Exit(9)
+	}
+	srv := &http.Server{Handler: handler, ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = srv.Serve(ln) }()
+	<-done
+	os.Exit(0)
+}
+
+// installFakeLocalVault installs a fake `vault` whose `server` subcommand
+// re-executes the test binary as TestFakeLocalVaultHelper.
+func installFakeLocalVault(t *testing.T) {
+	t.Helper()
+	t.Setenv("SAFE_FAKE_VAULT_TESTBIN", os.Args[0])
+	installFakeBin(t, "vault", `#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "Vault v1.15.4"
+  exit 0
+fi
+if [ "$1" = "server" ]; then
+  SAFE_FAKE_VAULT_HELPER=1 SAFE_FAKE_VAULT_CONFIG="$3" \
+    exec "$SAFE_FAKE_VAULT_TESTBIN" -test.run '^TestFakeLocalVaultHelper$' -test.count=1
+fi
+echo "unexpected invocation: vault $*" >&2
+exit 42
+`)
+}
+
+func TestCmdLocal_MemoryBackedLifecycle(t *testing.T) {
+	// No t.Parallel — captureStderr mutates os.Stderr.
+	isolateHome(t)
+	installFakeLocalVault(t)
+	c := localCLI(t)
+	c.opt.Local.Memory = true
+	c.opt.Local.As = "local-mem-test"
+
+	var err error
+	var stderr string
+	stdout := captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			err = c.cmdLocal("local")
+		})
+	})
+	if err != nil {
+		t.Fatalf("cmdLocal returned unexpected error: %v\nstderr:\n%s", err, stderr)
+	}
+
+	if !strings.Contains(stdout, "safe has mounted") {
+		t.Errorf("expected the mount notice on stdout, got:\n%s", stdout)
+	}
+	if !strings.Contains(stderr, "local-mem-test") {
+		t.Errorf("expected the temporary target named, got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "MEMORY-BACKED") {
+		t.Errorf("expected the memory-backed warning, got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "Vault terminated normally") {
+		t.Errorf("expected the normal-termination notice, got:\n%s", stderr)
+	}
+	if got := os.Getenv("VAULT_TOKEN"); got != "local-root-token" {
+		t.Errorf("VAULT_TOKEN: got %q, want the root token from init", got)
+	}
+
+	saferc, err := os.ReadFile(filepath.Join(os.Getenv("HOME"), ".saferc"))
+	if err != nil {
+		t.Fatalf("reading .saferc: %v", err)
+	}
+	if strings.Contains(string(saferc), "local-mem-test") {
+		t.Errorf("the temporary target was not cleaned out of .saferc:\n%s", saferc)
+	}
+}
+
+func TestCmdLocal_FileBackedLifecycleWithRandomName(t *testing.T) {
+	// No t.Parallel — captureStderr mutates os.Stderr.
+	isolateHome(t)
+	installFakeLocalVault(t)
+	c := localCLI(t)
+	c.opt.Local.File = filepath.Join(t.TempDir(), "local-vault.db")
+
+	var err error
+	var stderr string
+	captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			err = c.cmdLocal("local")
+		})
+	})
+	if err != nil {
+		t.Fatalf("cmdLocal returned unexpected error: %v\nstderr:\n%s", err, stderr)
+	}
+
+	if !strings.Contains(stderr, "Storing data (encrypted) in") {
+		t.Errorf("expected the storage-file notice, got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "local-seal-key") {
+		t.Errorf("expected the seal key echoed, got:\n%s", stderr)
+	}
+
+	saferc, err := os.ReadFile(filepath.Join(os.Getenv("HOME"), ".saferc"))
+	if err != nil {
+		t.Fatalf("reading .saferc: %v", err)
+	}
+	if strings.Contains(string(saferc), "http://127.0.0.1:") {
+		t.Errorf("the temporary target was not cleaned out of .saferc:\n%s", saferc)
+	}
+}

--- a/internal/cli/server_local_run_test.go
+++ b/internal/cli/server_local_run_test.go
@@ -14,9 +14,11 @@ package cli
 // this file.
 
 import (
+	"errors"
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -308,6 +310,48 @@ func TestCmdLocal_MountListFailureSurfaces(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "Could not list mounts") {
 		t.Errorf("unexpected error wording: %v", err)
+	}
+}
+
+// The paths through die() end in os.Exit, so they can only be observed from
+// outside the process: run the built safe binary against a vault whose
+// server subcommand refuses to start, the way a rejected config plays out.
+func TestSafeLocal_ReportsVaultStartupFailure(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "vault")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "Vault v1.15.4"
+  exit 0
+fi
+echo "Error parsing config: oops" >&2
+exit 1
+`), 0700); err != nil { // #nosec G306 -- must be executable
+		t.Fatalf("writing fake vault: %v", err)
+	}
+
+	cmd := exec.Command(safeBinary(t), "local", "--memory", "--port", "8219")
+	cmd.Env = append(os.Environ(),
+		"HOME="+t.TempDir(),
+		"SAFE_TARGET=", "VAULT_ADDR=", "VAULT_TOKEN=",
+		"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected safe local to exit nonzero, got %v\nstderr:\n%s", err, stderr.String())
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Errorf("exit code: got %d, want 1", exitErr.ExitCode())
+	}
+	if !strings.Contains(stderr.String(), "Vault exited before it became ready") {
+		t.Errorf("expected the early exit reported, got:\n%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Error parsing config: oops") {
+		t.Errorf("expected Vault's own complaint relayed, got:\n%s", stderr.String())
 	}
 }
 

--- a/internal/cli/server_local_run_test.go
+++ b/internal/cli/server_local_run_test.go
@@ -25,9 +25,22 @@ import (
 	"time"
 )
 
+// scheduleExit closes done once, a beat after the current response, so the
+// helper's answer reaches the client before the process goes away.
+func scheduleExit(once *sync.Once, done chan struct{}) {
+	once.Do(func() {
+		go func() {
+			time.Sleep(150 * time.Millisecond)
+			close(done)
+		}()
+	})
+}
+
 // TestFakeLocalVaultHelper is not a test: it is the body of the fake `vault
 // server` process. It only runs when the fake vault script re-executes the
-// test binary with SAFE_FAKE_VAULT_HELPER=1; otherwise it skips.
+// test binary with SAFE_FAKE_VAULT_HELPER=1; otherwise it skips. The
+// SAFE_FAKE_VAULT_FAIL variable, inherited from the test through the script,
+// selects a failure the real Vault could produce at that point.
 func TestFakeLocalVaultHelper(t *testing.T) {
 	if os.Getenv("SAFE_FAKE_VAULT_HELPER") != "1" {
 		t.Skip("helper process body, not a test")
@@ -74,9 +87,21 @@ func TestFakeLocalVaultHelper(t *testing.T) {
 			_, _ = w.Write([]byte(`{"sealed":false}`))
 
 		case r.URL.Path == "/v1/sys/mounts" && r.Method == http.MethodGet:
+			if os.Getenv("SAFE_FAKE_VAULT_FAIL") == "mounts-list" {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"errors":["mount listing is down"]}`))
+				scheduleExit(&exitOnce, done)
+				return
+			}
 			_, _ = w.Write([]byte(`{"data":{}}`))
 
 		case strings.HasPrefix(r.URL.Path, "/v1/sys/mounts/") && r.Method == http.MethodPost:
+			if os.Getenv("SAFE_FAKE_VAULT_FAIL") == "mounts-create" {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"errors":["mount creation is down"]}`))
+				scheduleExit(&exitOnce, done)
+				return
+			}
 			w.WriteHeader(http.StatusNoContent)
 
 		case strings.HasPrefix(r.URL.Path, "/v1/sys/internal/ui/mounts"):
@@ -87,12 +112,7 @@ func TestFakeLocalVaultHelper(t *testing.T) {
 			w.WriteHeader(http.StatusNoContent)
 			// The handshake write is the last thing cmdLocal asks of the
 			// Vault; shut down shortly after so the response gets out first.
-			exitOnce.Do(func() {
-				go func() {
-					time.Sleep(150 * time.Millisecond)
-					close(done)
-				}()
-			})
+			scheduleExit(&exitOnce, done)
 
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -204,5 +224,112 @@ func TestCmdLocal_FileBackedLifecycleWithRandomName(t *testing.T) {
 	}
 	if strings.Contains(string(saferc), "http://127.0.0.1:") {
 		t.Errorf("the temporary target was not cleaned out of .saferc:\n%s", saferc)
+	}
+}
+
+func TestCmdLocal_RestoresPreviousTargetOnExit(t *testing.T) {
+	// No t.Parallel — captureStderr mutates os.Stderr.
+	isolateHome(t)
+	writeSaferc(t, `version: 1
+current: alpha
+vaults:
+  alpha:
+    url: http://127.0.0.1:1
+    token: token-alpha
+    no_strongbox: true
+`)
+	installFakeLocalVault(t)
+	c := localCLI(t)
+	c.opt.Local.Memory = true
+	c.opt.Local.As = "local-prev-test"
+
+	var err error
+	captureStdout(t, func() {
+		captureStderr(t, func() {
+			err = c.cmdLocal("local")
+		})
+	})
+	if err != nil {
+		t.Fatalf("cmdLocal returned unexpected error: %v", err)
+	}
+
+	saferc, err := os.ReadFile(filepath.Join(os.Getenv("HOME"), ".saferc"))
+	if err != nil {
+		t.Fatalf("reading .saferc: %v", err)
+	}
+	if !strings.Contains(string(saferc), "current: alpha") {
+		t.Errorf("the previous target was not restored as current:\n%s", saferc)
+	}
+	if strings.Contains(string(saferc), "local-prev-test") {
+		t.Errorf("the temporary target was not cleaned out of .saferc:\n%s", saferc)
+	}
+}
+
+func TestCmdLocal_UnreadableSafercErrors(t *testing.T) {
+	isolateHome(t)
+	writeSaferc(t, "\t{{ this is not yaml")
+	// The rc failure comes after the server is spawned, so the fake exits
+	// immediately to leave nothing running.
+	t.Setenv("SAFE_FAKE_VAULT_TESTBIN", os.Args[0])
+	installFakeBin(t, "vault", `#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "Vault v1.15.4"
+  exit 0
+fi
+exit 0
+`)
+	c := localCLI(t)
+	c.opt.Local.Memory = true
+	c.opt.Local.Port = 8219
+
+	err := c.cmdLocal("local")
+	if err == nil {
+		t.Fatal("expected an error for an unreadable .saferc, got nil")
+	}
+}
+
+func TestCmdLocal_MountListFailureSurfaces(t *testing.T) {
+	// No t.Parallel — captureStderr mutates os.Stderr.
+	isolateHome(t)
+	installFakeLocalVault(t)
+	t.Setenv("SAFE_FAKE_VAULT_FAIL", "mounts-list")
+	c := localCLI(t)
+	c.opt.Local.Memory = true
+	c.opt.Local.As = "local-lsfail-test"
+
+	var err error
+	captureStdout(t, func() {
+		captureStderr(t, func() {
+			err = c.cmdLocal("local")
+		})
+	})
+	if err == nil {
+		t.Fatal("expected the mount-listing failure to surface, got nil")
+	}
+	if !strings.Contains(err.Error(), "Could not list mounts") {
+		t.Errorf("unexpected error wording: %v", err)
+	}
+}
+
+func TestCmdLocal_MountCreateFailureSurfaces(t *testing.T) {
+	// No t.Parallel — captureStderr mutates os.Stderr.
+	isolateHome(t)
+	installFakeLocalVault(t)
+	t.Setenv("SAFE_FAKE_VAULT_FAIL", "mounts-create")
+	c := localCLI(t)
+	c.opt.Local.Memory = true
+	c.opt.Local.As = "local-mkfail-test"
+
+	var err error
+	captureStdout(t, func() {
+		captureStderr(t, func() {
+			err = c.cmdLocal("local")
+		})
+	})
+	if err == nil {
+		t.Fatal("expected the mount-creation failure to surface, got nil")
+	}
+	if !strings.Contains(err.Error(), "Could not add") {
+		t.Errorf("unexpected error wording: %v", err)
 	}
 }

--- a/internal/cli/server_local_test.go
+++ b/internal/cli/server_local_test.go
@@ -1,0 +1,113 @@
+package cli
+
+// Tests for cmdLocal's validation paths (server.go): everything that fails
+// before a Vault server process is spawned. Where a `vault` binary is needed
+// for version probing, a fake that only answers `vault version` is placed on
+// PATH (installFakeBin lives in server_vault_cmd_test.go).
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// installFakeVaultVersionOnly installs a fake `vault` that answers `vault
+// version` with the given string and rejects any other invocation, so a test
+// that must not reach `vault server` fails loudly if it does.
+func installFakeVaultVersionOnly(t *testing.T, version string) {
+	t.Helper()
+	installFakeBin(t, "vault", `#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "`+version+`"
+  exit 0
+fi
+echo "unexpected invocation: vault $*" >&2
+exit 42
+`)
+}
+
+func localCLI(t *testing.T) *CLI {
+	t.Helper()
+	return &CLI{opt: &Options{}, r: NewRunner()}
+}
+
+func TestCmdLocal_NeitherMemoryNorFileErrors(t *testing.T) {
+	isolateHome(t)
+	c := localCLI(t)
+
+	err := c.cmdLocal("local")
+	if err == nil {
+		t.Fatal("expected an error when neither --memory nor --file is given, got nil")
+	}
+	if !strings.Contains(err.Error(), "--memory or --file") {
+		t.Errorf("unexpected error wording: %v", err)
+	}
+}
+
+func TestCmdLocal_BothMemoryAndFileErrors(t *testing.T) {
+	isolateHome(t)
+	c := localCLI(t)
+	c.opt.Local.Memory = true
+	c.opt.Local.File = filepath.Join(t.TempDir(), "vault.db")
+
+	err := c.cmdLocal("local")
+	if err == nil {
+		t.Fatal("expected an error when both --memory and --file are given, got nil")
+	}
+	if !strings.Contains(err.Error(), "not both") {
+		t.Errorf("unexpected error wording: %v", err)
+	}
+}
+
+func TestCmdLocal_MissingVaultBinaryErrors(t *testing.T) {
+	isolateHome(t)
+	// PATH holds only an empty directory, so there is no vault to run.
+	t.Setenv("PATH", t.TempDir())
+	c := localCLI(t)
+	c.opt.Local.Memory = true
+	c.opt.Local.Port = 8219
+
+	err := c.cmdLocal("local")
+	if err == nil {
+		t.Fatal("expected an error when vault is not installed, got nil")
+	}
+	if !strings.Contains(err.Error(), "neither vault nor bao") {
+		t.Errorf("unexpected error wording: %v", err)
+	}
+}
+
+func TestCmdLocal_MalformedConfigPairErrors(t *testing.T) {
+	isolateHome(t)
+	installFakeVaultVersionOnly(t, "Vault v1.15.4")
+	c := localCLI(t)
+	c.opt.Local.Memory = true
+	c.opt.Local.Port = 8219
+	c.opt.Local.Config = []string{"not-a-pair"}
+
+	err := c.cmdLocal("local")
+	if err == nil {
+		t.Fatal("expected an error for a malformed --config pair, got nil")
+	}
+	if !strings.Contains(err.Error(), "expected key=value") {
+		t.Errorf("unexpected error wording: %v", err)
+	}
+}
+
+func TestCmdLocal_MalformedListenerPairErrorsWithOldVault(t *testing.T) {
+	isolateHome(t)
+	// A pre-0.8 Vault takes the legacy "backend" storage-key branch before
+	// the listener pair is rejected.
+	installFakeVaultVersionOnly(t, "Vault v0.7.3")
+	c := localCLI(t)
+	c.opt.Local.File = filepath.Join(t.TempDir(), "does-not-exist.db")
+	c.opt.Local.Port = 8219
+	c.opt.Local.Listener = []string{"=no-key"}
+
+	err := c.cmdLocal("local")
+	if err == nil {
+		t.Fatal("expected an error for a malformed --listener pair, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty key") {
+		t.Errorf("unexpected error wording: %v", err)
+	}
+}

--- a/internal/cli/server_rekey_run_test.go
+++ b/internal/cli/server_rekey_run_test.go
@@ -31,13 +31,29 @@ type fakeRekeyVault struct {
 	newKeys []string
 	//startBody is the decoded body of the PUT that started the rekey.
 	startBody map[string]any
-	kv        *cliFakeVault
+	//failCancel makes the initial rekey-cancel request fail.
+	failCancel bool
+	//failKV makes every KV request fail, so --persist cannot save keys.
+	failKV bool
+	kv     *cliFakeVault
 }
 
 func (f *fakeRekeyVault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	f.mu.Lock()
+	failCancel, failKV := f.failCancel, f.failKV
+	f.mu.Unlock()
 	switch {
+	case r.URL.Path == "/v1/sys/health":
+		//correct500Error probes health after a 500 from a rekey endpoint.
+		_, _ = w.Write([]byte(`{}`))
+
 	case r.URL.Path == "/v1/sys/rekey/init" && r.Method == http.MethodDelete:
+		if failCancel {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"errors":["cancel refused"]}`))
+			return
+		}
 		_, _ = w.Write([]byte(`{}`))
 
 	case r.URL.Path == "/v1/sys/rekey/init" && r.Method == http.MethodPut:
@@ -72,6 +88,11 @@ func (f *fakeRekeyVault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		})
 
 	default:
+		if failKV {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"errors":["kv is down"]}`))
+			return
+		}
 		f.kv.ServeHTTP(w, r)
 	}
 }
@@ -192,5 +213,50 @@ func TestCmdRekey_PersistSavesNewSealKeys(t *testing.T) {
 	}
 	if saved["key1"] != "new-key-one" {
 		t.Errorf("persisted key1: got %q, want %q", saved["key1"], "new-key-one")
+	}
+}
+
+func TestCmdRekey_CancelFailureSurfaces(t *testing.T) {
+	// No t.Parallel — captureStdout mutates os.Stdout.
+	isolateHome(t)
+	f := newRekeyFake(t, []string{"new-key-one"})
+	f.mu.Lock()
+	f.failCancel = true
+	f.mu.Unlock()
+	c := rekeyCLI(t)
+	c.opt.Rekey.NKeys = 1
+
+	var err error
+	captureStdout(t, func() {
+		err = c.cmdRekey("rekey")
+	})
+	if err == nil {
+		t.Fatal("expected the rekey-cancel failure to surface, got nil")
+	}
+	if !strings.Contains(err.Error(), "cancel") {
+		t.Errorf("unexpected error wording: %v", err)
+	}
+}
+
+func TestCmdRekey_PersistFailureSurfaces(t *testing.T) {
+	// No t.Parallel — captureStdout mutates os.Stdout.
+	isolateHome(t)
+	f := newRekeyFake(t, []string{"new-key-one"})
+	f.mu.Lock()
+	f.failKV = true
+	f.mu.Unlock()
+	c := rekeyCLI(t)
+	c.opt.Rekey.NKeys = 1
+	c.opt.Rekey.Persist = true
+
+	var err error
+	captureStdout(t, func() {
+		err = c.cmdRekey("rekey")
+	})
+	if err == nil {
+		t.Fatal("expected the seal-key save failure to surface, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to save seal keys") {
+		t.Errorf("unexpected error wording: %v", err)
 	}
 }

--- a/internal/cli/server_rekey_run_test.go
+++ b/internal/cli/server_rekey_run_test.go
@@ -1,0 +1,196 @@
+package cli
+
+// End-to-end tests for cmdRekey (server.go) against a fake Vault that speaks
+// the sys/rekey API. The unseal key the operation asks for is fed through
+// prompt.SetReader, and KV traffic (for --persist) is delegated to the
+// existing cliFakeVault.
+//
+// captureStdout mutates os.Stdout — do NOT add t.Parallel to any test in
+// this file.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/prompt"
+)
+
+// fakeRekeyVault answers the four sys/rekey requests a rekey makes: cancel,
+// start, status, and update. Everything else falls through to the KV fake so
+// --persist can write the new keys back into the Vault.
+type fakeRekeyVault struct {
+	mu sync.Mutex
+	//required is how many current unseal keys the operation demands.
+	required int
+	//newKeys is what the completed rekey hands back.
+	newKeys []string
+	//startBody is the decoded body of the PUT that started the rekey.
+	startBody map[string]any
+	kv        *cliFakeVault
+}
+
+func (f *fakeRekeyVault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	switch {
+	case r.URL.Path == "/v1/sys/rekey/init" && r.Method == http.MethodDelete:
+		_, _ = w.Write([]byte(`{}`))
+
+	case r.URL.Path == "/v1/sys/rekey/init" && r.Method == http.MethodPut:
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		f.mu.Lock()
+		f.startBody = body
+		f.mu.Unlock()
+		_, _ = w.Write([]byte(`{}`))
+
+	case r.URL.Path == "/v1/sys/rekey/init" && r.Method == http.MethodGet:
+		f.mu.Lock()
+		required := f.required
+		f.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"started":  true,
+			"nonce":    "test-nonce",
+			"t":        1,
+			"n":        1,
+			"progress": 0,
+			"required": required,
+		})
+
+	case r.URL.Path == "/v1/sys/rekey/update" && r.Method == http.MethodPut:
+		f.mu.Lock()
+		keys := append([]string(nil), f.newKeys...)
+		f.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"complete":    true,
+			"keys":        keys,
+			"keys_base64": keys,
+		})
+
+	default:
+		f.kv.ServeHTTP(w, r)
+	}
+}
+
+// rekeyStart returns the recorded body of the PUT that began the rekey.
+func (f *fakeRekeyVault) rekeyStart() map[string]any {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.startBody
+}
+
+// newRekeyFake starts the fake, targets it via the environment, and queues
+// one current unseal key on the prompt reader.
+func newRekeyFake(t *testing.T, newKeys []string) *fakeRekeyVault {
+	t.Helper()
+	f := &fakeRekeyVault{
+		required: 1,
+		newKeys:  newKeys,
+		kv:       &cliFakeVault{data: map[string]map[string]string{}},
+	}
+	srv := httptest.NewServer(f)
+	t.Cleanup(srv.Close)
+	t.Setenv("VAULT_ADDR", srv.URL)
+	t.Setenv("VAULT_TOKEN", "test-token")
+	prompt.SetReader(strings.NewReader("current-unseal-key\n"))
+	t.Cleanup(func() { prompt.SetReader(nil) })
+	return f
+}
+
+func TestCmdRekey_RekeysAndPrintsNumberedKeys(t *testing.T) {
+	// No t.Parallel — captureStdout mutates os.Stdout.
+	isolateHome(t)
+	f := newRekeyFake(t, []string{"new-key-one"})
+	c := rekeyCLI(t)
+	c.opt.Rekey.NKeys = 1
+
+	var err error
+	out := captureStdout(t, func() {
+		err = c.cmdRekey("rekey")
+	})
+	if err != nil {
+		t.Fatalf("cmdRekey returned unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "re-keyed") {
+		t.Errorf("expected a re-key confirmation, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Unseal key 1") || !strings.Contains(out, "new-key-one") {
+		t.Errorf("expected the new key listed by number, got:\n%s", out)
+	}
+
+	start := f.rekeyStart()
+	if start == nil {
+		t.Fatal("no rekey was started on the Vault")
+	}
+	if got := start["secret_shares"]; got != float64(1) {
+		t.Errorf("secret_shares: got %v, want 1", got)
+	}
+	if got := start["secret_threshold"]; got != float64(1) {
+		t.Errorf("secret_threshold: got %v, want 1", got)
+	}
+}
+
+func TestCmdRekey_GPGKeysArePassedAndLabelOutput(t *testing.T) {
+	// No t.Parallel — captureStdout mutates os.Stdout.
+	isolateHome(t)
+	installFakeGPG(t)
+	f := newRekeyFake(t, []string{"new-key-one"})
+	c := rekeyCLI(t)
+	c.opt.Rekey.GPG = []string{"alice@example.com"}
+
+	var err error
+	out := captureStdout(t, func() {
+		err = c.cmdRekey("rekey")
+	})
+	if err != nil {
+		t.Fatalf("cmdRekey returned unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Unseal key for") || !strings.Contains(out, "alice@example.com") {
+		t.Errorf("expected the key labeled with its GPG owner, got:\n%s", out)
+	}
+
+	start := f.rekeyStart()
+	if start == nil {
+		t.Fatal("no rekey was started on the Vault")
+	}
+	pgp, ok := start["pgp_keys"].([]any)
+	if !ok || len(pgp) != 1 {
+		t.Fatalf("pgp_keys: got %v, want one entry", start["pgp_keys"])
+	}
+	want := base64.StdEncoding.EncodeToString([]byte(fakeGPGKeyBytes))
+	if pgp[0] != want {
+		t.Errorf("pgp_keys[0]: got %v, want %s", pgp[0], want)
+	}
+	if start["backup"] != true {
+		t.Errorf("backup: got %v, want true when GPG keys are given", start["backup"])
+	}
+}
+
+func TestCmdRekey_PersistSavesNewSealKeys(t *testing.T) {
+	// No t.Parallel — captureStdout mutates os.Stdout.
+	isolateHome(t)
+	f := newRekeyFake(t, []string{"new-key-one"})
+	c := rekeyCLI(t)
+	c.opt.Rekey.NKeys = 1
+	c.opt.Rekey.Persist = true
+
+	var err error
+	captureStdout(t, func() {
+		err = c.cmdRekey("rekey")
+	})
+	if err != nil {
+		t.Fatalf("cmdRekey returned unexpected error: %v", err)
+	}
+
+	saved := f.kv.get("secret/vault/seal/keys")
+	if saved == nil {
+		t.Fatal("the new seal keys were not persisted to secret/vault/seal/keys")
+	}
+	if saved["key1"] != "new-key-one" {
+		t.Errorf("persisted key1: got %q, want %q", saved["key1"], "new-key-one")
+	}
+}

--- a/internal/cli/server_rekey_test.go
+++ b/internal/cli/server_rekey_test.go
@@ -1,0 +1,125 @@
+package cli
+
+// Tests for cmdRekey's validation paths (server.go): everything that fails
+// before a Vault connection is attempted. GPG key material comes from a fake
+// `gpg` executable prepended to PATH (installFakeBin lives in
+// server_vault_cmd_test.go).
+
+import (
+	"strings"
+	"testing"
+)
+
+// installFakeGPG installs a fake `gpg` whose behavior is chosen by
+// $FAKE_GPG_MODE: "fail" exits nonzero, "empty" exits zero with no output
+// (how real gpg reports an unknown key), and anything else prints fixed key
+// bytes. fakeGPGKeyBytes is what the default mode emits.
+const fakeGPGKeyBytes = "FAKE-PGP-KEY"
+
+func installFakeGPG(t *testing.T) {
+	t.Helper()
+	installFakeBin(t, "gpg", `#!/bin/sh
+case "${FAKE_GPG_MODE:-ok}" in
+  fail)  exit 2 ;;
+  empty) exit 0 ;;
+  *)     printf '`+fakeGPGKeyBytes+`' ;;
+esac
+`)
+}
+
+func rekeyCLI(t *testing.T) *CLI {
+	t.Helper()
+	return &CLI{opt: &Options{}, r: NewRunner()}
+}
+
+func TestCmdRekey_UnknownTargetErrors(t *testing.T) {
+	isolateHome(t)
+	c := rekeyCLI(t)
+	c.opt.UseTarget = "no-such-target"
+
+	err := c.cmdRekey("rekey")
+	if err == nil {
+		t.Fatal("expected an error for an unknown target, got nil")
+	}
+	if !strings.Contains(err.Error(), "no-such-target") {
+		t.Errorf("error does not name the unknown target: %v", err)
+	}
+}
+
+func TestCmdRekey_GPGExportFailureErrors(t *testing.T) {
+	isolateHome(t)
+	installFakeGPG(t)
+	t.Setenv("FAKE_GPG_MODE", "fail")
+	c := rekeyCLI(t)
+	c.opt.Rekey.GPG = []string{"alice@example.com"}
+
+	err := c.cmdRekey("rekey")
+	if err == nil {
+		t.Fatal("expected an error when gpg --export fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "Failed to retrieve GPG key for alice@example.com") {
+		t.Errorf("unexpected error wording: %v", err)
+	}
+}
+
+func TestCmdRekey_GPGKeyNotFoundErrors(t *testing.T) {
+	isolateHome(t)
+	installFakeGPG(t)
+	t.Setenv("FAKE_GPG_MODE", "empty")
+	c := rekeyCLI(t)
+	c.opt.Rekey.GPG = []string{"bob@example.com"}
+
+	err := c.cmdRekey("rekey")
+	if err == nil {
+		t.Fatal("expected an error when gpg finds no key, got nil")
+	}
+	if !strings.Contains(err.Error(), "No GPG key found for bob@example.com") {
+		t.Errorf("unexpected error wording: %v", err)
+	}
+}
+
+func TestCmdRekey_GPGAndKeyCountMismatchErrors(t *testing.T) {
+	isolateHome(t)
+	installFakeGPG(t)
+	c := rekeyCLI(t)
+	c.opt.Rekey.GPG = []string{"alice@example.com"}
+	c.opt.Rekey.NKeys = 2
+
+	err := c.cmdRekey("rekey")
+	if err == nil {
+		t.Fatal("expected an error for mismatched --gpg and --keys counts, got nil")
+	}
+	if !strings.Contains(err.Error(), "counts did not match") {
+		t.Errorf("unexpected error wording: %v", err)
+	}
+}
+
+func TestCmdRekey_ThresholdAboveKeyCountErrors(t *testing.T) {
+	isolateHome(t)
+	c := rekeyCLI(t)
+	c.opt.Rekey.NKeys = 2
+	c.opt.Rekey.Threshold = 3
+
+	err := c.cmdRekey("rekey")
+	if err == nil {
+		t.Fatal("expected an error for a threshold above the key count, got nil")
+	}
+	if !strings.Contains(err.Error(), "only 2 unseal keys") {
+		t.Errorf("unexpected error wording: %v", err)
+	}
+}
+
+func TestCmdRekey_ThresholdOfOneWithManyKeysErrors(t *testing.T) {
+	isolateHome(t)
+	c := rekeyCLI(t)
+	c.opt.Rekey.NKeys = 3
+	c.opt.Rekey.Threshold = 1
+
+	err := c.cmdRekey("rekey")
+	if err == nil {
+		t.Fatal("expected an error for a threshold of 1 with several keys, got nil")
+	}
+	if !strings.Contains(err.Error(), "more than one key required to unseal") {
+		t.Errorf("unexpected error wording: %v", err)
+	}
+}

--- a/internal/cli/server_vault_cmd_test.go
+++ b/internal/cli/server_vault_cmd_test.go
@@ -1,0 +1,227 @@
+package cli
+
+// Tests for cmdVault (server.go): the passthrough to the system `vault`
+// binary. A fake `vault` executable placed first on PATH records its
+// arguments and environment in a file, so the passthrough can be driven
+// deterministically without a real Vault installation.
+//
+// captureStderr mutates os.Stderr — do NOT add t.Parallel to any test in
+// this file.
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// installFakeBin writes an executable shell script into a fresh directory and
+// prepends that directory to PATH for the duration of the test, so the script
+// shadows any real binary of the same name.
+func installFakeBin(t *testing.T, name, script string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(script), 0700); err != nil { // #nosec G306 -- must be executable
+		t.Fatalf("writing fake %s: %v", name, err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// installFakeVaultRecorder installs a fake `vault` that dumps its argv and
+// environment to a file and exits with $FAKE_VAULT_EXIT (default 0). It
+// returns the path of the dump file.
+func installFakeVaultRecorder(t *testing.T) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "vault-run.txt")
+	t.Setenv("FAKE_VAULT_OUT", out)
+	installFakeBin(t, "vault", `#!/bin/sh
+{
+  printf 'args:'
+  for a in "$@"; do printf ' %s' "$a"; done
+  printf '\n'
+  env
+} > "$FAKE_VAULT_OUT"
+exit "${FAKE_VAULT_EXIT:-0}"
+`)
+	return out
+}
+
+// clearProxyEnv empties every variable NewProxyRouter and cmdVault consult so
+// the developer's real proxy settings cannot leak into an assertion.
+func clearProxyEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"HTTP_PROXY", "http_proxy",
+		"HTTPS_PROXY", "https_proxy",
+		"NO_PROXY", "no_proxy",
+		"SAFE_ALL_PROXY", "safe_all_proxy",
+	} {
+		// t.Setenv registers the restore; Unsetenv removes the variable so it
+		// does not appear in os.Environ() as an empty entry.
+		t.Setenv(name, "")
+		_ = os.Unsetenv(name)
+	}
+}
+
+func TestCmdVault_UnknownTargetErrors(t *testing.T) {
+	isolateHome(t)
+	c := &CLI{opt: &Options{}, r: NewRunner()}
+	c.opt.UseTarget = "no-such-target"
+
+	err := c.cmdVault("vault", "status")
+	if err == nil {
+		t.Fatal("expected an error for an unknown target, got nil")
+	}
+	if !strings.Contains(err.Error(), "no-such-target") {
+		t.Errorf("error does not name the unknown target: %v", err)
+	}
+}
+
+func TestCmdVault_RunsVaultBinaryWithArgs(t *testing.T) {
+	isolateHome(t)
+	clearProxyEnv(t)
+	out := installFakeVaultRecorder(t)
+	c := &CLI{opt: &Options{}, r: NewRunner()}
+
+	if err := c.cmdVault("vault", "token", "lookup"); err != nil {
+		t.Fatalf("cmdVault returned unexpected error: %v", err)
+	}
+
+	dump, err := os.ReadFile(out) // #nosec G304 -- test-owned temp file
+	if err != nil {
+		t.Fatalf("the fake vault left no dump, so it never ran: %v", err)
+	}
+	if !strings.Contains(string(dump), "args: token lookup") {
+		t.Errorf("fake vault saw the wrong arguments:\n%s", dump)
+	}
+}
+
+func TestCmdVault_PropagatesNonZeroExit(t *testing.T) {
+	isolateHome(t)
+	clearProxyEnv(t)
+	installFakeVaultRecorder(t)
+	t.Setenv("FAKE_VAULT_EXIT", "3")
+	c := &CLI{opt: &Options{}, r: NewRunner()}
+
+	err := c.cmdVault("vault", "status")
+	if err == nil {
+		t.Fatal("expected the vault exit status to surface as an error, got nil")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *exec.ExitError, got %T: %v", err, err)
+	}
+	if exitErr.ExitCode() != 3 {
+		t.Errorf("exit code: got %d, want 3", exitErr.ExitCode())
+	}
+}
+
+func TestCmdVault_NoClobberIsWarnedAndIgnored(t *testing.T) {
+	// No t.Parallel — captureStderr mutates os.Stderr.
+	isolateHome(t)
+	clearProxyEnv(t)
+	installFakeVaultRecorder(t)
+	c := &CLI{opt: &Options{}, r: NewRunner()}
+	c.opt.SkipIfExists = true
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = c.cmdVault("vault", "status")
+	})
+	if err != nil {
+		t.Fatalf("cmdVault returned unexpected error: %v", err)
+	}
+	if !strings.Contains(stderr, "--no-clobber") || !strings.Contains(stderr, "ignored") {
+		t.Errorf("expected a warning that --no-clobber is ignored, got: %q", stderr)
+	}
+}
+
+func TestCmdVault_StatusUnsetsVaultNamespace(t *testing.T) {
+	isolateHome(t)
+	clearProxyEnv(t)
+	out := installFakeVaultRecorder(t)
+	t.Setenv("VAULT_NAMESPACE", "testns")
+	c := &CLI{opt: &Options{}, r: NewRunner()}
+
+	// The leading flag exercises the skip-flags-then-check loop.
+	if err := c.cmdVault("vault", "-tls-skip-verify", "status"); err != nil {
+		t.Fatalf("cmdVault returned unexpected error: %v", err)
+	}
+
+	dump, err := os.ReadFile(out) // #nosec G304 -- test-owned temp file
+	if err != nil {
+		t.Fatalf("the fake vault left no dump, so it never ran: %v", err)
+	}
+	if strings.Contains(string(dump), "VAULT_NAMESPACE=testns") {
+		t.Errorf("vault status still saw VAULT_NAMESPACE:\n%s", dump)
+	}
+}
+
+func TestCmdVault_NonStatusKeepsVaultNamespace(t *testing.T) {
+	isolateHome(t)
+	clearProxyEnv(t)
+	out := installFakeVaultRecorder(t)
+	t.Setenv("VAULT_NAMESPACE", "testns")
+	c := &CLI{opt: &Options{}, r: NewRunner()}
+
+	if err := c.cmdVault("vault", "token", "lookup"); err != nil {
+		t.Fatalf("cmdVault returned unexpected error: %v", err)
+	}
+
+	dump, err := os.ReadFile(out) // #nosec G304 -- test-owned temp file
+	if err != nil {
+		t.Fatalf("the fake vault left no dump, so it never ran: %v", err)
+	}
+	if !strings.Contains(string(dump), "VAULT_NAMESPACE=testns") {
+		t.Errorf("VAULT_NAMESPACE did not reach the vault binary:\n%s", dump)
+	}
+}
+
+func TestCmdVault_UppercasesLowercaseProxyVars(t *testing.T) {
+	isolateHome(t)
+	clearProxyEnv(t)
+	out := installFakeVaultRecorder(t)
+	t.Setenv("http_proxy", "http://127.0.0.1:9")
+	t.Setenv("no_proxy", "internal.example.com")
+	c := &CLI{opt: &Options{}, r: NewRunner()}
+
+	if err := c.cmdVault("vault", "token", "lookup"); err != nil {
+		t.Fatalf("cmdVault returned unexpected error: %v", err)
+	}
+
+	dump, err := os.ReadFile(out) // #nosec G304 -- test-owned temp file
+	if err != nil {
+		t.Fatalf("the fake vault left no dump, so it never ran: %v", err)
+	}
+	env := string(dump)
+	if !strings.Contains(env, "HTTP_PROXY=http://127.0.0.1:9") {
+		t.Errorf("http_proxy was not promoted to HTTP_PROXY:\n%s", env)
+	}
+	if strings.Contains(env, "http_proxy=http://127.0.0.1:9") {
+		t.Errorf("lowercase http_proxy leaked through unconverted:\n%s", env)
+	}
+	if !strings.Contains(env, "NO_PROXY=internal.example.com") {
+		t.Errorf("no_proxy was not promoted to NO_PROXY:\n%s", env)
+	}
+}
+
+func TestCmdVault_BadSSHProxyErrors(t *testing.T) {
+	isolateHome(t)
+	clearProxyEnv(t)
+	installFakeVaultRecorder(t)
+	// An ssh+socks5 proxy with no private key fails inside NewProxyRouter
+	// before any network activity.
+	t.Setenv("SAFE_ALL_PROXY", "ssh+socks5://user@127.0.0.1:22")
+	c := &CLI{opt: &Options{}, r: NewRunner()}
+
+	err := c.cmdVault("vault", "status")
+	if err == nil {
+		t.Fatal("expected a proxy setup error, got nil")
+	}
+	if !strings.Contains(err.Error(), "private key") {
+		t.Errorf("expected the missing private key named, got: %v", err)
+	}
+}

--- a/internal/cli/server_vault_cmd_test.go
+++ b/internal/cli/server_vault_cmd_test.go
@@ -185,6 +185,7 @@ func TestCmdVault_UppercasesLowercaseProxyVars(t *testing.T) {
 	clearProxyEnv(t)
 	out := installFakeVaultRecorder(t)
 	t.Setenv("http_proxy", "http://127.0.0.1:9")
+	t.Setenv("https_proxy", "http://127.0.0.1:10")
 	t.Setenv("no_proxy", "internal.example.com")
 	c := &CLI{opt: &Options{}, r: NewRunner()}
 
@@ -202,6 +203,9 @@ func TestCmdVault_UppercasesLowercaseProxyVars(t *testing.T) {
 	}
 	if strings.Contains(env, "http_proxy=http://127.0.0.1:9") {
 		t.Errorf("lowercase http_proxy leaked through unconverted:\n%s", env)
+	}
+	if !strings.Contains(env, "HTTPS_PROXY=http://127.0.0.1:10") {
+		t.Errorf("https_proxy was not promoted to HTTPS_PROXY:\n%s", env)
 	}
 	if !strings.Contains(env, "NO_PROXY=internal.example.com") {
 		t.Errorf("no_proxy was not promoted to NO_PROXY:\n%s", env)


### PR DESCRIPTION
## What

Brings `cmdLocal`, `cmdVault`, and `cmdRekey` (internal/cli/server.go) from 0% coverage to what can be covered honestly, with no production code changes.

Coverage (`go test -coverpkg=./... ./...`, `go tool cover -func`):

| Function | Before | After |
|----------|--------|-------|
| cmdLocal | 0.0% | ~80% (79.7–80.4%; the startup-poll retry branch is timing-dependent) |
| cmdVault | 0.0% | 97.1% |
| cmdRekey | 0.0% | 100.0% |

internal/cli package total for `./...`: 57.6% → 62.7%.

## How the untestable-looking parts were driven

- **cmdVault** executes the system `vault` binary. A fake `vault` shell script prepended to `PATH` dumps its argv and environment to a file, covering argument forwarding, exit-status propagation, the `--no-clobber` warning, `VAULT_NAMESPACE` removal for `vault status` (including skipping leading flags), promotion of lowercase `http_proxy`/`https_proxy`/`no_proxy`, and the proxy-router error for an `ssh+socks5://` proxy with no private key.
- **cmdRekey** talks to `sys/rekey`. A fake HTTP Vault serves cancel/start/status/update, the current unseal key is fed via `prompt.SetReader`, and GPG material comes from a fake `gpg` on `PATH`. Covers the full rekey (numbered output, GPG-labeled output, `pgp_keys`/`backup` in the start request), `--persist` writing `secret/vault/seal/keys` through the existing `cliFakeVault`, and every validation and error path (gpg export failure, key not found, count mismatch, threshold rules, cancel failure, persist failure).
- **cmdLocal** spawns `vault server`. The fake `vault`'s `server` subcommand re-executes the test binary as a minimal Vault API bound to the port parsed out of the rendered config, so the whole lifecycle runs for real: startup wait, init, unseal, mount creation, handshake write, memory and file backed notices, random and `--as` names, previous-target restore, and `.saferc` cleanup after the server exits. Failure variants (mount list/create 500s, unreadable `.saferc` after spawn) cover the error returns.

## Defects found

None fixed; nothing reproduced as an outright bug. One observation worth recording: when `cmdLocal` fails *after* spawning the Vault via a plain `return` (unreadable `.saferc` at rc.Apply, `MountExists`/`AddMount` failures), the spawned Vault process is left running and the temporary target stays in `.saferc`, unlike the `die()` paths, which kill the process and clean up. Whether that is a defect or a deliberate "leave it up for inspection" choice is a judgment call, so it is documented here rather than changed; the tests pin the current behavior (error surfaces, no cleanup).

## Left untested, and why

- The `die()` bodies and every branch that calls it in-process (name collision, init/unseal/root-token failures, startup timeout): `die` ends in `os.Exit(1)`, which would kill the test binary. The most important one — Vault exiting before it becomes ready, with its own stderr relayed — **is** verified from outside the process by running the built `safe` binary against a vault that refuses to start (exit code, message, and relayed config complaint asserted); subprocess execution just doesn't count toward the coverage profile.
- The pre-existing-storage path (`resolveRootToken` falling through to `NewRootToken`): requires faking the `sys/generate-root` OTP flow, where the returned token is XOR-decoded against a client-generated one-time pad — a fake would have to reimplement Vault's encoding, which crosses into stub-shaped testing.
- Temp-file `WriteString`/`Close` failures, `cmd.Start` failure after a successful `vault version`, and the env entry without `=` in cmdVault's environ loop: not honestly forceable.

## Verification

- `make check` passes
- `go test -race -count=1 ./...` passes
- Every commit builds and passes tests on its own

Note for the in-flight Strongbox-default branch: nothing here touches target creation or `usesStrongbox`; the lifecycle tests assert only messages and `.saferc` cleanup, not the `no_strongbox` field, so the merge should stay trivial.
