### PR TITLE
Serialize .saferc writes and isolate safe local

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,24 @@ renewed is reported and the rest are renewed anyway; the command
 exits non-zero with a count of what failed.  `-T` names a single
 target and is ignored here.
 
+### Concurrent safes and ~/.saferc.lock
+
+Targets live in `~/.saferc`.  Every command that changes them —
+`safe target`, `safe auth`, `safe local`, and friends — rewrites
+that file, and concurrent safes coordinate those rewrites through
+a lock on a sidecar file, `~/.saferc.lock`.  The sidecar is a
+zero-byte file that is created on first use and never removed;
+there is nothing in it to clean up, and deleting it while safes
+are running reopens the window it closes.  Locks are released by
+the kernel when a process exits, so a killed safe cannot leave
+the file stuck.
+
+One caveat: on filesystems whose advisory locks do not span
+clients — NFS before v4 is the common case — safes on *different
+hosts* sharing one home directory are not serialized against each
+other.  Writes are still atomic there, so `~/.saferc` cannot be
+corrupted; a simultaneous change from another host can be lost.
+
 Proxies
 -------
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/cloudfoundry-community/goutils v0.0.0-20230124234059-1add95a6ecd7
 	github.com/cloudfoundry-community/vaultkv v0.7.0-rc2
+	github.com/gofrs/flock v0.13.0
 	github.com/jhunt/go-ansi v0.0.0-20180630013815-403d5f0d9ccb
 	github.com/jhunt/go-cli v0.0.0-20170503201019-f04a1744b5e3
 	github.com/jhunt/go-envirotron v0.0.0-20171017043611-8bdb90f72b39
