### PR TITLE
Cover the pkg/vault crypto and subject helpers

### DIFF
--- a/pkg/vault/rsakey_test.go
+++ b/pkg/vault/rsakey_test.go
@@ -1,0 +1,80 @@
+// White-box tests for the unexported rsakey() function (rsa.go).
+package vault
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+)
+
+// TestRSAKeyPrivatePEMValid verifies rsakey() produces a valid PKCS#1 RSA
+// private key PEM block that can be parsed back.
+func TestRSAKeyPrivatePEMValid(t *testing.T) {
+	t.Parallel()
+
+	priv, _, err := rsakey(2048)
+	if err != nil {
+		t.Fatalf("rsakey(2048) error: %v", err)
+	}
+
+	block, rest := pem.Decode([]byte(priv))
+	if block == nil {
+		t.Fatal("private key: pem.Decode returned nil block")
+	}
+	if len(strings.TrimSpace(string(rest))) > 0 {
+		t.Errorf("private key: unexpected trailing data after PEM block: %q", rest)
+	}
+	if block.Type != "RSA PRIVATE KEY" {
+		t.Errorf("PEM type = %q; want RSA PRIVATE KEY", block.Type)
+	}
+
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("x509.ParsePKCS1PrivateKey: %v", err)
+	}
+	if err := key.Validate(); err != nil {
+		t.Errorf("rsa.PrivateKey.Validate: %v", err)
+	}
+	if got := key.N.BitLen(); got != 2048 {
+		t.Errorf("key size = %d bits; want 2048", got)
+	}
+}
+
+// TestRSAKeyPublicMatchesPrivate verifies the public key PEM is a PKIX
+// PUBLIC KEY block holding the public half of the private key.
+func TestRSAKeyPublicMatchesPrivate(t *testing.T) {
+	t.Parallel()
+
+	priv, pub, err := rsakey(2048)
+	if err != nil {
+		t.Fatalf("rsakey(2048) error: %v", err)
+	}
+
+	pubBlock, _ := pem.Decode([]byte(pub))
+	if pubBlock == nil {
+		t.Fatal("public key: pem.Decode returned nil block")
+	}
+	if pubBlock.Type != "PUBLIC KEY" {
+		t.Errorf("PEM type = %q; want PUBLIC KEY", pubBlock.Type)
+	}
+
+	parsedPub, err := x509.ParsePKIXPublicKey(pubBlock.Bytes)
+	if err != nil {
+		t.Fatalf("x509.ParsePKIXPublicKey: %v", err)
+	}
+	rsaPub, ok := parsedPub.(*rsa.PublicKey)
+	if !ok {
+		t.Fatalf("public key type = %T; want *rsa.PublicKey", parsedPub)
+	}
+
+	privBlock, _ := pem.Decode([]byte(priv))
+	privKey, err := x509.ParsePKCS1PrivateKey(privBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse private key: %v", err)
+	}
+	if !rsaPub.Equal(&privKey.PublicKey) {
+		t.Error("public key does not match the private key's public half")
+	}
+}

