### PR TITLE
Cover remaining untested cli and prompt code

### DIFF
--- a/internal/cli/option_cmd_test.go
+++ b/internal/cli/option_cmd_test.go
@@ -1,0 +1,170 @@
+package cli
+
+// `safe option' reads and writes the options block of ~/.saferc. With no
+// arguments it lists every option and its value; given option=value pairs it
+// flips them and persists the result. These tests run the handler in-process
+// against an isolated home, so nothing they read or write is the developer's
+// own ~/.saferc.
+//
+// captureStdout mutates the process-global os.Stdout — do NOT add t.Parallel
+// to any test in this file.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOptionWithNoArgsListsEveryOption(t *testing.T) {
+	isolateHome(t)
+	c := newTestCLI(t)
+
+	var err error
+	out := captureStdout(t, func() {
+		err = c.cmdOption("option")
+	})
+	if err != nil {
+		t.Fatalf("cmdOption: %v", err)
+	}
+	if !strings.Contains(out, "manage_vault_token") {
+		t.Errorf("the listing does not name manage_vault_token:\n%s", out)
+	}
+	if !strings.Contains(out, "false") {
+		t.Errorf("an unset option should list as false:\n%s", out)
+	}
+}
+
+func TestOptionListingReflectsTheStoredValue(t *testing.T) {
+	isolateHome(t)
+	writeSaferc(t, `version: 1
+current: ""
+vaults: {}
+options:
+  manage_vault_token: true
+`)
+	c := newTestCLI(t)
+
+	out := captureStdout(t, func() {
+		if err := c.cmdOption("option"); err != nil {
+			t.Fatalf("cmdOption: %v", err)
+		}
+	})
+	if !strings.Contains(out, "true") {
+		t.Errorf("manage_vault_token is stored true but lists as:\n%s", out)
+	}
+}
+
+func TestOptionSetsAndPersistsAValue(t *testing.T) {
+	isolateHome(t)
+	c := newTestCLI(t)
+
+	out := captureStdout(t, func() {
+		if err := c.cmdOption("option", "manage_vault_token=true"); err != nil {
+			t.Fatalf("cmdOption: %v", err)
+		}
+	})
+	if !strings.Contains(out, "updated") || !strings.Contains(out, "manage_vault_token") {
+		t.Errorf("setting an option should say which one was updated:\n%s", out)
+	}
+
+	cfg := readConfig(t)
+	if !cfg.Options.ManageVaultToken {
+		t.Error("manage_vault_token=true was not persisted to ~/.saferc")
+	}
+}
+
+func TestOptionTurnsAValueBackOff(t *testing.T) {
+	isolateHome(t)
+	writeSaferc(t, `version: 1
+current: ""
+vaults: {}
+options:
+  manage_vault_token: true
+`)
+	c := newTestCLI(t)
+
+	captureStdout(t, func() {
+		if err := c.cmdOption("option", "manage_vault_token=off"); err != nil {
+			t.Fatalf("cmdOption: %v", err)
+		}
+	})
+
+	if readConfig(t).Options.ManageVaultToken {
+		t.Error("manage_vault_token=off left the option on in ~/.saferc")
+	}
+}
+
+// The option is stored with underscores, but hyphens are how flags are
+// usually spelled, so both spellings name the same option.
+func TestOptionAcceptsHyphensForUnderscores(t *testing.T) {
+	isolateHome(t)
+	c := newTestCLI(t)
+
+	captureStdout(t, func() {
+		if err := c.cmdOption("option", "manage-vault-token=yes"); err != nil {
+			t.Fatalf("cmdOption: %v", err)
+		}
+	})
+
+	if !readConfig(t).Options.ManageVaultToken {
+		t.Error("manage-vault-token=yes was not persisted to ~/.saferc")
+	}
+}
+
+func TestOptionRejectsAnArgWithoutAValue(t *testing.T) {
+	isolateHome(t)
+	c := newTestCLI(t)
+
+	err := c.cmdOption("option", "manage_vault_token")
+	if err == nil {
+		t.Fatal("an arg with no = should be an error")
+	}
+	if !strings.Contains(err.Error(), "option=value") {
+		t.Errorf("the error should show the expected syntax, got: %v", err)
+	}
+}
+
+func TestOptionRejectsAValueThatIsNotBoolean(t *testing.T) {
+	isolateHome(t)
+	c := newTestCLI(t)
+
+	err := c.cmdOption("option", "manage_vault_token=maybe")
+	if err == nil {
+		t.Fatal("a value that is not true/false should be an error")
+	}
+	if !strings.Contains(err.Error(), "true|on|yes|false|off|no") {
+		t.Errorf("the error should list the accepted values, got: %v", err)
+	}
+}
+
+func TestOptionRejectsAnOptionSafeDoesNotHave(t *testing.T) {
+	isolateHome(t)
+	c := newTestCLI(t)
+
+	err := c.cmdOption("option", "no_such_option=true")
+	if err == nil {
+		t.Fatal("an unknown option should be an error")
+	}
+	if !strings.Contains(err.Error(), "no_such_option") {
+		t.Errorf("the error should name the unknown option, got: %v", err)
+	}
+}
+
+// A bad pair must not take effect: an unknown option or a value that does not
+// parse leaves ~/.saferc as it was, even when an earlier pair on the same
+// command line was good.
+func TestOptionDoesNotPersistWhenALaterArgIsBad(t *testing.T) {
+	isolateHome(t)
+	c := newTestCLI(t)
+
+	var err error
+	captureStdout(t, func() {
+		err = c.cmdOption("option", "manage_vault_token=true", "bogus=true")
+	})
+	if err == nil {
+		t.Fatal("a bad pair should fail the command")
+	}
+
+	if readConfig(t).Options.ManageVaultToken {
+		t.Error("a failed command wrote the earlier pair to ~/.saferc")
+	}
+}