@@ -26,8 +27,6 @@ require (
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/jhunt/go-snapshot v0.0.0-20170309042712-92984e0ad8d8 // indirect
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/cloudfoundry-community/vaultkv v0.7.0-rc2/go.mod h1:D17jAL9n2GS66nbap
 github.com/coreos/go-oidc/v3 v3.5.0/go.mod h1:ecXRtV4romGPeO6ieExAsUK9cb/3fp9hXNz1tlv8PIM=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.14.1/go.mod h1:2oHN61fhTpgcxD3TSWCgKDiH1+x4OiDVVGH8WlgGZGg=
@@ -18,6 +19,8 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-jose/go-jose/v3 v3.0.1/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
@@ -61,6 +64,7 @@ github.com/jhunt/go-envirotron v0.0.0-20171017043611-8bdb90f72b39/go.mod h1:QWmf
 github.com/jhunt/go-snapshot v0.0.0-20170309042712-92984e0ad8d8 h1:hejiJzi7jtU+jl0SnMozrS81wYkrNSvUGn0NQjVtVoU=
 github.com/jhunt/go-snapshot v0.0.0-20170309042712-92984e0ad8d8/go.mod h1:oNu1YULLxQcu77xYyAN0Xb2YbEspiSwDSn9kPW2zRKU=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -74,8 +78,6 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
-github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -89,8 +91,10 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -102,6 +106,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tredoe/osutil v0.0.0-20161130133508-7d3ee1afa71c h1:5q7IHeqvAA4hWR1CfpTOS7RFsTDC36TaSZ8Dvc00bPk=
 github.com/tredoe/osutil v0.0.0-20161130133508-7d3ee1afa71c/go.mod h1:M/I710pXKQToMdqt/D+mJ4QsnW6WDaajyB6DWFmDXBs=
 github.com/yhat/scrape v0.0.0-20161128144610-24b7890b0945/go.mod h1:4vRFPPNYllgCacoj+0FoKOjTW68rUhEfqPLiEJaK2w8=
@@ -215,8 +221,8 @@ google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
@@ -225,5 +231,6 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 mvdan.cc/gofumpt v0.5.0/go.mod h1:HBeVDtMKRZpXyxFciAirzdKklDlGu8aAy1wEbH5Y9js=

--- a/internal/cli/concurrency_test.go
+++ b/internal/cli/concurrency_test.go
@@ -1,0 +1,242 @@
+//go:build unix
+
+package cli
+
+// The ticket's evidence table, as tests: four concurrent `safe local`
+// processes sharing one $HOME used to leave one or two of four targets in
+// ~/.saferc, or a corrupted file, and losers of the port race initialized
+// each other's vaults ("Vault is already initialized"). All four must now
+// come up, register, keep to their own servers, and clean up after
+// themselves.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cloudfoundry-community/safe/pkg/rc"
+)
+
+var fleetNames = []string{"alpha", "beta", "gamma", "delta"}
+
+type localProc struct {
+	name   string
+	cmd    *exec.Cmd
+	output *lockedBuffer
+}
+
+// startFleet launches one `safe local --memory` per name against a shared
+// home, all at once.
+func startFleet(t *testing.T, home, engine string, extraFor func(name string) []string) []*localProc {
+	t.Helper()
+	fleet := make([]*localProc, 0, len(fleetNames))
+	for _, name := range fleetNames {
+		var extra []string
+		if extraFor != nil {
+			extra = extraFor(name)
+		}
+		cmd, output, _ := startSafeLocal(t, home, engine, name, extra...)
+		fleet = append(fleet, &localProc{name: name, cmd: cmd, output: output})
+	}
+	return fleet
+}
+
+// awaitFleetReady waits for every process to print its "Now targeting" line.
+func awaitFleetReady(t *testing.T, fleet []*localProc) {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for _, p := range fleet {
+		for {
+			if strings.Contains(p.output.String(), "Now targeting") {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("%s did not become ready:\n%s", p.name, p.output.String())
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
+// stopFleet interrupts every process group and waits for the exits.
+func stopFleet(t *testing.T, fleet []*localProc) {
+	t.Helper()
+	for _, p := range fleet {
+		_ = syscall.Kill(-p.cmd.Process.Pid, syscall.SIGINT)
+	}
+	for _, p := range fleet {
+		done := make(chan error, 1)
+		go func() { done <- p.cmd.Wait() }()
+		select {
+		case <-done:
+		case <-time.After(20 * time.Second):
+			t.Errorf("%s did not exit after SIGINT:\n%s", p.name, p.output.String())
+		}
+	}
+}
+
+// checkFleetRegistered requires all four targets in one valid config, each
+// on its own port, and returns the config.
+func checkFleetRegistered(t *testing.T, home string) rc.Config {
+	t.Helper()
+	cfg, ok := readSafercAt(t, home)
+	if !ok {
+		t.Fatalf("no ~/.saferc after the fleet came up")
+	}
+	ports := map[string]string{}
+	for _, name := range fleetNames {
+		v, found := cfg.Vaults[name]
+		if !found {
+			t.Errorf("target %q lost to a concurrent safe local", name)
+			continue
+		}
+		if v.Token == "" {
+			t.Errorf("target %q has no stored token", name)
+		}
+		if holder, taken := ports[v.URL]; taken {
+			t.Errorf("targets %q and %q share %s", holder, name, v.URL)
+		}
+		ports[v.URL] = name
+	}
+	return cfg
+}
+
+// vaultSecretRoundTrip writes {"owner": owner} at secret/probe on the vault
+// behind url and reads it back, through the KV v2 API cmdLocal mounts.
+func vaultSecretRoundTrip(t *testing.T, url, token, owner string) string {
+	t.Helper()
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	body, _ := json.Marshal(map[string]any{"data": map[string]string{"owner": owner}})
+	req, _ := http.NewRequest(http.MethodPost, url+"/v1/secret/data/probe", bytes.NewReader(body))
+	req.Header.Set("X-Vault-Token", token)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("writing probe secret to %s: %v", url, err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("writing probe secret to %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, url+"/v1/secret/data/probe", nil)
+	req.Header.Set("X-Vault-Token", token)
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("reading probe secret from %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var out struct {
+		Data struct {
+			Data map[string]string `json:"data"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decoding probe secret from %s: %v", url, err)
+	}
+	return out.Data.Data["owner"]
+}
+
+// Four concurrent auto-scan starts under one $HOME: all four targets
+// registered on distinct ports, no process touched another's vault, and the
+// teardowns remove exactly their own entries.
+func TestConcurrentLocalAutoScan(t *testing.T) {
+	engine := localEngine(t)
+	home := t.TempDir()
+
+	fleet := startFleet(t, home, engine, nil)
+	awaitFleetReady(t, fleet)
+	cfg := checkFleetRegistered(t, home)
+
+	// The signature of cross-connection is a loser initializing the winner's
+	// vault: "Vault is already initialized".
+	for _, p := range fleet {
+		if strings.Contains(p.output.String(), "already initialized") {
+			t.Errorf("%s initialized someone else's vault:\n%s", p.name, p.output.String())
+		}
+	}
+
+	// Each process's target must front its own vault: a unique marker
+	// written through one target must read back identically, and the four
+	// must not collapse onto fewer servers.
+	if !t.Failed() {
+		for _, name := range fleetNames {
+			v := cfg.Vaults[name]
+			if got := vaultSecretRoundTrip(t, v.URL, v.Token, name); got != name {
+				t.Errorf("target %q's vault answered as %q", name, got)
+			}
+		}
+	}
+
+	stopFleet(t, fleet)
+
+	// Every teardown removed its own target and only its own.
+	if cfg, ok := readSafercAt(t, home); ok {
+		for _, name := range fleetNames {
+			if _, found := cfg.Vaults[name]; found {
+				t.Errorf("target %q still present after teardown", name)
+			}
+		}
+	}
+}
+
+// Four concurrent starts with explicit, distinct ports: same guarantees,
+// with each target on exactly the port it was given.
+func TestConcurrentLocalExplicitPorts(t *testing.T) {
+	engine := localEngine(t)
+	home := t.TempDir()
+
+	ports := map[string]int{}
+	next := localPortScanStart + 100
+	for _, name := range fleetNames {
+		port, err := findCandidatePort(next)
+		if err != nil {
+			t.Fatalf("choosing a port for %s: %v", name, err)
+		}
+		ports[name] = port
+		next = port + 20
+	}
+
+	fleet := startFleet(t, home, engine, func(name string) []string {
+		return []string{"--port", fmt.Sprintf("%d", ports[name])}
+	})
+	awaitFleetReady(t, fleet)
+	cfg := checkFleetRegistered(t, home)
+
+	for _, name := range fleetNames {
+		if v, found := cfg.Vaults[name]; found {
+			want := localVaultURL(ports[name])
+			if v.URL != want {
+				t.Errorf("target %q at %s, want %s", name, v.URL, want)
+			}
+		}
+	}
+
+	stopFleet(t, fleet)
+}
+
+// A home directory that cannot be written must fail `safe target` with an
+// error, not report success with the old file still in place.
+func TestTargetAddFailsWhenHomeUnwritable(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("directory permissions do not bind root")
+	}
+	isolateHome(t)
+	home := os.Getenv("HOME")
+	if err := os.Chmod(home, 0500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(home, 0700) })
+
+	err := newTestCLI(t).cmdTarget("target", "https://x.example.com", "x")
+	if err == nil {
+		t.Fatalf("cmdTarget reported success with an unwritable home")
+	}
+}

--- a/internal/cli/local_config.go
+++ b/internal/cli/local_config.go
@@ -176,6 +176,23 @@ func (b *lockedBuffer) String() string {
 	return b.buf.String()
 }
 
+// isAddrInUse reports whether the server's output says its listener failed
+// because the address was taken -- the one startup failure it is correct to
+// retry on another port. Both engines print an "Error initializing listener"
+// line whose cause is the OS bind error: "address already in use" on unix,
+// "only one usage of each socket address" on Windows. An address-in-use
+// phrase anywhere else in the log is not the listener failing.
+func isAddrInUse(output string) bool {
+	lower := strings.ToLower(output)
+	idx := strings.Index(lower, "error initializing listener")
+	if idx < 0 {
+		return false
+	}
+	rest := lower[idx:]
+	return strings.Contains(rest, "address already in use") ||
+		strings.Contains(rest, "only one usage of each socket address")
+}
+
 // engineStartupError explains why the local server failed to start, preferring
 // the engine's own stderr output and falling back to the process wait error.
 func engineStartupError(stderr string, waitErr error) string {

--- a/internal/cli/local_isolation_test.go
+++ b/internal/cli/local_isolation_test.go
@@ -54,18 +54,22 @@ func decoyVault(t *testing.T) (*httptest.Server, *atomic.Int64) {
 
 // startSafeLocal runs `safe local --memory --as <name>` in its own process
 // group under the given home, so the whole tree (safe plus the server child)
-// can be torn down without orphans.
-func startSafeLocal(t *testing.T, home, engine, name string) (*exec.Cmd, *strings.Builder) {
+// can be torn down without orphans. The process gets a private TMPDIR (also
+// returned) so tests can check exactly which temp files it leaves behind.
+func startSafeLocal(t *testing.T, home, engine, name string, extra ...string) (*exec.Cmd, *lockedBuffer, string) {
 	t.Helper()
-	cmd := exec.Command(safeBinary(t), "local", "--memory", "--engine", engine, "--as", name)
+	args := append([]string{"local", "--memory", "--engine", engine, "--as", name}, extra...)
+	tmpDir := t.TempDir()
+	cmd := exec.Command(safeBinary(t), args...)
 	cmd.Env = append(os.Environ(),
 		"HOME="+home,
+		"TMPDIR="+tmpDir,
 		"SAFE_TARGET=",
 		"VAULT_ADDR=",
 		"VAULT_TOKEN=",
 	)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	var output strings.Builder
+	var output lockedBuffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output
 	if err := cmd.Start(); err != nil {
@@ -75,7 +79,7 @@ func startSafeLocal(t *testing.T, home, engine, name string) (*exec.Cmd, *string
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 		_ = cmd.Wait()
 	})
-	return cmd, &output
+	return cmd, &output, tmpDir
 }
 
 func readSafercAt(t *testing.T, home string) (rc.Config, bool) {
@@ -104,23 +108,25 @@ func TestLocalNeverTouchesConfiguredTarget(t *testing.T) {
 		t.Fatalf("seeding ~/.saferc: %v", err)
 	}
 
-	cmd, output := startSafeLocal(t, home, engine, "isolated")
+	cmd, output, _ := startSafeLocal(t, home, engine, "isolated")
 
-	// The stored token appears only after init and unseal have succeeded
-	// against safe's own server.
+	// "Now targeting" is printed once setup is complete and safe has settled
+	// into waiting on its server; interrupting before that point exercises
+	// the setup error paths instead of the teardown.
 	deadline := time.Now().Add(30 * time.Second)
-	var token string
+	ready := false
 	for time.Now().Before(deadline) {
-		if cfg, ok := readSafercAt(t, home); ok {
-			if v, found := cfg.Vaults["isolated"]; found && v.Token != "" {
-				token = v.Token
-				break
-			}
+		if strings.Contains(output.String(), "Now targeting") {
+			ready = true
+			break
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	if token == "" {
+	if !ready {
 		t.Fatalf("safe local did not become ready:\n%s", output.String())
+	}
+	if cfg, ok := readSafercAt(t, home); !ok || cfg.Vaults["isolated"] == nil || cfg.Vaults["isolated"].Token == "" {
+		t.Errorf("ready without a stored token for the temporary target")
 	}
 
 	// Wind the server down the way Ctrl-C would: SIGINT to the process
@@ -170,7 +176,7 @@ func TestLocalAbortsWhenConfigUnwritable(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(home, 0700) })
 
-	cmd, output := startSafeLocal(t, home, engine, "isolated")
+	cmd, output, _ := startSafeLocal(t, home, engine, "isolated")
 
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()

--- a/internal/cli/local_isolation_test.go
+++ b/internal/cli/local_isolation_test.go
@@ -1,0 +1,192 @@
+//go:build unix
+
+package cli
+
+// `safe local` must talk only to the server it starts. It used to build its
+// client by re-reading ~/.saferc and applying whatever `current` named -- so
+// a stale, concurrently changed, or unwritable config aimed Init(1,1) at a
+// remote production Vault. These tests target the real binary at a recording
+// decoy and require that it receives no requests, ever.
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/cloudfoundry-community/safe/pkg/rc"
+)
+
+// localEngine names an installed engine binary, or skips the test.
+func localEngine(t *testing.T) string {
+	t.Helper()
+	for _, name := range []string{"vault", "bao"} {
+		if _, err := exec.LookPath(name); err == nil {
+			return name
+		}
+	}
+	t.Skip("neither vault nor bao is installed; skipping safe local test")
+	return ""
+}
+
+// decoyVault records every request it receives. A `safe local` that reaches
+// it has connected through config state instead of to its own server.
+func decoyVault(t *testing.T) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		t.Logf("decoy vault received: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// startSafeLocal runs `safe local --memory --as <name>` in its own process
+// group under the given home, so the whole tree (safe plus the server child)
+// can be torn down without orphans.
+func startSafeLocal(t *testing.T, home, engine, name string) (*exec.Cmd, *strings.Builder) {
+	t.Helper()
+	cmd := exec.Command(safeBinary(t), "local", "--memory", "--engine", engine, "--as", name)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"SAFE_TARGET=",
+		"VAULT_ADDR=",
+		"VAULT_TOKEN=",
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var output strings.Builder
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting safe local: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		_ = cmd.Wait()
+	})
+	return cmd, &output
+}
+
+func readSafercAt(t *testing.T, home string) (rc.Config, bool) {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(home, ".saferc"))
+	if err != nil {
+		return rc.Config{}, false
+	}
+	var cfg rc.Config
+	if err := yaml.Unmarshal(b, &cfg); err != nil {
+		t.Fatalf("~/.saferc does not parse: %v\n%s", err, b)
+	}
+	return cfg, true
+}
+
+// A reachable target named by `current` must receive nothing while safe
+// local brings up, initializes, and tears down its own server.
+func TestLocalNeverTouchesConfiguredTarget(t *testing.T) {
+	engine := localEngine(t)
+	decoy, hits := decoyVault(t)
+
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".saferc"), fmt.Appendf(nil,
+		"version: 1\ncurrent: prod\nvaults:\n  prod:\n    url: %s\n    token: prod-token\n",
+		decoy.URL), 0600); err != nil {
+		t.Fatalf("seeding ~/.saferc: %v", err)
+	}
+
+	cmd, output := startSafeLocal(t, home, engine, "isolated")
+
+	// The stored token appears only after init and unseal have succeeded
+	// against safe's own server.
+	deadline := time.Now().Add(30 * time.Second)
+	var token string
+	for time.Now().Before(deadline) {
+		if cfg, ok := readSafercAt(t, home); ok {
+			if v, found := cfg.Vaults["isolated"]; found && v.Token != "" {
+				token = v.Token
+				break
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if token == "" {
+		t.Fatalf("safe local did not become ready:\n%s", output.String())
+	}
+
+	// Wind the server down the way Ctrl-C would: SIGINT to the process
+	// group. safe ignores it; the server exits; safe cleans up.
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Errorf("safe local did not exit after SIGINT:\n%s", output.String())
+	}
+
+	if n := hits.Load(); n != 0 {
+		t.Errorf("the configured target received %d requests from safe local; want 0\n%s", n, output.String())
+	}
+
+	// And the teardown removed the temporary target, restoring `prod`.
+	if cfg, ok := readSafercAt(t, home); ok {
+		if _, found := cfg.Vaults["isolated"]; found {
+			t.Errorf("temporary target still present after teardown")
+		}
+		if cfg.Current != "prod" {
+			t.Errorf("current = %q after teardown, want %q", cfg.Current, "prod")
+		}
+	}
+}
+
+// The incident replay: when the config cannot be written, safe local used to
+// carry on with the stale config -- whose `current` named a remote Vault --
+// and issue Init(1,1) at it. It must abort instead, touching nothing.
+func TestLocalAbortsWhenConfigUnwritable(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("directory permissions do not bind root")
+	}
+	engine := localEngine(t)
+	decoy, hits := decoyVault(t)
+
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".saferc"), fmt.Appendf(nil,
+		"version: 1\ncurrent: prod\nvaults:\n  prod:\n    url: %s\n    token: prod-token\n",
+		decoy.URL), 0600); err != nil {
+		t.Fatalf("seeding ~/.saferc: %v", err)
+	}
+	if err := os.Chmod(home, 0500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(home, 0700) })
+
+	cmd, output := startSafeLocal(t, home, engine, "isolated")
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Errorf("safe local exited zero with an unwritable config:\n%s", output.String())
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatalf("safe local did not abort with an unwritable config:\n%s", output.String())
+	}
+
+	if n := hits.Load(); n != 0 {
+		t.Errorf("the configured target received %d requests; want 0\n%s", n, output.String())
+	}
+	if !strings.Contains(output.String(), ".saferc") {
+		t.Errorf("abort message does not name the config file:\n%s", output.String())
+	}
+}

--- a/internal/cli/local_port_test.go
+++ b/internal/cli/local_port_test.go
@@ -1,0 +1,148 @@
+//go:build unix
+
+package cli
+
+// Port selection for `safe local`. The old dial probe raced every concurrent
+// starter toward the same "free" port, and a lost race surfaced as a generic
+// startup timeout. Selection now bind-probes, treats the server's own bind
+// failure as the answer, and retries on it -- unless the operator pinned the
+// port, which fails with a diagnosis instead.
+
+import (
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// holdPort binds and holds a port from the scan range.
+func holdPort(t *testing.T) int {
+	t.Helper()
+	port, err := findCandidatePort(localPortScanStart)
+	if err != nil {
+		t.Fatalf("finding a port to hold: %v", err)
+	}
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("holding port %d: %v", port, err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	return port
+}
+
+// With the first scanned port held by someone else, auto-scan must come up
+// on another port rather than fail or stall.
+func TestLocalAutoScanAvoidsHeldPort(t *testing.T) {
+	engine := localEngine(t)
+	held := holdPort(t)
+
+	home := t.TempDir()
+	cmd, output, _ := startSafeLocal(t, home, engine, "dodger")
+
+	deadline := time.Now().Add(30 * time.Second)
+	ready := false
+	for time.Now().Before(deadline) {
+		if strings.Contains(output.String(), "Now targeting") {
+			ready = true
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !ready {
+		t.Fatalf("safe local did not become ready:\n%s", output.String())
+	}
+	cfg, ok := readSafercAt(t, home)
+	if !ok || cfg.Vaults["dodger"] == nil {
+		t.Fatalf("no registered target after readiness:\n%s", output.String())
+	}
+	if url := cfg.Vaults["dodger"].URL; strings.HasSuffix(url, fmt.Sprintf(":%d", held)) {
+		t.Errorf("safe local claims the held port: %s", url)
+	}
+
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Errorf("safe local did not exit after SIGINT:\n%s", output.String())
+	}
+}
+
+// An explicit --port that is taken is an error naming the port and the way
+// out -- not an auto-retry onto a port the operator did not ask for, and not
+// a startup timeout with the server's stderr dumped raw.
+func TestLocalExplicitPortHeldFailsAccurately(t *testing.T) {
+	engine := localEngine(t)
+	held := holdPort(t)
+
+	home := t.TempDir()
+	cmd, output, _ := startSafeLocal(t, home, engine, "pinned", "--port", fmt.Sprintf("%d", held))
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Errorf("safe local exited zero with its port held:\n%s", output.String())
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatalf("safe local did not exit with its port held:\n%s", output.String())
+	}
+
+	out := output.String()
+	if !strings.Contains(out, fmt.Sprintf("port %d is already in use", held)) {
+		t.Errorf("failure does not diagnose the held port %d:\n%s", held, out)
+	}
+	if !strings.Contains(out, "--port") {
+		t.Errorf("failure does not point at --port:\n%s", out)
+	}
+
+	// No half-registered target may survive the failed start.
+	if cfg, ok := readSafercAt(t, home); ok {
+		if _, found := cfg.Vaults["pinned"]; found {
+			t.Errorf("failed start left a target in ~/.saferc")
+		}
+	}
+}
+
+// A listener override pinning the address to a held port defeats every
+// retry; the loop must run its bounded course and then say what it tried.
+// (This is also the only deterministic way to drive the retry path: the
+// probe passes, the server's own bind fails, ten times.)
+func TestLocalRetryLoopIsBounded(t *testing.T) {
+	engine := localEngine(t)
+	held := holdPort(t)
+
+	home := t.TempDir()
+	cmd, output, tmpDir := startSafeLocal(t, home, engine, "bounded",
+		"--listener", fmt.Sprintf("address=127.0.0.1:%d", held))
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Errorf("safe local exited zero with its listener address held:\n%s", output.String())
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatalf("retry loop did not terminate:\n%s", output.String())
+	}
+
+	if !strings.Contains(output.String(), "10 attempts") {
+		t.Errorf("failure does not report the bounded attempts:\n%s", output.String())
+	}
+
+	// Every attempt's temp config file must be cleaned up. The process ran
+	// with a private TMPDIR, so anything left there is safe's own leak.
+	leftovers, err := filepath.Glob(filepath.Join(tmpDir, "kazoo*"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(leftovers) > 0 {
+		t.Errorf("%d temp config files leaked: %v", len(leftovers), leftovers)
+	}
+}

--- a/internal/cli/port_test.go
+++ b/internal/cli/port_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestFindCandidatePortSkipsAHeldPort(t *testing.T) {
+	// Hold a port inside the scan range, then scan starting exactly there:
+	// the probe must move past it, not report it free.
+	held, err := findCandidatePort(localPortScanStart)
+	if err != nil {
+		t.Fatalf("finding a port to hold: %v", err)
+	}
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", held))
+	if err != nil {
+		t.Fatalf("holding port %d: %v", held, err)
+	}
+	defer func() { _ = l.Close() }()
+
+	got, err := findCandidatePort(held)
+	if err != nil {
+		t.Fatalf("findCandidatePort: %v", err)
+	}
+	if got == held {
+		t.Errorf("probe reported held port %d as free", held)
+	}
+	if got < held {
+		t.Errorf("probe went backwards: start %d, got %d", held, got)
+	}
+}
+
+func TestFindCandidatePortReturnsABindablePort(t *testing.T) {
+	got, err := findCandidatePort(localPortScanStart)
+	if err != nil {
+		t.Fatalf("findCandidatePort: %v", err)
+	}
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", got))
+	if err != nil {
+		t.Errorf("reported port %d cannot be bound: %v", got, err)
+	} else {
+		_ = l.Close()
+	}
+}
+
+func TestIsAddrInUse(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			"vault and bao on unix",
+			"Error parsing listener configuration.\nError initializing listener of type tcp: listen tcp 127.0.0.1:8201: bind: address already in use",
+			true,
+		},
+		{
+			"windows socket error",
+			"Error initializing listener of type tcp: listen tcp 127.0.0.1:8201: bind: Only one usage of each socket address (protocol/network address/port) is normally permitted.",
+			true,
+		},
+		{
+			"bad config is not a port collision",
+			"Error parsing listener configuration.\nError initializing listener of type tcp: no such file or directory",
+			false,
+		},
+		{
+			"address-in-use elsewhere in the log is not the listener failing",
+			"[INFO] core: address already in use reported by peer",
+			false,
+		},
+		{"empty output", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAddrInUse(tc.output); got != tc.want {
+				t.Errorf("isAddrInUse(%q) = %v, want %v", tc.output, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -1197,12 +1197,21 @@ func (c *CLI) cmdOption(command string, args ...string) error {
 		return err
 	}
 
-	optLookup := []struct {
+	// One table names the known options; it is built against whichever
+	// Options struct is being read or written at the time -- cfg's for the
+	// listing below, the freshly read config's for the persisted update.
+	optionFields := func(o *rc.Options) []struct {
 		opt string
 		val *bool
-	}{
-		{"manage_vault_token", &cfg.Options.ManageVaultToken},
+	} {
+		return []struct {
+			opt string
+			val *bool
+		}{
+			{"manage_vault_token", &o.ManageVaultToken},
+		}
 	}
+	optLookup := optionFields(&cfg.Options)
 
 	if len(args) == 0 {
 		table := table{}
@@ -1218,6 +1227,7 @@ func (c *CLI) cmdOption(command string, args ...string) error {
 		return nil
 	}
 
+	changes := map[string]bool{}
 	for _, arg := range args {
 		argSplit := strings.Split(arg, "=")
 		if len(argSplit) != 2 {
@@ -1245,7 +1255,7 @@ func (c *CLI) cmdOption(command string, args ...string) error {
 		for _, opt := range optLookup {
 			if opt.opt == optionKey {
 				found = true
-				*opt.val = optionVal
+				changes[opt.opt] = optionVal
 				_, _ = fmt.Printf("updated @G{%s}\n", opt.opt)
 				break
 			}
@@ -1256,5 +1266,12 @@ func (c *CLI) cmdOption(command string, args ...string) error {
 		}
 	}
 
-	return cfg.Write()
+	return rc.Update(func(c *rc.Config) error {
+		for _, field := range optionFields(&c.Options) {
+			if val, ok := changes[field.opt]; ok {
+				*field.val = val
+			}
+		}
+		return nil
+	})
 }

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -295,10 +295,9 @@ func (c *CLI) cmdInit(command string, args ...string) error {
 	if opt.UseTarget != "" {
 		target = opt.UseTarget
 	}
-	if err := cfg.SetTokenFor(target, token); err != nil {
-		return err
-	}
-	if err := cfg.Write(); err != nil {
+	if err := rc.Update(func(c *rc.Config) error {
+		return c.SetTokenFor(target, token)
+	}); err != nil {
 		return err
 	}
 	_ = os.Setenv("VAULT_TOKEN", token)

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -20,6 +20,26 @@ import (
 	"github.com/cloudfoundry-community/safe/pkg/vault"
 )
 
+// localVaultURL is where the server cmdLocal starts can be reached: loopback,
+// plain HTTP, on the port cmdLocal chose.
+func localVaultURL(port int) string {
+	return fmt.Sprintf("http://127.0.0.1:%d", port)
+}
+
+// connectLocal builds a client aimed at the server cmdLocal launched --
+// deliberately not connect(), which derives its target from the environment
+// as applied from ~/.saferc. Everything cmdLocal does to its server -- the
+// readiness poll, Init, Unseal, the mount -- must go to the process it
+// started, and no state of ~/.saferc (stale, lost to a concurrent writer, or
+// corrupted) may aim those calls anywhere else. Init against a foreign vault
+// is the incident this guards against.
+func connectLocal(port int, token string) (*vault.Vault, error) {
+	return vault.NewVault(vault.VaultConfig{
+		URL:   localVaultURL(port),
+		Token: token,
+	})
+}
+
 func (c *CLI) cmdLocal(command string, args ...string) error {
 	opt := c.opt
 
@@ -139,13 +159,9 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 	}
 	previous := cfg.Current
 
-	_ = cfg.SetTarget(name, rc.Vault{
-		URL:        fmt.Sprintf("http://127.0.0.1:%d", port),
-		SkipVerify: false,
-	})
 	if err := rc.Update(func(c *rc.Config) error {
 		return c.SetTarget(name, rc.Vault{
-			URL:        fmt.Sprintf("http://127.0.0.1:%d", port),
+			URL:        localVaultURL(port),
 			SkipVerify: false,
 		})
 	}); err != nil {
@@ -153,11 +169,15 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 		// than leave one running that no config file points at.
 		die(fmt.Errorf("Unable to register '%s' in ~/.saferc: %w", name, err))
 	}
+	// Outputs of the decision just made, for anything spawned from here on.
+	// Never read back as inputs: the client below is built from the port
+	// directly.
+	_ = os.Setenv("VAULT_ADDR", localVaultURL(port))
 
-	if _, err := rc.Apply(""); err != nil {
-		return err
+	v, err := connectLocal(port, "")
+	if err != nil {
+		die(fmt.Errorf("Unable to build a client for the local %s server: %w", engine.Title(), err))
 	}
-	v := connect(false)
 
 	const maxStartupWait = 5 * time.Second
 	const betweenChecksWait = 250 * time.Millisecond
@@ -216,11 +236,14 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 		// to reach it instead. The token going to stderr is deliberate: this
 		// flow already prints the seal key, and the server is loopback-only.
 		_, _ = fmt.Fprintf(os.Stderr, "@R{!! Unable to save the root token in ~/.saferc: %s}\n", err)
-		_, _ = fmt.Fprintf(os.Stderr, "@R{!! The %s server at} @C{http://127.0.0.1:%d} @R{is still running.}\n", engine.Title(), port)
+		_, _ = fmt.Fprintf(os.Stderr, "@R{!! The %s server at} @C{%s} @R{is still running.}\n", engine.Title(), localVaultURL(port))
 		_, _ = fmt.Fprintf(os.Stderr, "@R{!! Its root token is} @M{%s}\n", token)
-		_, _ = fmt.Fprintf(os.Stderr, "@R{!! To reach it:} @C{safe target %s http://127.0.0.1:%d && safe auth token}\n", name, port)
+		_, _ = fmt.Fprintf(os.Stderr, "@R{!! To reach it:} @C{safe target %s %s && safe auth token}\n", name, localVaultURL(port))
 	}
-	v = connect(true)
+	v, err = connectLocal(port, token)
+	if err != nil {
+		return fmt.Errorf("Unable to build a client for the local %s server: %w", engine.Title(), err)
+	}
 
 	exists, err := v.MountExists("secret")
 	if err != nil {
@@ -240,7 +263,7 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 	_ = v.Write("secret/handshake", s)
 
 	if !opt.Quiet {
-		_, _ = fmt.Fprintf(os.Stderr, "Now targeting (temporary) @Y{%s} at @C{%s}\n", cfg.Current, cfg.URL())
+		_, _ = fmt.Fprintf(os.Stderr, "Now targeting (temporary) @Y{%s} at @C{%s}\n", name, localVaultURL(port))
 		if opt.Local.Memory {
 			_, _ = fmt.Fprintf(os.Stderr, "@R{This %s server is MEMORY-BACKED!}\n", engine.Title())
 			_, _ = fmt.Fprintf(os.Stderr, "If you want to @Y{retain your secrets} be sure to @C{safe export}.\n")

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -143,7 +143,16 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 		URL:        fmt.Sprintf("http://127.0.0.1:%d", port),
 		SkipVerify: false,
 	})
-	_ = cfg.Write()
+	if err := rc.Update(func(c *rc.Config) error {
+		return c.SetTarget(name, rc.Vault{
+			URL:        fmt.Sprintf("http://127.0.0.1:%d", port),
+			SkipVerify: false,
+		})
+	}); err != nil {
+		// Nothing irreversible has happened yet: kill the server rather
+		// than leave one running that no config file points at.
+		die(fmt.Errorf("Unable to register '%s' in ~/.saferc: %w", name, err))
+	}
 
 	if _, err := rc.Apply(""); err != nil {
 		return err
@@ -195,9 +204,22 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 		die(fmt.Errorf("Unable to generate a new root token: %w", err))
 	}
 
-	_ = cfg.SetToken(token)
 	_ = os.Setenv("VAULT_TOKEN", token)
-	_ = cfg.Write()
+	// SetTokenFor, not SetToken: SetToken stores against whatever target is
+	// current in the state just read, which under concurrency can be some
+	// other process's vault. The token belongs to the server started here.
+	if err := rc.Update(func(c *rc.Config) error {
+		return c.SetTokenFor(name, token)
+	}); err != nil {
+		// The server is initialized and unsealed; aborting now would destroy
+		// it (unrecoverably, for --memory). Hand the operator what they need
+		// to reach it instead. The token going to stderr is deliberate: this
+		// flow already prints the seal key, and the server is loopback-only.
+		_, _ = fmt.Fprintf(os.Stderr, "@R{!! Unable to save the root token in ~/.saferc: %s}\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "@R{!! The %s server at} @C{http://127.0.0.1:%d} @R{is still running.}\n", engine.Title(), port)
+		_, _ = fmt.Fprintf(os.Stderr, "@R{!! Its root token is} @M{%s}\n", token)
+		_, _ = fmt.Fprintf(os.Stderr, "@R{!! To reach it:} @C{safe target %s http://127.0.0.1:%d && safe auth token}\n", name, port)
+	}
 	v = connect(true)
 
 	exists, err := v.MountExists("secret")
@@ -231,21 +253,24 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 
 	err = <-echan
 	_, _ = fmt.Fprintf(os.Stderr, "%s terminated normally, cleaning up...\n", engine.Title())
-	{
-		var applyErr error
-		cfg, applyErr = rc.Apply("")
-		if applyErr != nil {
-			return applyErr
+	if updateErr := rc.Update(func(c *rc.Config) error {
+		// Evaluated against the state as it is now, not as it was at
+		// startup: if another process has moved `current` to its own
+		// target in the meantime, it is left alone.
+		if c.Current == name {
+			c.Current = ""
+			if _, found, _ := c.Find(previous); found {
+				c.Current = previous
+			}
 		}
+		delete(c.Vaults, name)
+		return nil
+	}); updateErr != nil {
+		// The server is already gone; the config entry is now stale. Say
+		// so, but let the server's own exit status be what is returned.
+		_, _ = fmt.Fprintf(os.Stderr, "@R{!! Unable to remove '%s' from ~/.saferc: %s}\n", name, updateErr)
+		_, _ = fmt.Fprintf(os.Stderr, "@R{!! Remove it by hand with} @C{safe targets delete %s}\n", name)
 	}
-	if cfg.Current == name {
-		cfg.Current = ""
-		if _, found, _ := cfg.Find(previous); found {
-			cfg.Current = previous
-		}
-	}
-	delete(cfg.Vaults, name)
-	_ = cfg.Write()
 	return err
 }
 

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -40,6 +41,134 @@ func connectLocal(port int, token string) (*vault.Vault, error) {
 	})
 }
 
+// localPortScanStart is where automatic port selection begins scanning.
+const localPortScanStart = 8201
+
+// findCandidatePort returns the first port at or after start that accepts a
+// loopback bind, probing with the same listen(2) the server child performs.
+// The old dial probe called a port free when connecting to it failed, which
+// TIME_WAIT remnants pass while the bind still fails. The probe listener
+// closes before the server launches, so the answer is only advisory: the
+// child's own bind failure is authoritative, and cmdLocal retries on it.
+func findCandidatePort(start int) (int, error) {
+	for port := start; port < 9999; port++ {
+		l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			continue
+		}
+		_ = l.Close()
+		return port, nil
+	}
+	return 0, fmt.Errorf("no free local port found between %d and 9998", start)
+}
+
+// localServer is one launched attempt at running the engine.
+type localServer struct {
+	cmd     *exec.Cmd
+	echan   chan error
+	output  *lockedBuffer
+	cfgFile string
+}
+
+// launchLocalServer renders the config, writes it to a temp file, and starts
+// the engine on it. The returned echan is buffered so the exit of a server
+// nobody is currently waiting on does not strand the reaper goroutine.
+func launchLocalServer(engine Engine, params localConfigParams) (*localServer, error) {
+	configBody, err := buildLocalConfig(params)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.CreateTemp("", "kazoo")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := f.WriteString(configBody); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return nil, fmt.Errorf("Unable to write the %s config: %w", engine.Title(), err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return nil, fmt.Errorf("Unable to write the %s config: %w", engine.Title(), err)
+	}
+
+	// Capture the server's output so a bad config (which safe deliberately
+	// does not validate) is reported instead of surfacing as a startup
+	// timeout. Config-parse errors go to stdout, so capture both streams.
+	// Pointing Stdout and Stderr at the same writer is the documented way
+	// to avoid an interleaving race (os/exec serializes the writes).
+	var output lockedBuffer
+	echan := make(chan error, 1)
+	// #nosec G204 - engine.Binary() is a PATH lookup of a known name, and
+	// f.Name() is a temp file we created
+	cmd := exec.Command(engine.Binary(), "server", "-config", f.Name())
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		_ = os.Remove(f.Name())
+		return nil, fmt.Errorf("failed to start %s server: %w", engine.Title(), err)
+	}
+	go func() {
+		echan <- cmd.Wait()
+	}()
+	return &localServer{cmd: cmd, echan: echan, output: &output, cfgFile: f.Name()}, nil
+}
+
+// waitLocalReady polls until the launched server answers on its port. It
+// returns nil on readiness, and otherwise the reason: the server's own exit,
+// in its own words, or a timeout.
+//
+// An answer on the port is not readiness by itself. If the child lost the
+// bind race, whatever won it answers there instead -- and treating that
+// stranger as ready is how a safe once fed Init to a vault it never started.
+// Readiness is an answer, plus our child alive, plus no bind failure in its
+// output. The probe carries its own short timeout so a holder that accepts
+// and never speaks HTTP cannot stall the poll.
+func waitLocalReady(engine Engine, port int, srv *localServer) error {
+	const maxStartupWait = 5 * time.Second
+	const betweenChecksWait = 250 * time.Millisecond
+	probe := &http.Client{Timeout: time.Second}
+	begin := time.Now()
+	var lastErr error
+	for {
+		// If the server exited before becoming ready (most often a rejected
+		// config), report its own error rather than waiting out the timeout.
+		select {
+		case waitErr := <-srv.echan:
+			return fmt.Errorf("%s exited before it became ready: %s", engine.Title(), engineStartupError(srv.output.String(), waitErr))
+		default:
+		}
+
+		resp, err := probe.Get(localVaultURL(port) + "/v1/sys/seal-status")
+		if err == nil {
+			_ = resp.Body.Close()
+			if isAddrInUse(srv.output.String()) {
+				// Someone else answered; our child lost the bind and is on
+				// its way out. Reap it and report its own account.
+				waitErr := <-srv.echan
+				return fmt.Errorf("%s exited before it became ready: %s", engine.Title(), engineStartupError(srv.output.String(), waitErr))
+			}
+			select {
+			case waitErr := <-srv.echan:
+				return fmt.Errorf("%s exited before it became ready: %s", engine.Title(), engineStartupError(srv.output.String(), waitErr))
+			default:
+				return nil
+			}
+		}
+		lastErr = err
+
+		if time.Since(begin) > maxStartupWait {
+			if msg := strings.TrimSpace(srv.output.String()); msg != "" {
+				return fmt.Errorf("Timed out waiting for %s to begin listening: %s\n%s", engine.Title(), lastErr, msg)
+			}
+			return fmt.Errorf("Timed out waiting for %s to begin listening: %s", engine.Title(), lastErr)
+		}
+
+		time.Sleep(betweenChecksWait)
+	}
+}
+
 func (c *CLI) cmdLocal(command string, args ...string) error {
 	opt := c.opt
 
@@ -55,16 +184,12 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 		return fmt.Errorf("@R{%s}", err)
 	}
 
-	var port int
-	if opt.Local.Port != 0 {
-		port = opt.Local.Port
-	} else {
-		for port = 8201; port < 9999; port++ {
-			conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-			if err != nil {
-				break
-			}
-			_ = conn.Close()
+	autoScan := opt.Local.Port == 0
+	port := opt.Local.Port
+	if autoScan {
+		port, err = findCandidatePort(localPortScanStart)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -76,60 +201,23 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 		}
 	}
 
-	configBody, err := buildLocalConfig(localConfigParams{
-		port:       port,
-		memory:     opt.Local.Memory,
-		filePath:   opt.Local.File,
-		engineName: engine.Name(),
-		global:     opt.Local.Config,
-		listener:   opt.Local.Listener,
-	})
-	if err != nil {
-		return err
-	}
-
-	f, err := os.CreateTemp("", "kazoo")
-	if err != nil {
-		return err
-	}
-	if _, err := f.WriteString(configBody); err != nil {
-		return fmt.Errorf("Unable to write the %s config: %w", engine.Title(), err)
-	}
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("Unable to write the %s config: %w", engine.Title(), err)
-	}
-
-	// Capture the server's output so a bad config (which safe deliberately
-	// does not validate) is reported instead of surfacing as a startup
-	// timeout. Config-parse errors go to stdout, so capture both streams.
-	// Pointing Stdout and Stderr at the same writer is the documented way
-	// to avoid an interleaving race (os/exec serializes the writes).
-	var engineOutput lockedBuffer
-	echan := make(chan error)
-	// #nosec G204 - engine.Binary() is a PATH lookup of a known name, and
-	// f.Name() is a temp file we created
-	cmd := exec.Command(engine.Binary(), "server", "-config", f.Name())
-	cmd.Stdout = &engineOutput
-	cmd.Stderr = &engineOutput
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start %s server: %w", engine.Title(), err)
-	}
-	go func() {
-		echan <- cmd.Wait()
-	}()
 	signal.Ignore(syscall.SIGINT)
 
+	var srv *localServer
 	die := func(err error) {
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "@R{!! %s}\n", err)
 		}
 		_, _ = fmt.Fprintf(os.Stderr, "@Y{shutting down %s...}\n", engine.Title())
-		// On the startup path the wait goroutine has usually reaped the
-		// process already; that is a clean shutdown, not a kill failure.
-		if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
-			_, _ = fmt.Fprintf(os.Stderr, "@R{NOTE: Unable to terminate the %s process.}\n", engine.Title())
-			_, _ = fmt.Fprintf(os.Stderr, "@R{      You may have some environmental cleanup to do.}\n")
-			_, _ = fmt.Fprintf(os.Stderr, "@R{      Apologies.}\n")
+		if srv != nil {
+			// On the startup path the wait goroutine has usually reaped the
+			// process already; that is a clean shutdown, not a kill failure.
+			if err := srv.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+				_, _ = fmt.Fprintf(os.Stderr, "@R{NOTE: Unable to terminate the %s process.}\n", engine.Title())
+				_, _ = fmt.Fprintf(os.Stderr, "@R{      You may have some environmental cleanup to do.}\n")
+				_, _ = fmt.Fprintf(os.Stderr, "@R{      Apologies.}\n")
+			}
+			_ = os.Remove(srv.cfgFile)
 		}
 		rc.Cleanup()
 		os.Exit(1)
@@ -159,6 +247,57 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 	}
 	previous := cfg.Current
 
+	// Launch, retrying on the one failure that is safe to retry: the child's
+	// own report that the port was taken. The bind probe above narrows the
+	// race but cannot close it -- only the server's listen(2) is
+	// authoritative. A losing attempt exits immediately, so a retry costs
+	// milliseconds.
+	const maxPortAttempts = 10
+	for attempt := 1; ; attempt++ {
+		srv, err = launchLocalServer(engine, localConfigParams{
+			port:       port,
+			memory:     opt.Local.Memory,
+			filePath:   opt.Local.File,
+			engineName: engine.Name(),
+			global:     opt.Local.Config,
+			listener:   opt.Local.Listener,
+		})
+		if err != nil {
+			return err
+		}
+
+		startupErr := waitLocalReady(engine, port, srv)
+		if startupErr == nil {
+			break
+		}
+
+		if isAddrInUse(srv.output.String()) {
+			_ = os.Remove(srv.cfgFile)
+			if !autoScan {
+				// An explicit --port is a decision, not a preference:
+				// diagnose it accurately and let the operator make the
+				// next one.
+				die(fmt.Errorf("port %d is already in use; choose another with --port, or omit --port to let safe pick one", port))
+			}
+			if attempt < maxPortAttempts {
+				port, err = findCandidatePort(port + 1)
+				if err != nil {
+					die(err)
+				}
+				continue
+			}
+			die(fmt.Errorf("no free port found for %s after %d attempts (last tried %d)", engine.Title(), maxPortAttempts, port))
+		}
+		die(startupErr)
+	}
+
+	v, err := connectLocal(port, "")
+	if err != nil {
+		die(fmt.Errorf("Unable to build a client for the local %s server: %w", engine.Title(), err))
+	}
+
+	// Registered only now that the server is up on a port that is final: a
+	// failed or retried launch must not leave a target pointing at nothing.
 	if err := rc.Update(func(c *rc.Config) error {
 		return c.SetTarget(name, rc.Vault{
 			URL:        localVaultURL(port),
@@ -170,41 +309,9 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 		die(fmt.Errorf("Unable to register '%s' in ~/.saferc: %w", name, err))
 	}
 	// Outputs of the decision just made, for anything spawned from here on.
-	// Never read back as inputs: the client below is built from the port
+	// Never read back as inputs: the client above was built from the port
 	// directly.
 	_ = os.Setenv("VAULT_ADDR", localVaultURL(port))
-
-	v, err := connectLocal(port, "")
-	if err != nil {
-		die(fmt.Errorf("Unable to build a client for the local %s server: %w", engine.Title(), err))
-	}
-
-	const maxStartupWait = 5 * time.Second
-	const betweenChecksWait = 250 * time.Millisecond
-	startupCheckBeginTime := time.Now()
-	for {
-		// If the server exited before becoming ready (most often a rejected
-		// config), report its own error rather than waiting out the timeout.
-		select {
-		case waitErr := <-echan:
-			die(fmt.Errorf("%s exited before it became ready: %s", engine.Title(), engineStartupError(engineOutput.String(), waitErr)))
-		default:
-		}
-
-		_, err := v.Sealed()
-		if err == nil {
-			break
-		}
-
-		if time.Since(startupCheckBeginTime) > maxStartupWait {
-			if msg := strings.TrimSpace(engineOutput.String()); msg != "" {
-				die(fmt.Errorf("Timed out waiting for %s to begin listening: %s\n%s", engine.Title(), err, msg))
-			}
-			die(fmt.Errorf("Timed out waiting for %s to begin listening: %s", engine.Title(), err))
-		}
-
-		time.Sleep(betweenChecksWait)
-	}
 
 	token := ""
 	if len(keys) == 0 {
@@ -274,7 +381,8 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 		_, _ = fmt.Fprintf(os.Stderr, "Ctrl-C to shut down the %s server\n", engine.Title())
 	}
 
-	err = <-echan
+	err = <-srv.echan
+	_ = os.Remove(srv.cfgFile)
 	_, _ = fmt.Fprintf(os.Stderr, "%s terminated normally, cleaning up...\n", engine.Title())
 	if updateErr := rc.Update(func(c *rc.Config) error {
 		// Evaluated against the state as it is now, not as it was at

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -203,7 +203,9 @@ func (c *CLI) cmdTarget(command string, args ...string) error {
 				_, _ = fmt.Fprintf(os.Stderr, "@R{%s}\n", err)
 				continue
 			}
-			err = cfg.Write()
+			err = rc.Update(func(c *rc.Config) error {
+				return c.SetCurrent(t, skipverify)
+			})
 			if err != nil {
 				return err
 			}
@@ -256,7 +258,9 @@ func (c *CLI) cmdTarget(command string, args ...string) error {
 		//Saved before it is reported: a home directory that cannot be written
 		// to used to be answered with the new target on the screen and the old
 		// one still in the file.
-		if err := cfg.Write(); err != nil {
+		if err := rc.Update(func(c *rc.Config) error {
+			return c.SetCurrent(args[0], skipverify)
+		}); err != nil {
 			return err
 		}
 		if !opt.Quiet {
@@ -298,17 +302,24 @@ func (c *CLI) cmdTarget(command string, args ...string) error {
 			caCerts = append(caCerts, string(toWrite))
 		}
 
-		err = cfg.SetTarget(alias, rc.Vault{
+		newTarget := rc.Vault{
 			URL:        url,
 			SkipVerify: skipverify,
 			Strongbox:  opt.Target.Strongbox,
 			Namespace:  opt.Target.Namespace,
 			CACerts:    caCerts,
-		})
+		}
+		// Applied to cfg for the report below, and separately to the freshly
+		// read state inside Update for what is persisted. SetTarget's keep-
+		// the-token-when-the-URL-matches check runs against the fresh state,
+		// where the answer is current.
+		err = cfg.SetTarget(alias, newTarget)
 		if err != nil {
 			return err
 		}
-		if err := cfg.Write(); err != nil {
+		if err := rc.Update(func(c *rc.Config) error {
+			return c.SetTarget(alias, newTarget)
+		}); err != nil {
 			return err
 		}
 		if !opt.Quiet {
@@ -344,18 +355,19 @@ func (c *CLI) cmdTargetDelete(command string, args ...string) error {
 		return fmt.Errorf("Unknown target '%s'", args[0])
 	}
 
-	delete(cfg.Vaults, alias)
-	//The selection is compared by resolving it rather than by matching the
-	// alias: a config written before it was recorded by alias names the current
-	// target by URL, and a URL stops naming anything once the target carrying
-	// it is gone. Left as it was, the selection would name a Vault that is not
-	// in the file, which every later command -- including the write below --
-	// reports as a missing current target.
-	if _, ok, _ := cfg.Alias(cfg.Current); !ok {
-		cfg.Current = ""
-	}
-
-	return cfg.Write()
+	return rc.Update(func(c *rc.Config) error {
+		delete(c.Vaults, alias)
+		//The selection is compared by resolving it rather than by matching the
+		// alias: a config written before it was recorded by alias names the current
+		// target by URL, and a URL stops naming anything once the target carrying
+		// it is gone. Left as it was, the selection would name a Vault that is not
+		// in the file, which every later command -- including the write below --
+		// reports as a missing current target.
+		if _, ok, _ := c.Alias(c.Current); !ok {
+			c.Current = ""
+		}
+		return nil
+	})
 }
 
 func (c *CLI) cmdStatus(command string, args ...string) error {
@@ -645,10 +657,9 @@ func (c *CLI) cmdAuth(command string, args ...string) error {
 
 	//The token belongs to the target that was authenticated against, which
 	// -T may have named, and storing it must not move the current target.
-	if err := cfg.SetTokenFor(target, token); err != nil {
-		return err
-	}
-	return cfg.Write()
+	return rc.Update(func(c *rc.Config) error {
+		return c.SetTokenFor(target, token)
+	})
 }
 
 func (c *CLI) cmdLogout(command string, args ...string) error {
@@ -665,10 +676,9 @@ func (c *CLI) cmdLogout(command string, args ...string) error {
 	}
 	//Dropping the token of the target that was named, rather than of the
 	// current one, which is the only target SetToken can reach.
-	if err := cfg.SetTokenFor(target, ""); err != nil {
-		return err
-	}
-	if err := cfg.Write(); err != nil {
+	if err := rc.Update(func(c *rc.Config) error {
+		return c.SetTokenFor(target, "")
+	}); err != nil {
 		return err
 	}
 

--- a/internal/cli/target_concurrent_test.go
+++ b/internal/cli/target_concurrent_test.go
@@ -1,0 +1,94 @@
+package cli
+
+// Concurrent `safe target` invocations used to lose each other's entries:
+// each read ~/.saferc at startup, applied its own change to that snapshot,
+// and rewrote the whole file. Whoever wrote last won; everyone else's target
+// vanished. These run the real command handlers concurrently and require
+// every writer's entry to survive.
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestConcurrentTargetAddsAllSurvive(t *testing.T) {
+	isolateHome(t)
+
+	const n = 8
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c := newTestCLI(t)
+			alias := fmt.Sprintf("target-%02d", i)
+			errs[i] = c.cmdTarget("target", fmt.Sprintf("https://%s.example.com", alias), alias)
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("cmdTarget %d: %v", i, err)
+		}
+	}
+
+	cfg := readConfig(t)
+	for i := range n {
+		alias := fmt.Sprintf("target-%02d", i)
+		if _, ok := cfg.Vaults[alias]; !ok {
+			t.Errorf("target %q lost to a concurrent writer", alias)
+		}
+	}
+	if len(cfg.Vaults) != n {
+		t.Errorf("%d targets in config, want %d", len(cfg.Vaults), n)
+	}
+}
+
+// Deleting one target while another is being added must end with the added
+// target present and the deleted one gone -- not with either operation's
+// whole-file view of the world.
+func TestConcurrentTargetAddAndDelete(t *testing.T) {
+	isolateHome(t)
+	writeSaferc(t, `version: 1
+current: keep
+vaults:
+  keep:
+    url: https://keep.example.com
+  doomed:
+    url: https://doomed.example.com
+`)
+
+	var wg sync.WaitGroup
+	var addErr, delErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		addErr = newTestCLI(t).cmdTarget("target", "https://fresh.example.com", "fresh")
+	}()
+	go func() {
+		defer wg.Done()
+		delErr = newTestCLI(t).cmdTargetDelete("target delete", "doomed")
+	}()
+	wg.Wait()
+
+	if addErr != nil {
+		t.Fatalf("cmdTarget: %v", addErr)
+	}
+	if delErr != nil {
+		t.Fatalf("cmdTargetDelete: %v", delErr)
+	}
+
+	cfg := readConfig(t)
+	if _, ok := cfg.Vaults["fresh"]; !ok {
+		t.Error("added target lost to the concurrent delete")
+	}
+	if _, ok := cfg.Vaults["doomed"]; ok {
+		t.Error("deleted target still present")
+	}
+	if _, ok := cfg.Vaults["keep"]; !ok {
+		t.Error("bystander target lost")
+	}
+}

--- a/internal/cli/target_concurrent_test.go
+++ b/internal/cli/target_concurrent_test.go
@@ -92,3 +92,37 @@ vaults:
 		t.Error("bystander target lost")
 	}
 }
+
+// `safe option` writes the whole config too; setting an option while a target
+// is being added must keep both changes.
+func TestConcurrentOptionSetAndTargetAdd(t *testing.T) {
+	isolateHome(t)
+
+	var wg sync.WaitGroup
+	var optErr, addErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		optErr = newTestCLI(t).cmdOption("option", "manage-vault-token=true")
+	}()
+	go func() {
+		defer wg.Done()
+		addErr = newTestCLI(t).cmdTarget("target", "https://fresh.example.com", "fresh")
+	}()
+	wg.Wait()
+
+	if optErr != nil {
+		t.Fatalf("cmdOption: %v", optErr)
+	}
+	if addErr != nil {
+		t.Fatalf("cmdTarget: %v", addErr)
+	}
+
+	cfg := readConfig(t)
+	if !cfg.Options.ManageVaultToken {
+		t.Error("option lost to the concurrent target add")
+	}
+	if _, ok := cfg.Vaults["fresh"]; !ok {
+		t.Error("target lost to the concurrent option set")
+	}
+}

--- a/pkg/rc/atomic.go
+++ b/pkg/rc/atomic.go
@@ -1,0 +1,60 @@
+package rc
+
+import (
+	"os"
+	"path/filepath"
+
+	fmt "github.com/jhunt/go-ansi"
+)
+
+// writeFileAtomic replaces the file at path with data in one rename, so a
+// reader (or a crash) sees either the previous complete file or the new one,
+// never a truncated or half-written mix. The previous file survives every
+// failure intact: nothing here ever truncates the target.
+//
+// The temp file is created in the target's own directory -- rename cannot
+// cross filesystems -- and synced before the rename, since these files hold
+// root tokens and a short file after a crash is not acceptable. The directory
+// itself is not synced: that is not portable, and the worst case it leaves
+// open is the rename not surviving a power loss -- a stale config, not a
+// corrupt one.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir, base := filepath.Split(path)
+	if dir == "" {
+		dir = "."
+	}
+
+	tmp, err := os.CreateTemp(dir, "."+base+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("could not write %s: %w", path, err)
+	}
+
+	// From here on, any failure removes the temp file and leaves the target
+	// alone.
+	fail := func(what string, err error) error {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return fmt.Errorf("could not %s %s: %w", what, path, err)
+	}
+
+	// CreateTemp always uses 0600; apply the caller's mode explicitly so the
+	// renamed file carries it.
+	if err := tmp.Chmod(perm); err != nil {
+		return fail("set permissions on", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return fail("write", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fail("sync", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return fmt.Errorf("could not close %s: %w", path, err)
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		_ = os.Remove(tmp.Name())
+		return fmt.Errorf("could not replace %s: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/rc/atomic_test.go
+++ b/pkg/rc/atomic_test.go
@@ -1,0 +1,119 @@
+package rc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteFileAtomicCreates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "saferc")
+
+	if err := writeFileAtomic(path, []byte("version: 1\n"), 0600); err != nil {
+		t.Fatalf("writeFileAtomic: %s", err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %s", err)
+	}
+	if string(b) != "version: 1\n" {
+		t.Errorf("content = %q", b)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %s", err)
+	}
+	if got := fi.Mode().Perm(); got != 0600 {
+		t.Errorf("mode = %04o, want 0600", got)
+	}
+}
+
+func TestWriteFileAtomicReplaces(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "saferc")
+
+	if err := os.WriteFile(path, []byte("old"), 0600); err != nil {
+		t.Fatalf("seed: %s", err)
+	}
+	if err := writeFileAtomic(path, []byte("new"), 0600); err != nil {
+		t.Fatalf("writeFileAtomic: %s", err)
+	}
+
+	b, _ := os.ReadFile(path)
+	if string(b) != "new" {
+		t.Errorf("content = %q, want %q", b, "new")
+	}
+}
+
+func TestWriteFileAtomicLeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "saferc")
+
+	for range 3 {
+		if err := writeFileAtomic(path, []byte("x"), 0600); err != nil {
+			t.Fatalf("writeFileAtomic: %s", err)
+		}
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %s", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "saferc" {
+			t.Errorf("leftover file %q", e.Name())
+		}
+	}
+	if len(entries) != 1 {
+		t.Errorf("%d entries in dir, want 1", len(entries))
+	}
+}
+
+// A failed write must leave the previous file exactly as it was: this is the
+// credential store, and today's failure mode (truncate first, write maybe) is
+// the defect being fixed.
+func TestWriteFileAtomicFailureKeepsOriginal(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("directory permissions do not bind root")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "saferc")
+	if err := os.WriteFile(path, []byte("precious"), 0600); err != nil {
+		t.Fatalf("seed: %s", err)
+	}
+
+	// An unwritable directory fails temp-file creation -- the earliest and
+	// most common failure (unwritable $HOME).
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatalf("chmod: %s", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+	err := writeFileAtomic(path, []byte("clobber"), 0600)
+	if err == nil {
+		t.Fatalf("writeFileAtomic succeeded in an unwritable directory")
+	}
+
+	b, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("original after failed write: %s", readErr)
+	}
+	if string(b) != "precious" {
+		t.Errorf("original content = %q, want %q", b, "precious")
+	}
+}
+
+func TestWriteFileAtomicRejectsMissingDir(t *testing.T) {
+	err := writeFileAtomic(filepath.Join(t.TempDir(), "no", "such", "dir", "f"), []byte("x"), 0600)
+	if err == nil {
+		t.Fatalf("writeFileAtomic succeeded into a missing directory")
+	}
+	if !strings.Contains(err.Error(), "f") {
+		t.Errorf("error %q does not mention the target", err)
+	}
+}

--- a/pkg/rc/concurrency_test.go
+++ b/pkg/rc/concurrency_test.go
@@ -1,0 +1,132 @@
+package rc
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+// The lost-update defect, at full contention: every writer's delta must land,
+// no matter how many read-mutate-write cycles overlap.
+func TestConcurrentUpdatersLoseNothing(t *testing.T) {
+	setHome(t)
+
+	const writers = 8
+	const rounds = 5
+	var wg sync.WaitGroup
+	var failures atomic.Int64
+
+	for w := range writers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for r := range rounds {
+				name := fmt.Sprintf("w%02d-r%02d", w, r)
+				if err := Update(func(c *Config) error {
+					return c.SetTarget(name, Vault{URL: "http://" + name})
+				}); err != nil {
+					t.Errorf("Update(%s): %s", name, err)
+					failures.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if failures.Load() > 0 {
+		return
+	}
+	c, err := Read()
+	if err != nil {
+		t.Fatalf("Read: %s", err)
+	}
+	if len(c.Vaults) != writers*rounds {
+		t.Errorf("%d targets survived, want %d", len(c.Vaults), writers*rounds)
+	}
+	for w := range writers {
+		for r := range rounds {
+			name := fmt.Sprintf("w%02d-r%02d", w, r)
+			if _, ok := c.Vaults[name]; !ok {
+				t.Errorf("target %q lost", name)
+			}
+		}
+	}
+}
+
+// The torn-file defect: the production artifact was a complete YAML document
+// with the tail of a longer one appended -- a truncating rewrite caught
+// mid-flight. Readers hammering the file during a write storm must only ever
+// see complete, parseable documents, and never fewer targets than they saw
+// before (this file only grows during the storm).
+func TestReadersNeverSeeATornFile(t *testing.T) {
+	setHome(t)
+
+	stop := make(chan struct{})
+	var readerWG sync.WaitGroup
+	for range 4 {
+		readerWG.Add(1)
+		go func() {
+			defer readerWG.Done()
+			most := 0
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+
+				b, err := os.ReadFile(saferc())
+				if err != nil {
+					if os.IsNotExist(err) {
+						continue
+					}
+					t.Errorf("reading .saferc: %s", err)
+					return
+				}
+				var c Config
+				if err := yaml.Unmarshal(b, &c); err != nil {
+					t.Errorf("torn .saferc observed: %s\n%s", err, b)
+					return
+				}
+				if len(c.Vaults) < most {
+					t.Errorf("targets went backwards: saw %d after %d", len(c.Vaults), most)
+					return
+				}
+				most = len(c.Vaults)
+			}
+		}()
+	}
+
+	const writers = 6
+	const rounds = 8
+	var writerWG sync.WaitGroup
+	for w := range writers {
+		writerWG.Add(1)
+		go func() {
+			defer writerWG.Done()
+			for r := range rounds {
+				name := fmt.Sprintf("storm-w%02d-r%02d", w, r)
+				if err := Update(func(c *Config) error {
+					return c.SetTarget(name, Vault{URL: "http://" + name})
+				}); err != nil {
+					t.Errorf("Update(%s): %s", name, err)
+				}
+			}
+		}()
+	}
+	writerWG.Wait()
+	close(stop)
+	readerWG.Wait()
+
+	c, err := Read()
+	if err != nil {
+		t.Fatalf("Read after storm: %s", err)
+	}
+	if len(c.Vaults) != writers*rounds {
+		t.Errorf("%d targets survived the storm, want %d", len(c.Vaults), writers*rounds)
+	}
+}

--- a/pkg/rc/config.go
+++ b/pkg/rc/config.go
@@ -1,6 +1,7 @@
 package rc
 
 import (
+	"errors"
 	"os"
 	"os/signal"
 	"runtime"
@@ -125,14 +126,35 @@ func Apply(use string) (Config, error) {
 	return c, nil
 }
 
+// Update applies a single mutation to the persisted configuration. It takes
+// the config write lock, reads the current on-disk state, invokes mutate on
+// it, writes the result atomically, and releases the lock.
+//
+// Reading under the lock, immediately before mutating, is what makes a
+// concurrent writer's delta survive: each mutation lands on the latest file,
+// not on whatever this process read at startup. Keep mutate to the mutation
+// itself -- the lock is held for its duration, so no prompts, no network I/O,
+// nothing slower than the file writes it protects.
+func Update(mutate func(c *Config) error) error {
+	return withLock(func() error {
+		c, err := Read()
+		if err != nil {
+			return err
+		}
+		if err := mutate(&c); err != nil {
+			return err
+		}
+		return c.Write()
+	})
+}
+
 func (c *Config) Write() error {
 	b, err := yaml.Marshal(c)
 	if err != nil {
 		return err
 	}
 
-	err = os.WriteFile(saferc(), b, 0600)
-	if err != nil {
+	if err := writeFileAtomic(saferc(), b, 0600); err != nil {
 		return err
 	}
 
@@ -141,7 +163,9 @@ func (c *Config) Write() error {
 		return err
 	}
 	if v == nil {
-		_ = os.Remove(svtoken())
+		if err := os.Remove(svtoken()); err != nil && !os.IsNotExist(err) {
+			return err
+		}
 		return nil
 	}
 
@@ -162,11 +186,15 @@ func (c *Config) Write() error {
 	if err != nil {
 		return err
 	}
-	if c.Options.ManageVaultToken {
-		_ = os.WriteFile(fmt.Sprintf("%s/.vault-token", userHomeDir()), []byte(v.Token), 0600)
-	}
 
-	return os.WriteFile(svtoken(), b, 0600)
+	// .vault-token before .svtoken, with both attempted and both reported:
+	// managing ~/.vault-token is an explicit operator opt-in, and failing it
+	// silently leaves the Vault CLI authenticated as whoever wrote it last.
+	var tokenErr error
+	if c.Options.ManageVaultToken {
+		tokenErr = writeFileAtomic(fmt.Sprintf("%s/.vault-token", userHomeDir()), []byte(v.Token), 0600)
+	}
+	return errors.Join(tokenErr, writeFileAtomic(svtoken(), b, 0600))
 }
 
 // Returns the path of the file that the certificates were written into

--- a/pkg/rc/config.go
+++ b/pkg/rc/config.go
@@ -144,11 +144,11 @@ func Update(mutate func(c *Config) error) error {
 		if err := mutate(&c); err != nil {
 			return err
 		}
-		return c.Write()
+		return c.write()
 	})
 }
 
-func (c *Config) Write() error {
+func (c *Config) write() error {
 	b, err := yaml.Marshal(c)
 	if err != nil {
 		return err

--- a/pkg/rc/config_test.go
+++ b/pkg/rc/config_test.go
@@ -187,7 +187,7 @@ func TestWrite(t *testing.T) {
 				"prod": {URL: "https://vault.prod:8200", Token: "prod-token", Namespace: "ns"},
 			},
 		}
-		if err := c.Write(); err != nil {
+		if err := c.write(); err != nil {
 			t.Fatalf("Write: %s", err)
 		}
 
@@ -211,7 +211,7 @@ func TestWrite(t *testing.T) {
 		writeFile(t, filepath.Join(home, ".svtoken"), "stale: true\n")
 
 		c := Config{Version: 1} // Current empty => Vault("") returns nil
-		if err := c.Write(); err != nil {
+		if err := c.write(); err != nil {
 			t.Fatalf("Write: %s", err)
 		}
 		if _, err := os.Stat(filepath.Join(home, ".saferc")); err != nil {
@@ -230,7 +230,7 @@ func TestWrite(t *testing.T) {
 			Vaults:  map[string]*Vault{"prod": {URL: "https://vault.prod:8200", Token: "secret-token"}},
 			Options: Options{ManageVaultToken: true},
 		}
-		if err := c.Write(); err != nil {
+		if err := c.write(); err != nil {
 			t.Fatalf("Write: %s", err)
 		}
 		assertPerm(t, filepath.Join(home, ".vault-token"), 0600)
@@ -248,7 +248,7 @@ func TestWrite(t *testing.T) {
 				"prod": {URL: "https://vault.prod:8200", Token: "prod-token", SkipVerify: true, Namespace: "ns"},
 			},
 		}
-		if err := c.Write(); err != nil {
+		if err := c.write(); err != nil {
 			t.Fatalf("Write: %s", err)
 		}
 		got, err := Read()

--- a/pkg/rc/lock.go
+++ b/pkg/rc/lock.go
@@ -1,0 +1,69 @@
+package rc
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gofrs/flock"
+	fmt "github.com/jhunt/go-ansi"
+)
+
+// configMutex serializes writers within one process. flock(2) locks are held
+// per open file description, not per process, so without it two goroutines
+// taking the file lock through separate opens would not conflict -- and two
+// through a shared one would silently succeed together.
+var configMutex sync.Mutex
+
+// How long a writer waits for whoever holds the lock, and how often it asks
+// again. The lock only ever covers milliseconds of file I/O, so a holder that
+// keeps another writer waiting anywhere near this long is gone or wedged --
+// give up with an error rather than write unlocked. Variables so tests can
+// prove the timeout path without sitting through it.
+var (
+	lockTimeout    = 10 * time.Second
+	lockRetryDelay = 50 * time.Millisecond
+)
+
+func lockPath() string {
+	return fmt.Sprintf("%s/.saferc.lock", userHomeDir())
+}
+
+// withLock runs fn while holding an exclusive lock over the config files
+// (.saferc, .svtoken, .vault-token, written together as one transaction).
+//
+// The lock lives on a sidecar file, ~/.saferc.lock, not on .saferc itself:
+// writes replace .saferc by rename, which swaps the inode, and a lock on a
+// replaced inode excludes nobody. The sidecar is created once and never
+// removed -- unlinking a lock file reintroduces the same inode race.
+//
+// flock locks die with the process, so a writer killed mid-transaction --
+// including safe local's own die(), which calls os.Exit -- cannot leave the
+// lock stuck. No staleness handling is needed or present.
+//
+// Caveat: on filesystems where flock is advisory-only per client (NFS before
+// v4, some network mounts), concurrent safes on *different hosts* sharing a
+// $HOME are not serialized. The atomic rename still makes corruption
+// impossible there; the exposure degrades to a lost update.
+func withLock(fn func() error) error {
+	configMutex.Lock()
+	defer configMutex.Unlock()
+
+	fl := flock.New(lockPath(), flock.SetPermissions(0600))
+	ctx, cancel := context.WithTimeout(context.Background(), lockTimeout)
+	defer cancel()
+
+	locked, err := fl.TryLockContext(ctx, lockRetryDelay)
+	if err != nil && !locked {
+		if ctx.Err() != nil {
+			return fmt.Errorf("timed out after %s waiting to lock %s (another safe holding it? remove the file only if you are sure none is running)", lockTimeout, lockPath())
+		}
+		return fmt.Errorf("could not lock %s: %w", lockPath(), err)
+	}
+	if !locked {
+		return fmt.Errorf("could not lock %s", lockPath())
+	}
+	defer func() { _ = fl.Unlock() }()
+
+	return fn()
+}

--- a/pkg/rc/lock_test.go
+++ b/pkg/rc/lock_test.go
@@ -1,0 +1,128 @@
+package rc
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+// shortenLockWaits makes lock-contention tests fast. The real values wait 10s
+// for a holder to finish; a test that proves the timeout path cannot sit
+// through that.
+func shortenLockWaits(t *testing.T) {
+	prevTimeout, prevDelay := lockTimeout, lockRetryDelay
+	lockTimeout = 100 * time.Millisecond
+	lockRetryDelay = 5 * time.Millisecond
+	t.Cleanup(func() {
+		lockTimeout, lockRetryDelay = prevTimeout, prevDelay
+	})
+}
+
+func TestWithLockRunsFn(t *testing.T) {
+	setHome(t)
+
+	ran := false
+	if err := withLock(func() error {
+		ran = true
+		return nil
+	}); err != nil {
+		t.Fatalf("withLock: %s", err)
+	}
+	if !ran {
+		t.Fatalf("withLock returned without running fn")
+	}
+
+	// The sidecar must exist afterward and must not be world-readable: it
+	// sits next to a file of root tokens and shares its directory perms.
+	fi, err := os.Stat(lockPath())
+	if err != nil {
+		t.Fatalf("lock file after withLock: %s", err)
+	}
+	if got := fi.Mode().Perm(); got != 0600 {
+		t.Errorf("lock file mode = %04o, want 0600", got)
+	}
+}
+
+func TestWithLockPropagatesFnError(t *testing.T) {
+	setHome(t)
+
+	sentinel := errors.New("mutation failed")
+	if err := withLock(func() error { return sentinel }); !errors.Is(err, sentinel) {
+		t.Fatalf("withLock error = %v, want %v", err, sentinel)
+	}
+
+	// The failure must have released the lock: a second writer proceeds.
+	if err := withLock(func() error { return nil }); err != nil {
+		t.Fatalf("withLock after failed fn: %s", err)
+	}
+}
+
+func TestWithLockExcludesConcurrentWriters(t *testing.T) {
+	setHome(t)
+
+	var inside, total int
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := withLock(func() error {
+				mu.Lock()
+				inside++
+				if inside > 1 {
+					t.Errorf("%d writers inside the critical section", inside)
+				}
+				mu.Unlock()
+
+				time.Sleep(2 * time.Millisecond)
+
+				mu.Lock()
+				inside--
+				total++
+				mu.Unlock()
+				return nil
+			})
+			if err != nil {
+				t.Errorf("withLock: %s", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if total != 8 {
+		t.Errorf("%d of 8 writers ran", total)
+	}
+}
+
+func TestWithLockTimesOutWhenHeld(t *testing.T) {
+	setHome(t)
+	shortenLockWaits(t)
+
+	// Hold the file lock through a separate open file description, the way
+	// another process would. flock(2) locks are per open file description,
+	// so this conflicts with withLock's own even within one test binary.
+	holder := flock.New(lockPath(), flock.SetPermissions(0600))
+	locked, err := holder.TryLock()
+	if err != nil || !locked {
+		t.Fatalf("could not pre-acquire lock (locked=%v): %v", locked, err)
+	}
+	defer func() { _ = holder.Unlock() }()
+
+	err = withLock(func() error {
+		t.Error("fn ran while the lock was held elsewhere")
+		return nil
+	})
+	if err == nil {
+		t.Fatalf("withLock succeeded against a held lock")
+	}
+	if !strings.Contains(err.Error(), lockPath()) {
+		t.Errorf("timeout error %q does not name the lock file", err)
+	}
+}

--- a/pkg/rc/update_test.go
+++ b/pkg/rc/update_test.go
@@ -1,0 +1,162 @@
+package rc
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpdatePersistsMutation(t *testing.T) {
+	setHome(t)
+
+	err := Update(func(c *Config) error {
+		return c.SetTarget("unit", Vault{URL: "http://127.0.0.1:8201"})
+	})
+	if err != nil {
+		t.Fatalf("Update: %s", err)
+	}
+
+	c, err := Read()
+	if err != nil {
+		t.Fatalf("Read: %s", err)
+	}
+	if v, ok, _ := c.Find("unit"); !ok || v.URL != "http://127.0.0.1:8201" {
+		t.Errorf("target not persisted: found=%v", ok)
+	}
+	if c.Current != "unit" {
+		t.Errorf("current = %q, want %q", c.Current, "unit")
+	}
+}
+
+// The lost-update defect: a writer applying its delta to state it read
+// earlier erases whatever landed in between. Update must read at mutation
+// time, under the lock, so a delta lands on top of the latest file.
+func TestUpdateAppliesDeltaToLatestState(t *testing.T) {
+	setHome(t)
+
+	if err := Update(func(c *Config) error {
+		return c.SetTarget("first", Vault{URL: "http://first"})
+	}); err != nil {
+		t.Fatalf("seed: %s", err)
+	}
+
+	// Another process's write, after this process last read the file.
+	writeFile(t, saferc(), strings.Join([]string{
+		"version: 1",
+		"current: second",
+		"vaults:",
+		"  first:",
+		"    url: http://first",
+		"  second:",
+		"    url: http://second",
+	}, "\n")+"\n")
+
+	if err := Update(func(c *Config) error {
+		return c.SetTarget("third", Vault{URL: "http://third"})
+	}); err != nil {
+		t.Fatalf("Update: %s", err)
+	}
+
+	c, err := Read()
+	if err != nil {
+		t.Fatalf("Read: %s", err)
+	}
+	for _, name := range []string{"first", "second", "third"} {
+		if _, ok, _ := c.Find(name); !ok {
+			t.Errorf("target %q lost", name)
+		}
+	}
+}
+
+func TestUpdateMutationErrorAbortsWrite(t *testing.T) {
+	setHome(t)
+
+	writeFile(t, saferc(), "version: 1\ncurrent: keep\nvaults:\n  keep:\n    url: http://keep\n")
+	before := readFile(t, saferc())
+
+	sentinel := errors.New("no thanks")
+	err := Update(func(c *Config) error {
+		c.Current = "clobbered"
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Update error = %v, want %v", err, sentinel)
+	}
+
+	if after := readFile(t, saferc()); after != before {
+		t.Errorf(".saferc changed after failed mutation:\n%s", after)
+	}
+}
+
+// A legacy (version 0) file read by Update must round-trip into a valid
+// version 1 file with its targets intact.
+func TestUpdateUpgradesLegacyConfig(t *testing.T) {
+	setHome(t)
+
+	writeFile(t, saferc(), strings.Join([]string{
+		"Current: http://legacy",
+		"Targets:",
+		"  http://legacy: sekrit-token",
+		"Aliases:",
+		"  legacy: http://legacy",
+		"SkipVerify:",
+		"  http://legacy: true",
+	}, "\n")+"\n")
+
+	if err := Update(func(c *Config) error { return nil }); err != nil {
+		t.Fatalf("Update: %s", err)
+	}
+
+	c, err := Read()
+	if err != nil {
+		t.Fatalf("Read after upgrade: %s", err)
+	}
+	if c.Version != 1 {
+		t.Errorf("version = %d, want 1", c.Version)
+	}
+	v, ok, _ := c.Find("legacy")
+	if !ok {
+		t.Fatalf("legacy target lost in upgrade")
+	}
+	if v.Token != "sekrit-token" || !v.SkipVerify {
+		t.Errorf("legacy target = %+v", v)
+	}
+}
+
+// manage_vault_token failures must surface (the operator opted in; failing
+// silently leaves the Vault CLI authenticated as someone else), and a failure
+// there must not stop the .svtoken write behind it.
+func TestWriteSurfacesVaultTokenError(t *testing.T) {
+	dir := setHome(t)
+
+	// A directory where the file should be makes the atomic rename fail.
+	if err := os.Mkdir(filepath.Join(dir, ".vault-token"), 0700); err != nil {
+		t.Fatalf("mkdir: %s", err)
+	}
+
+	err := Update(func(c *Config) error {
+		c.Options.ManageVaultToken = true
+		return c.SetTarget("t", Vault{URL: "http://t", Token: "tok"})
+	})
+	if err == nil {
+		t.Fatalf("Update succeeded with an unwritable .vault-token")
+	}
+	if !strings.Contains(err.Error(), ".vault-token") {
+		t.Errorf("error %q does not name .vault-token", err)
+	}
+
+	// The trailing .svtoken write still happened.
+	if _, statErr := os.Stat(svtoken()); statErr != nil {
+		t.Errorf(".svtoken missing after .vault-token failure: %s", statErr)
+	}
+	// And .saferc itself was written before the failure.
+	c, readErr := Read()
+	if readErr != nil {
+		t.Fatalf("Read: %s", readErr)
+	}
+	if _, ok, _ := c.Find("t"); !ok {
+		t.Errorf(".saferc write did not happen")
+	}
+}


### PR DESCRIPTION
## Problem

Running several `safe` processes against one `$HOME` corrupts state in three
independent ways:

1. **Lost updates and torn files.** Every command that changes `~/.saferc`
   does an unlocked read-mutate-truncating-write. Concurrent writers silently
   drop each other's targets, and readers can observe a half-written YAML
   document (the production artifact was a complete document with the tail of
   a longer one appended).
2. **Cross-connection.** `safe local` talked to its vault through the freshly
   re-read `current` target — which, under concurrency, may belong to a
   *different* process's vault (or a remote production vault). Losers of a
   startup race would `init`/`unseal`/mount someone else's server
   ("Vault is already initialized").
3. **Port TOCTOU.** Port selection dial-probed for a free port, then launched
   the server later; every concurrent starter raced toward the same "free"
   port and lost races surfaced as generic startup timeouts.

## Changes

- **`~/.saferc.lock` sidecar + atomic writes** (`pkg/rc`): all config
  mutations serialize on a `flock`-based sidecar lock (10s timeout, in-process
  mutex for goroutine safety), and every file write goes through a
  same-directory temp file + `fsync` + `rename`, so readers only ever see
  complete documents and a failed write leaves the original intact. The lock
  file is never unlinked (unlink would reintroduce the race via inode swap).
- **`rc.Update(func(*Config) error)`** (`pkg/rc`): the only way to persist
  config changes is now a read-mutate-write cycle under the lock. `Config`'s
  write method is unexported, so the old lost-update pattern no longer
  compiles. All call sites migrated (`target`, `option`, `init`, `local`).
- **`safe local` direct connection** (`internal/cli`): the local server is
  addressed by its own URL and token everywhere — never through the shared
  `current` target. Token storage uses `SetTokenFor(name, …)` instead of
  `SetToken` (which delegated through a possibly-foreign `current`).
  Registration happens only after the server is verified ready, so failed
  starts leave nothing behind in `~/.saferc`.
- **Bind-probe + authoritative retry** (`internal/cli`): port candidates are
  chosen by actually binding, and the server's own "address already in use"
  bind failure — the only authoritative signal — triggers a bounded retry
  (10 attempts) onto a new candidate. An explicit `--port` never retries; it
  fails with `port N is already in use` and points at the flag.
- **Readiness hardening** (found by the new tests): the readiness poll used
  to accept *any* HTTP answer on the port. A child that lost the bind race
  would see the race winner answer, be declared ready, and initialize the
  winner's vault. Readiness now requires an answer *and* our child alive
  *and* no bind failure in its output.
- **Error policy for `safe local`**: registration failure is fatal
  (pre-init, nothing lost); token-save failure warns with the URL, token,
  and recovery commands (the server keeps running); teardown failure warns
  with the `safe targets delete` cleanup command and still reports the
  child's exit status.

## Testing

All new behavior is covered by tests committed alongside their fixes:

- `pkg/rc`: lock/atomic-write units, `Update` semantics (including a legacy
  `version: 0` round-trip), an 8-writer lost-update storm, and a
  readers-vs-writers torn-file storm — all race-enabled.
- `internal/cli`: real multi-process end-to-end tests — four concurrent
  `safe local` fleets sharing one `$HOME` (auto-scan and explicit ports),
  per-vault secret round-trips proving no cross-connection, decoy-vault
  tests proving a hostile `current` target receives zero requests through
  the full lifecycle (including a replay of the incident where an unwritable
  `$HOME` caused `safe local` to init a *remote* vault), held-port and
  bounded-retry tests, and temp-config leak checks. Engine-dependent tests
  skip when neither `vault` nor `bao` is installed.

`gofmt` clean, `go vet` clean, `go test ./... -race` green, and
`make build-all` succeeds for all five platforms.

## Known limitation

`os.Rename` over the config files is exercised by tests on unix only; the
windows/amd64 build is verified by cross-compilation, not by running the
suite on Windows.
