### PR TITLE
Fix port clash flake in cmdLocal lifecycle tests

### DIFF
--- a/internal/cli/server_local_run_test.go
+++ b/internal/cli/server_local_run_test.go
@@ -27,6 +27,22 @@ import (
 	"time"
 )
 
+// freePort reserves an ephemeral port for one test's Vault. Without it every
+// test here listens on cmdLocal's default port, and a helper from the
+// previous test that has not finished its post-response exit yet is still
+// holding it — the new helper dies with exit status 9 while cmdLocal talks
+// to the stale one and sees the wrong failure.
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
 // scheduleExit closes done once, a beat after the current response, so the
 // helper's answer reaches the client before the process goes away.
 func scheduleExit(once *sync.Once, done chan struct{}) {
@@ -157,6 +173,7 @@ func TestCmdLocal_MemoryBackedLifecycle(t *testing.T) {
 	installFakeLocalVault(t)
 	c := localCLI(t)
 	c.opt.Local.Memory = true
+	c.opt.Local.Port = freePort(t)
 	c.opt.Local.As = "local-mem-test"
 
 	var err error
@@ -201,6 +218,7 @@ func TestCmdLocal_FileBackedLifecycleWithRandomName(t *testing.T) {
 	installFakeLocalVault(t)
 	c := localCLI(t)
 	c.opt.Local.File = filepath.Join(t.TempDir(), "local-vault.db")
+	c.opt.Local.Port = freePort(t)
 
 	var err error
 	var stderr string
@@ -243,6 +261,7 @@ vaults:
 	installFakeLocalVault(t)
 	c := localCLI(t)
 	c.opt.Local.Memory = true
+	c.opt.Local.Port = freePort(t)
 	c.opt.Local.As = "local-prev-test"
 
 	var err error
@@ -297,6 +316,7 @@ func TestCmdLocal_MountListFailureSurfaces(t *testing.T) {
 	t.Setenv("SAFE_FAKE_VAULT_FAIL", "mounts-list")
 	c := localCLI(t)
 	c.opt.Local.Memory = true
+	c.opt.Local.Port = freePort(t)
 	c.opt.Local.As = "local-lsfail-test"
 
 	var err error
@@ -362,6 +382,7 @@ func TestCmdLocal_MountCreateFailureSurfaces(t *testing.T) {
 	t.Setenv("SAFE_FAKE_VAULT_FAIL", "mounts-create")
 	c := localCLI(t)
 	c.opt.Local.Memory = true
+	c.opt.Local.Port = freePort(t)
 	c.opt.Local.As = "local-mkfail-test"
 
 	var err error


### PR DESCRIPTION
## What

The five cmdLocal lifecycle tests merged in #55 all ran their fake Vault on cmdLocal's default port. Each test now reserves its own ephemeral port before spawning.

## Why

The failure-path fakes outlive their test on purpose — they exit ~150ms after the last response so the 500 reaches cmdLocal first — and cmdLocal's error returns leave the server running (the judgment call noted in #55). Under load, the next test's fake found the port still held and died with exit status 9, while cmdLocal connected to the stale fake instead. Observed both ways:

- `TestCmdLocal_MountCreateFailureSurfaces` failed with the *previous* test's error: `Could not list mounts: ... mount listing is down`.
- `TestCmdLocal_MemoryBackedLifecycle` failed with `exit status 9` from the fake losing the bind race.

Reproduced roughly one run in three with three test suites running concurrently; zero failures in the same stress after the fix.

## Verification

- `make check` green, `go test -race -count=1 ./...` green.
- Three concurrent `go test -run 'TestCmdLocal|TestSafeLocal|TestFakeLocalVault'` suites: all pass (two of three failed before).