--- a/internal/cli/recursively_test.go
+++ b/internal/cli/recursively_test.go
@@ -1,0 +1,64 @@
+package cli
+
+// recursively is the confirmation gate in front of every recursive delete,
+// move, and copy: it asks, names the command and the paths it is about to
+// touch, and only a plain yes lets the command proceed.
+//
+// prompt.SetReader and captureStderr both mutate process-global state — do
+// NOT add t.Parallel to any test in this file. An empty input is not tested
+// because exhausting the prompt's input ends the process.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/prompt"
+)
+
+func TestRecursivelyAcceptsOnlyYes(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"y\n", true},
+		{"yes\n", true},
+		{"  y  \n", true}, // surrounding whitespace is not a refusal
+		{"n\n", false},
+		{"no\n", false},
+		{"Y\n", false}, // consent is spelled in lowercase
+		{"YES\n", false},
+		{"yeah\n", false},
+		{"\n", false}, // just pressing enter is not consent
+	}
+	for _, tc := range tests {
+		t.Run(strings.TrimSpace(tc.input), func(t *testing.T) {
+			prompt.SetReader(strings.NewReader(tc.input))
+			t.Cleanup(func() { prompt.SetReader(nil) })
+
+			var got bool
+			captureStderr(t, func() {
+				got = recursively("delete", "secret/a")
+			})
+			if got != tc.want {
+				t.Errorf("recursively with input %q = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// The question names the command and every path it was given, because a
+// prompt that does not say what it is about to do is not one anyone can
+// answer.
+func TestRecursivelyNamesTheCommandAndPaths(t *testing.T) {
+	prompt.SetReader(strings.NewReader("n\n"))
+	t.Cleanup(func() { prompt.SetReader(nil) })
+
+	out := captureStderr(t, func() {
+		recursively("move", "secret/from", "secret/to")
+	})
+	for _, want := range []string{"Recursively", "move", "secret/from secret/to", "(y/n)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the prompt is missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/cli/sig.go
+++ b/internal/cli/sig.go
@@ -9,6 +9,10 @@ import (
 )
 
 func Signals() {
+	//When stdin is not a terminal there is no state to put back, and prev is
+	// nil. Restore dereferences the state it is handed, so restoring nil
+	// turned the clean exit below into a panic: a piped safe that caught
+	// Ctrl-C died of a nil pointer instead of leaving with status 1.
 	prev, err := term.GetState(int(os.Stdin.Fd()))
 	if err != nil {
 		prev = nil
@@ -17,7 +21,9 @@ func Signals() {
 	s := make(chan os.Signal, 1)
 	signal.Notify(s, syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT)
 	for range s {
-		_ = term.Restore(int(os.Stdin.Fd()), prev)
+		if prev != nil {
+			_ = term.Restore(int(os.Stdin.Fd()), prev)
+		}
 		os.Exit(1)
 	}
 }

--- a/internal/cli/sig_smoke_test.go
+++ b/internal/cli/sig_smoke_test.go
@@ -1,0 +1,109 @@
+package cli
+
+// Signals waits for SIGTERM, SIGINT, or SIGQUIT, puts the terminal back the
+// way it was found, and exits 1. The exit is the observable part, and it can
+// only be seen from outside: a process that dies of the signal itself reports
+// no exit code at all, while one that catches it leaves with status 1. These
+// tests park safe at an interactive prompt and interrupt it.
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// interruptAtThePrompt starts safe target -i against a home with one Vault
+// configured, waits for the prompt that reads from stdin, and delivers sig.
+// It returns the exit status and whether the process exited on its own
+// rather than being killed by the signal.
+func interruptAtThePrompt(t *testing.T, sig syscall.Signal) (status int, exited bool) {
+	t.Helper()
+
+	home := t.TempDir()
+	saferc := `version: 1
+current: alpha
+vaults:
+  alpha:
+    url: https://alpha.example.com
+    token: token-alpha
+`
+	if err := os.WriteFile(filepath.Join(home, ".saferc"), []byte(saferc), 0600); err != nil {
+		t.Fatalf("write .saferc: %v", err)
+	}
+
+	cmd := exec.Command(safeBinary(t), "target", "-i")
+	cmd.Env = append(os.Environ(), "HOME="+home, "SAFE_TARGET=", "VAULT_ADDR=", "VAULT_TOKEN=")
+
+	// stdin stays open so the prompt blocks instead of hitting EOF.
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	defer func() { _ = stdin.Close() }()
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting safe target -i: %v", err)
+	}
+	// A process that never reaches the prompt, or never dies, should fail
+	// the test rather than hang it.
+	killer := time.AfterFunc(30*time.Second, func() { _ = cmd.Process.Kill() })
+	defer killer.Stop()
+
+	// Wait until safe is at the prompt, reading stdin, before signaling.
+	var seen strings.Builder
+	buf := make([]byte, 1)
+	for !strings.Contains(seen.String(), "Which Vault") {
+		n, err := stderr.Read(buf)
+		seen.Write(buf[:n])
+		if err != nil {
+			t.Fatalf("safe never asked which Vault to target; stderr so far:\n%s", seen.String())
+		}
+	}
+
+	if err := cmd.Process.Signal(sig); err != nil {
+		t.Fatalf("delivering %v: %v", sig, err)
+	}
+	_, _ = io.Copy(io.Discard, stderr)
+
+	var exitErr *exec.ExitError
+	switch err := cmd.Wait(); {
+	case err == nil:
+		return 0, true
+	case errors.As(err, &exitErr):
+		ws, ok := exitErr.Sys().(syscall.WaitStatus)
+		return exitErr.ExitCode(), ok && ws.Exited()
+	default:
+		t.Fatalf("waiting on safe: %v", err)
+		return 0, false
+	}
+}
+
+// An interrupted safe leaves with exit status 1 -- its own exit, not death by
+// the signal, so anything it has to put back on the way out gets put back.
+func TestASignalEndsSafeWithExitStatusOne(t *testing.T) {
+	for name, sig := range map[string]syscall.Signal{
+		"SIGTERM": syscall.SIGTERM,
+		"SIGINT":  syscall.SIGINT,
+	} {
+		t.Run(name, func(t *testing.T) {
+			status, exited := interruptAtThePrompt(t, sig)
+			if !exited {
+				t.Fatalf("safe was killed by %s instead of catching it", name)
+			}
+			if status != 1 {
+				t.Errorf("safe exited %d on %s, want 1", status, name)
+			}
+		})
+	}
+}

--- a/internal/cli/target_interactive_test.go
+++ b/internal/cli/target_interactive_test.go
@@ -1,0 +1,91 @@
+package cli
+
+// `safe target -i' walks the list of known Vaults and asks which one to
+// point at. With nothing on the list there is nothing to choose from, so it
+// explains how to target a Vault manually and leaves with status 1 -- an
+// exit, so that branch is pinned from outside the process. With Vaults on
+// the list it keeps asking until it is given a name it knows.
+//
+// prompt.SetReader and captureStderr both mutate process-global state -- do
+// NOT add t.Parallel to any test in this file.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/prompt"
+)
+
+// With no Vaults targeted yet there is no menu to offer: interactive
+// targeting turns into instructions and a failure, not a prompt that could
+// only be answered wrongly.
+func TestInteractiveTargetWithNoVaultsExplainsAndFails(t *testing.T) {
+	stdout, stderr, status := run(t, "target", "-i")
+	if status != 1 {
+		t.Errorf("safe target -i with no Vaults exited %d, want 1", status)
+	}
+	if !strings.Contains(stderr, "No Vaults have been targeted yet.") {
+		t.Errorf("stderr does not say there is nothing to choose from:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "safe target ops https://address.of.your.vault") {
+		t.Errorf("stderr does not show how to target a Vault manually:\n%s", stderr)
+	}
+	if strings.Contains(stdout+stderr, "Which Vault") {
+		t.Errorf("safe asked which Vault to target with none to offer:\n%s", stdout+stderr)
+	}
+}
+
+func TestInteractiveTargetSelectsAndPersistsTheAnswer(t *testing.T) {
+	isolateHome(t)
+	twoAliasedTargets(t)
+	c := newTestCLI(t)
+	c.opt.Target.Interactive = true
+
+	prompt.SetReader(strings.NewReader("alpha\n"))
+	t.Cleanup(func() { prompt.SetReader(nil) })
+
+	var err error
+	out := captureStderr(t, func() {
+		err = c.cmdTarget("target")
+	})
+	if err != nil {
+		t.Fatalf("cmdTarget: %v", err)
+	}
+	if !strings.Contains(out, "Which Vault") {
+		t.Errorf("the prompt never asked which Vault to target:\n%s", out)
+	}
+	if !strings.Contains(out, "Now targeting") {
+		t.Errorf("the answer was never confirmed:\n%s", out)
+	}
+
+	if cfg := readConfig(t); cfg.Current != "alpha" {
+		t.Errorf("current = %q, want alpha written to ~/.saferc", cfg.Current)
+	}
+}
+
+// A name safe does not know is not the end of the conversation: the mistake
+// is reported and the question asked again.
+func TestInteractiveTargetAsksAgainAfterAnUnknownName(t *testing.T) {
+	isolateHome(t)
+	twoAliasedTargets(t)
+	c := newTestCLI(t)
+	c.opt.Target.Interactive = true
+
+	prompt.SetReader(strings.NewReader("gamma\nbeta\n"))
+	t.Cleanup(func() { prompt.SetReader(nil) })
+
+	var err error
+	out := captureStderr(t, func() {
+		err = c.cmdTarget("target")
+	})
+	if err != nil {
+		t.Fatalf("cmdTarget: %v", err)
+	}
+	if !strings.Contains(out, "Unknown target 'gamma'") {
+		t.Errorf("the unknown name was not reported:\n%s", out)
+	}
+
+	if cfg := readConfig(t); cfg.Current != "beta" {
+		t.Errorf("current = %q, want beta -- the answer given after the mistake", cfg.Current)
+	}
+}

--- a/internal/cli/version_help_smoke_test.go
+++ b/internal/cli/version_help_smoke_test.go
@@ -1,0 +1,106 @@
+package cli
+
+// The version, help, and commands handlers end in os.Exit, so their exit
+// status and what they leave on each stream can only be read from outside the
+// process. main_smoke_test.go pins where their output goes; these tests pin
+// what the version says about the build it came from and how help finds its
+// topics.
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A binary built without version metadata says so, rather than claiming a
+// version it does not have.
+func TestVersionOfADevelopmentBuild(t *testing.T) {
+	stdout, _, status := run(t, "version")
+	if status != 0 {
+		t.Errorf("safe version exited %d, want 0", status)
+	}
+	if !strings.Contains(stdout, "development build") {
+		t.Errorf("a build with no version should say development build, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "commit") || strings.Contains(stdout, "built") {
+		t.Errorf("a build with no metadata should not print commit or build lines:\n%s", stdout)
+	}
+}
+
+// A released binary carries its version, commit, and build time, set through
+// -ldflags at build time, and safe version reads them all back.
+func TestVersionReportsBuildMetadata(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "safe")
+	build := exec.Command("go", "build",
+		"-ldflags", "-X main.Version=1.2.3 -X main.GitCommit=abc1234 -X main.BuildTime=2026-07-31T00:00:00Z",
+		"-o", bin, "github.com/cloudfoundry-community/safe/cmd/safe")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(bin, "version")
+	cmd.Env = append(os.Environ(), "HOME="+t.TempDir(), "SAFE_TARGET=", "VAULT_ADDR=", "VAULT_TOKEN=")
+	var out, errOut strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+
+	var exitErr *exec.ExitError
+	switch err := cmd.Run(); {
+	case err == nil:
+	case errors.As(err, &exitErr):
+		t.Errorf("safe version exited %d, want 0", exitErr.ExitCode())
+	default:
+		t.Fatalf("running safe version: %v", err)
+	}
+
+	stdout := out.String()
+	for _, want := range []string{"safe v1.2.3", "commit abc1234", "built", "2026-07-31T00:00:00Z"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("safe version output is missing %q:\n%s", want, stdout)
+		}
+	}
+	if errOut.Len() != 0 {
+		t.Errorf("safe version wrote to standard error: %q", errOut.String())
+	}
+}
+
+// help with nothing to look up answers with the command listing, the same
+// answer safe commands gives.
+func TestHelpWithNoTopicGivesTheListing(t *testing.T) {
+	stdout, stderr, status := run(t, "help")
+	if status != 0 {
+		t.Errorf("safe help exited %d, want 0", status)
+	}
+	if !strings.Contains(stdout, "Valid commands are:") {
+		t.Errorf("safe help printed no listing on standard output; standard error had:\n%s", stderr)
+	}
+}
+
+// Sub-commands are registered under two-word names, and help joins its
+// arguments back together to find them: safe help target delete is the topic
+// `target delete', not the topic `target' with an argument.
+func TestHelpJoinsAMultiWordTopic(t *testing.T) {
+	stdout, stderr, status := run(t, "help", "target", "delete")
+	if status != 0 {
+		t.Errorf("safe help target delete exited %d, want 0:\n%s", status, stdout+stderr)
+	}
+	if !strings.Contains(stdout, "target delete") {
+		t.Errorf("the topic printed does not name target delete:\n%s", stdout)
+	}
+}
+
+// safe commands and safe help commands are the same topic reached two ways,
+// so they answer alike.
+func TestCommandsMatchesHelpCommands(t *testing.T) {
+	direct, _, directStatus := run(t, "commands")
+	viaHelp, _, helpStatus := run(t, "help", "commands")
+	if directStatus != 0 || helpStatus != 0 {
+		t.Fatalf("exited %d and %d, want 0 and 0", directStatus, helpStatus)
+	}
+	if direct != viaHelp {
+		t.Errorf("safe commands and safe help commands disagree:\n--- commands ---\n%s\n--- help commands ---\n%s", direct, viaHelp)
+	}
+}

--- a/pkg/prompt/password_test.go
+++ b/pkg/prompt/password_test.go
@@ -1,0 +1,71 @@
+package prompt
+
+// readPassword turns off terminal echo, which is only possible on a
+// terminal. Its callers guard the call with an isatty check, so the contract
+// worth pinning here is what happens when that guard is bypassed: a stdin
+// that is not a terminal is an error handed back to the caller, never a
+// silent empty string that could be mistaken for a password someone typed.
+// The echo-off success path needs a real TTY and is exercised by hand, not
+// here.
+//
+// These tests swap the process-global os.Stdin and os.Stderr -- do NOT add
+// t.Parallel.
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// swapStdinWithPipe points os.Stdin at the read end of a fresh pipe and
+// restores it via t.Cleanup.
+func swapStdinWithPipe(t *testing.T) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = orig
+		_ = r.Close()
+		_ = w.Close()
+	})
+}
+
+func TestReadPasswordRefusesAStdinThatIsNotATerminal(t *testing.T) {
+	swapStdinWithPipe(t)
+
+	er, ew, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	origErr := os.Stderr
+	os.Stderr = ew
+	t.Cleanup(func() { os.Stderr = origErr })
+
+	got, readErr := readPassword("Passphrase @Y{(hidden)}: ")
+
+	_ = ew.Close()
+	os.Stderr = origErr
+	buf := make([]byte, 4096)
+	n, _ := er.Read(buf)
+	_ = er.Close()
+	stderr := string(buf[:n])
+
+	if readErr == nil {
+		t.Fatal("reading a password from a pipe should be an error")
+	}
+	if got != "" {
+		t.Errorf("a failed read handed back %q, want nothing at all", got)
+	}
+	//The label was already on the screen when the read failed, and the
+	// newline after it keeps whatever is printed next off the prompt's line.
+	if !strings.Contains(stderr, "Passphrase") {
+		t.Errorf("the prompt label never printed; stderr was %q", stderr)
+	}
+	if !strings.HasSuffix(stderr, "\n") {
+		t.Errorf("stderr should end with a newline, got %q", stderr)
+	}
+}


### PR DESCRIPTION
## What

Adds tests for the remaining zero-coverage code in `internal/cli` and `pkg/prompt`, and fixes a nil-pointer panic those tests uncovered in the signal handler.

- `cmdOption` (`internal/cli/secrets.go`) — in-process tests: the no-argument listing, setting and persisting `manage_vault_token`, the hyphen/underscore spelling equivalence, and the rejects (missing `=`, non-boolean value, unknown option). Also pins that a rejected pair keeps the whole command from writing `~/.saferc`.
- `cmdVersion` / `cmdHelp` / `cmdCommands` (`internal/cli/misc.go`) — these end in `os.Exit`, so they are exercised as subprocesses via the existing `safeBinary(t)` pattern: a development build says so and prints no commit/built lines; a build carrying `-ldflags` metadata reads back version, commit, and build time on stdout; `safe help` with no topic gives the listing; multi-word arguments join into one topic (`safe help target delete`); `safe commands` and `safe help commands` answer identically. These complement the stdout/stderr routing and exit-code tests already in `main_smoke_test.go`.
- `recursively` (`internal/cli/cli.go`) — in-process: only lowercase `y`/`yes` (whitespace-trimmed) reads as consent; `Y`, `YES`, `yeah`, and a bare enter do not; the prompt names the command and the paths it is about to touch.
- `Signals` (`internal/cli/sig.go`) — subprocess: safe parked at the interactive target prompt catches SIGTERM/SIGINT and exits with status 1 of its own accord rather than being killed by the signal. Writing this test found a real bug (below).
- `readPassword` (`pkg/prompt/prompt.go`) — in-process: with stdin pointed at a pipe the read fails with an error instead of handing back a silent empty string, and the prompt line is closed off with a newline.
- Bonus: the `safe target -i` branch guarded by `len(cfg.Vaults) == 0` is pinned from both sides — no Vaults gives instructions and exit 1 without prompting (subprocess); with Vaults it prompts, reports an unknown name and asks again, and persists the accepted answer (in-process via `prompt.SetReader`).

## Bug found and fixed

`Signals` restores the terminal state it saved at startup before exiting. When stdin is not a terminal, `term.GetState` fails and the saved state is nil — but the handler still passed it to `term.Restore`, which dereferences it. Any piped or scripted `safe` that received Ctrl-C/SIGTERM/SIGQUIT died of a nil-pointer panic (SIGSEGV, exit status 2) instead of exiting 1. The fix skips the restore when there is nothing to restore; the new subprocess test pins the clean exit.

## Skipped, and why

- `readPassword` success path — turning terminal echo off requires a real TTY on stdin, and faking one needs a pty dependency (e.g. creack/pty), which this PR does not add. The non-TTY error contract is tested; the echo-off path remains manual.
- `readline`'s exit-on-EOF path (a pre-existing gap, noted in its own test file) is untouched: it ends the process from library code.

## Verification

- `make check` — green.
- `go test -race -count=1 ./...` — green.
- The `internal/cli` suite run three times concurrently — green each time. The new tests spawn no listeners and hard-code no ports; the only subprocesses are `safe` itself, blocked at a prompt or exiting immediately.
- `cmdOption`, `recursively`, `readPassword`, and `cmdTarget`'s interactive path leave the zero-coverage list in the in-process profile; `Signals` and the `os.Exit`-bound handlers are exercised as subprocesses, which the coverage profile does not count.