--- a/pkg/vault/secret_dhparam_test.go
+++ b/pkg/vault/secret_dhparam_test.go
@@ -1,0 +1,64 @@
+// Black-box tests for Secret.DHParam (secret.go), which shells out to
+// openssl to generate Diffie-Hellman parameters and stores them under
+// 'dhparam-pem'. The unexported genDHParam bit validation has its own
+// white-box tests in dhparam_test.go; here the concern is what ends up in
+// the secret. 1024 bits is the smallest size DHParam accepts and keeps
+// generation fast.
+package vault_test
+
+import (
+	"encoding/pem"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// TestDHParamStoresPEM verifies DHParam stores a parseable DH PARAMETERS
+// PEM block under 'dhparam-pem'.
+func TestDHParamStoresPEM(t *testing.T) {
+	t.Parallel()
+
+	s := vault.NewSecret()
+	if err := s.DHParam(1024, false); err != nil {
+		t.Fatalf("DHParam(1024): %v", err)
+	}
+
+	block, _ := pem.Decode([]byte(s.Get("dhparam-pem")))
+	if block == nil {
+		t.Fatal("'dhparam-pem' is not a PEM block")
+	}
+	if block.Type != "DH PARAMETERS" {
+		t.Errorf("PEM type = %q; want DH PARAMETERS", block.Type)
+	}
+}
+
+// TestDHParamRejectsInvalidBits verifies an unsupported bit count is
+// reported as an error and nothing is stored.
+func TestDHParamRejectsInvalidBits(t *testing.T) {
+	t.Parallel()
+
+	s := vault.NewSecret()
+	if err := s.DHParam(512, false); err == nil {
+		t.Fatal("expected an error for 512 bits, got nil")
+	}
+	if !s.Empty() {
+		t.Errorf("secret is not empty after a failed DHParam: %v", s.Keys())
+	}
+}
+
+// TestDHParamRefusesToClobber verifies that with skipIfExists set, an
+// existing 'dhparam-pem' entry survives and the collision is reported.
+func TestDHParamRefusesToClobber(t *testing.T) {
+	t.Parallel()
+
+	s := vault.NewSecret()
+	if err := s.Set("dhparam-pem", "keep-me", false); err != nil {
+		t.Fatalf("seed 'dhparam-pem': %v", err)
+	}
+	if err := s.DHParam(1024, true); err == nil {
+		t.Fatal("expected an error for an existing 'dhparam-pem', got nil")
+	}
+	if got := s.Get("dhparam-pem"); got != "keep-me" {
+		t.Errorf("'dhparam-pem' was clobbered: %q", got)
+	}
+}

--- a/pkg/vault/secret_keypair_test.go
+++ b/pkg/vault/secret_keypair_test.go
@@ -1,0 +1,128 @@
+// Black-box tests for Secret.RSAKey and Secret.SSHKey (secret.go), the two
+// generators that store a keypair in a secret. Between them they also cover
+// the keypair() helper both methods share: RSAKey stores no fingerprint,
+// SSHKey does, and both refuse to clobber existing keys when asked not to.
+package vault_test
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"regexp"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+	"golang.org/x/crypto/ssh"
+)
+
+// TestRSAKeyStoresPrivateAndPublicOnly verifies RSAKey stores the keypair
+// under 'private' and 'public', and — unlike SSHKey — no fingerprint.
+func TestRSAKeyStoresPrivateAndPublicOnly(t *testing.T) {
+	t.Parallel()
+
+	s := vault.NewSecret()
+	if err := s.RSAKey(2048, false); err != nil {
+		t.Fatalf("RSAKey(2048): %v", err)
+	}
+
+	if !s.Has("private") {
+		t.Error("secret has no 'private' key")
+	}
+	if !s.Has("public") {
+		t.Error("secret has no 'public' key")
+	}
+	if s.Has("fingerprint") {
+		t.Error("RSAKey stored a 'fingerprint'; only SSHKey should")
+	}
+}
+
+// TestRSAKeyStoredPairMatches verifies the stored private and public halves
+// parse and belong to each other, at the requested size.
+func TestRSAKeyStoredPairMatches(t *testing.T) {
+	t.Parallel()
+
+	s := vault.NewSecret()
+	if err := s.RSAKey(2048, false); err != nil {
+		t.Fatalf("RSAKey(2048): %v", err)
+	}
+
+	privBlock, _ := pem.Decode([]byte(s.Get("private")))
+	if privBlock == nil {
+		t.Fatal("'private' is not a PEM block")
+	}
+	priv, err := x509.ParsePKCS1PrivateKey(privBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse 'private': %v", err)
+	}
+	if got := priv.N.BitLen(); got != 2048 {
+		t.Errorf("key size = %d bits; want 2048", got)
+	}
+
+	pubBlock, _ := pem.Decode([]byte(s.Get("public")))
+	if pubBlock == nil {
+		t.Fatal("'public' is not a PEM block")
+	}
+	pub, err := x509.ParsePKIXPublicKey(pubBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse 'public': %v", err)
+	}
+	if !priv.PublicKey.Equal(pub) {
+		t.Error("'public' does not match the public half of 'private'")
+	}
+}
+
+// TestSSHKeyStoresKeypairWithFingerprint verifies SSHKey stores 'private',
+// an authorized_keys-format 'public', and an MD5 colon-hex 'fingerprint'.
+func TestSSHKeyStoresKeypairWithFingerprint(t *testing.T) {
+	t.Parallel()
+
+	s := vault.NewSecret()
+	if err := s.SSHKey(2048, false); err != nil {
+		t.Fatalf("SSHKey(2048): %v", err)
+	}
+
+	if !s.Has("private") {
+		t.Error("secret has no 'private' key")
+	}
+	if _, _, _, _, err := ssh.ParseAuthorizedKey([]byte(s.Get("public"))); err != nil {
+		t.Errorf("'public' is not an authorized_keys line: %v", err)
+	}
+
+	pattern := regexp.MustCompile(`^[0-9a-f]{2}(?::[0-9a-f]{2}){15}$`)
+	if fp := s.Get("fingerprint"); !pattern.MatchString(fp) {
+		t.Errorf("fingerprint %q does not match MD5 colon-hex pattern", fp)
+	}
+}
+
+// TestKeypairRefusesToClobber verifies that with skipIfExists set, an
+// existing 'private', 'public', or 'fingerprint' entry survives and the
+// generator reports the collision instead of overwriting.
+func TestKeypairRefusesToClobber(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		existing string
+		generate func(s *vault.Secret) error
+	}{
+		{"rsa private", "private", func(s *vault.Secret) error { return s.RSAKey(2048, true) }},
+		{"rsa public", "public", func(s *vault.Secret) error { return s.RSAKey(2048, true) }},
+		{"ssh fingerprint", "fingerprint", func(s *vault.Secret) error { return s.SSHKey(2048, true) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := vault.NewSecret()
+			if err := s.Set(tt.existing, "keep-me", false); err != nil {
+				t.Fatalf("seed %q: %v", tt.existing, err)
+			}
+			if err := tt.generate(s); err == nil {
+				t.Fatalf("expected an error for existing %q, got nil", tt.existing)
+			}
+			if got := s.Get(tt.existing); got != "keep-me" {
+				t.Errorf("%q was clobbered: %q", tt.existing, got)
+			}
+		})
+	}
+}

--- a/pkg/vault/x509_saveto_test.go
+++ b/pkg/vault/x509_saveto_test.go
@@ -1,0 +1,98 @@
+package vault_test
+
+// X509.SaveTo (x509.go) is how every x509 command persists a certificate:
+// it renders the certificate as a secret and writes it at the given path.
+// It had no coverage. Verified against the fake Vault from
+// httptest_helper_test.go: a CA lands with its serial and CRL beside the
+// certificate, a leaf without them, and a write the Vault refuses surfaces
+// as an error instead of vanishing.
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// TestSaveToWritesCASecret verifies saving a CA stores certificate, key,
+// and combined entries plus the CA-only serial and crl entries, and that
+// the stored certificate is the CA's own.
+func TestSaveToWritesCASecret(t *testing.T) {
+	t.Parallel()
+
+	v, fv := newTestVault(t)
+	ca := signingCA(t)
+
+	if err := ca.SaveTo(v, "secret/x509/ca", false); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	kv := mustGetSecret(t, fv, "secret/x509/ca")
+	for _, key := range []string{"certificate", "key", "combined", "serial", "crl"} {
+		if kv[key] == "" {
+			t.Errorf("stored CA secret has no %q entry", key)
+		}
+	}
+
+	block, _ := pem.Decode([]byte(kv["certificate"]))
+	if block == nil {
+		t.Fatal("stored certificate is not a PEM block")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse stored certificate: %v", err)
+	}
+	if got, want := cert.Subject.CommonName, ca.Certificate.Subject.CommonName; got != want {
+		t.Errorf("stored certificate CN = %q; want %q", got, want)
+	}
+}
+
+// TestSaveToLeafOmitsCAEntries verifies a certificate that is not a CA is
+// stored without the serial and crl entries only an authority carries.
+func TestSaveToLeafOmitsCAEntries(t *testing.T) {
+	t.Parallel()
+
+	v, fv := newTestVault(t)
+	ca := signingCA(t)
+	leaf, err := vault.NewCertificate("CN=leaf", []string{"leaf"},
+		[]string{"server_auth"}, "", vault.KeySpec{Algorithm: "rsa", Bits: 2048})
+	if err != nil {
+		t.Fatalf("NewCertificate: %v", err)
+	}
+	if err := ca.Sign(leaf, time.Hour); err != nil {
+		t.Fatalf("sign leaf: %v", err)
+	}
+
+	if err := leaf.SaveTo(v, "secret/x509/leaf", false); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	kv := mustGetSecret(t, fv, "secret/x509/leaf")
+	for _, key := range []string{"certificate", "key", "combined"} {
+		if kv[key] == "" {
+			t.Errorf("stored leaf secret has no %q entry", key)
+		}
+	}
+	for _, key := range []string{"serial", "crl"} {
+		if _, ok := kv[key]; ok {
+			t.Errorf("stored leaf secret has a %q entry; only a CA should", key)
+		}
+	}
+}
+
+// TestSaveToSurfacesWriteErrors verifies a path the Vault cannot be written
+// at — here the path:key notation Write rejects — comes back as an error
+// and leaves nothing behind.
+func TestSaveToSurfacesWriteErrors(t *testing.T) {
+	t.Parallel()
+
+	v, fv := newTestVault(t)
+	ca := signingCA(t)
+
+	if err := ca.SaveTo(v, "secret/x509/ca:certificate", false); err == nil {
+		t.Fatal("expected an error writing to a path:key path, got nil")
+	}
+	secretAbsent(t, fv, "secret/x509/ca")
+}

--- a/pkg/vault/x509_subject_format_test.go
+++ b/pkg/vault/x509_subject_format_test.go
@@ -1,0 +1,115 @@
+package vault_test
+
+// X509.Subject, Issuer, and IntermediarySubject render distinguished names
+// through formatSubject (x509.go), and that rendering is what `x509 show`
+// and `x509 validate` print for a certificate and what error messages name
+// a signer by. None of it was covered. The contract: fields appear as
+// key=value pairs in cn, c, st, l, o, ou order, absent fields are left out,
+// and the result is a subject string safe's own ParseSubject accepts.
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// TestSubjectRendersAllFieldsInOrder verifies every supported field of a
+// distinguished name comes back, in the fixed cn,c,st,l,o,ou order.
+func TestSubjectRendersAllFieldsInOrder(t *testing.T) {
+	t.Parallel()
+
+	c, err := vault.NewCertificate("/cn=foo.example/c=US/st=NY/l=Buffalo/o=Stark & Wayne/ou=R&D",
+		[]string{"foo.example"}, []string{"server_auth"}, "",
+		vault.KeySpec{Algorithm: "rsa", Bits: 2048})
+	if err != nil {
+		t.Fatalf("NewCertificate: %v", err)
+	}
+
+	want := "cn=foo.example,c=US,st=NY,l=Buffalo,o=Stark & Wayne,ou=R&D"
+	if got := c.Subject(); got != want {
+		t.Errorf("Subject() = %q; want %q", got, want)
+	}
+}
+
+// TestSubjectOmitsAbsentFields verifies fields the name does not carry
+// leave no trace — no empty pairs, no stray separators.
+func TestSubjectOmitsAbsentFields(t *testing.T) {
+	t.Parallel()
+
+	c, err := vault.NewCertificate("CN=only-a-name",
+		[]string{"only-a-name"}, []string{"server_auth"}, "",
+		vault.KeySpec{Algorithm: "rsa", Bits: 2048})
+	if err != nil {
+		t.Fatalf("NewCertificate: %v", err)
+	}
+
+	if got := c.Subject(); got != "cn=only-a-name" {
+		t.Errorf("Subject() = %q; want %q", got, "cn=only-a-name")
+	}
+}
+
+// TestSubjectRoundTripsThroughParseSubject verifies the rendered subject is
+// accepted by ParseSubject and comes back as the same name, so a subject
+// safe prints can be handed straight back to `x509 issue`.
+func TestSubjectRoundTripsThroughParseSubject(t *testing.T) {
+	t.Parallel()
+
+	c, err := vault.NewCertificate("/cn=round.trip/c=US/o=Stark & Wayne",
+		[]string{"round.trip"}, []string{"server_auth"}, "",
+		vault.KeySpec{Algorithm: "rsa", Bits: 2048})
+	if err != nil {
+		t.Fatalf("NewCertificate: %v", err)
+	}
+
+	name, err := vault.ParseSubject(c.Subject())
+	if err != nil {
+		t.Fatalf("ParseSubject(%q): %v", c.Subject(), err)
+	}
+	reparsed := vault.X509{Certificate: &x509.Certificate{Subject: name}}
+	if got := reparsed.Subject(); got != c.Subject() {
+		t.Errorf("round-tripped subject = %q; want %q", got, c.Subject())
+	}
+}
+
+// TestIssuerNamesTheSigningCA verifies Issuer() renders the subject of the
+// CA that signed the certificate, not the certificate's own.
+func TestIssuerNamesTheSigningCA(t *testing.T) {
+	t.Parallel()
+
+	ca := signingCA(t)
+	leaf, err := vault.NewCertificate("CN=leaf", []string{"leaf"},
+		[]string{"server_auth"}, "", vault.KeySpec{Algorithm: "rsa", Bits: 2048})
+	if err != nil {
+		t.Fatalf("NewCertificate: %v", err)
+	}
+	if err := ca.Sign(leaf, time.Hour); err != nil {
+		t.Fatalf("sign leaf: %v", err)
+	}
+	parsed, err := x509.ParseCertificate(leaf.Certificate.Raw)
+	if err != nil {
+		t.Fatalf("parse the signed leaf: %v", err)
+	}
+	leaf.Certificate = parsed
+
+	if got := leaf.Issuer(); got != ca.Subject() {
+		t.Errorf("Issuer() = %q; want the CA's subject %q", got, ca.Subject())
+	}
+	if got := leaf.Subject(); got != "cn=leaf" {
+		t.Errorf("Subject() = %q; want %q", got, "cn=leaf")
+	}
+}
+
+// TestIntermediarySubjectNamesTheChain verifies IntermediarySubject renders
+// the subject of the n-th certificate read from the chain stored alongside
+// the leading one — what `x509 show` lists under "via".
+func TestIntermediarySubjectNamesTheChain(t *testing.T) {
+	t.Parallel()
+
+	inter, root := chained(t)
+
+	if got, want := inter.IntermediarySubject(0), root.Subject(); got != want {
+		t.Errorf("IntermediarySubject(0) = %q; want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What

Adds behavior-focused tests for the pure/crypto helpers in `pkg/vault` that had no coverage at all:

- `rsa.go` — `rsakey` (0% → 77.8%)
- `secret.go` — `DHParam` (0% → 100%), `keypair` (0% → 100%), `RSAKey` (0% → 75%), `SSHKey` (0% → 75%)
- `x509.go` — `formatSubject` (0% → 100%), `Subject` (0% → 100%), `Issuer` (0% → 100%), `IntermediarySubject` (0% → 100%), `SaveTo` (0% → 75%)

Package coverage rises from 72.2% to 75.1%. The remaining uncovered lines are error branches that require `rsa.GenerateKey` or key marshalling to fail.

New test files:

- `pkg/vault/rsakey_test.go` — white-box: `rsakey` emits a parseable PKCS#1 private PEM and a PKIX public PEM that belong to each other at the requested size
- `pkg/vault/secret_keypair_test.go` — `RSAKey` stores `private`/`public` (and no fingerprint), `SSHKey` adds an authorized_keys line and MD5 colon-hex fingerprint, and both honor the no-clobber contract (covering `keypair`)
- `pkg/vault/secret_dhparam_test.go` — `DHParam` stores a parseable `DH PARAMETERS` block under `dhparam-pem` (1024 bits, the smallest accepted size, keeps generation fast), rejects unsupported sizes, and refuses to clobber
- `pkg/vault/x509_subject_format_test.go` — subjects render as `key=value` pairs in the fixed `cn,c,st,l,o,ou` order with absent fields left out, `Issuer` names the signing CA, `IntermediarySubject` names the stored chain, and the output round-trips through `ParseSubject`
- `pkg/vault/x509_saveto_test.go` — against the existing fake Vault: a saved CA carries `certificate`/`key`/`combined`/`serial`/`crl`, a leaf omits the CA-only entries, and a refused write surfaces as an error

No production code changes; no new dependencies.

## Why

These helpers back `safe rsa`, `safe ssh`, `safe dhparam`, and every `safe x509` command, but nothing pinned their contracts: the key format stored in a secret, the subject string `x509 show` prints, or what `SaveTo` writes for a CA versus a leaf. Regressions here would only have shown up against a live Vault.

## Verification

- `make check` — lint, vet, staticcheck, full test suite, engine helper tests: all green
- `go test -race -count=1 ./...` — all packages pass under the race detector
- `go tool cover -func` confirms every listed function moved off 0%
