### PR TITLE
Cover the untested Vault API paths in pkg/vault

### DIFF
--- a/pkg/vault/delete_versions_undelete_test.go
+++ b/pkg/vault/delete_versions_undelete_test.go
@@ -1,0 +1,238 @@
+// DeleteVersions and Undelete are the two whole-version operations `safe rm`
+// and `safe undelete` stand on. On a KV v2 mount, deleting marks versions
+// recoverable and undeleting brings one back; on v1 there are no versions to
+// mark, so DeleteVersions destroys outright. Undelete also explains what it
+// could not restore -- a key, a missing secret, a destroyed or never-written
+// version -- and its version errors are deliberately plain errors rather
+// than not-found ones, so that MoveCopyTree's walk does not swallow them.
+
+package vault_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+func TestDeleteVersionsMarksV2VersionsDeleted(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv2")
+	fv.setV2("kv2/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+
+	if err := v.DeleteVersions("kv2/app", []uint{1}); err != nil {
+		t.Fatalf("DeleteVersions: %v", err)
+	}
+
+	got := fv.v2States("kv2/app")
+	want := []string{"deleted", "alive"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+	//The latest version was not named, so the secret still reads.
+	s, err := v.Read("kv2/app")
+	if err != nil {
+		t.Fatalf("Read after deleting version 1: %v", err)
+	}
+	if s.Get("password") != "two" {
+		t.Errorf("password = %q, want %q", s.Get("password"), "two")
+	}
+}
+
+func TestDeleteVersionsCanNameEveryVersion(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv2")
+	fv.setV2("kv2/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+
+	if err := v.DeleteVersions("kv2/app", []uint{1, 2}); err != nil {
+		t.Fatalf("DeleteVersions: %v", err)
+	}
+
+	got := fv.v2States("kv2/app")
+	want := []string{"deleted", "deleted"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+	_, err := v.Read("kv2/app")
+	assertSecretNotFound(t, err)
+}
+
+// A v1 backend has nothing to mark, so DeleteVersions falls through to a
+// real delete and the secret is gone for good.
+func TestDeleteVersionsDestroysOnAV1Mount(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/app", map[string]string{"password": "one"})
+
+	if err := v.DeleteVersions("secret/app", []uint{1}); err != nil {
+		t.Fatalf("DeleteVersions: %v", err)
+	}
+
+	secretAbsent(t, fv, "secret/app")
+}
+
+// With no version named, Undelete restores the newest version and leaves
+// older deletions alone.
+func TestUndeleteRestoresTheLatestVersion(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv2")
+	fv.setV2("kv2/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+	fv.deleteV2("kv2/app", 1, 2)
+
+	if err := v.Undelete("kv2/app"); err != nil {
+		t.Fatalf("Undelete: %v", err)
+	}
+
+	got := fv.v2States("kv2/app")
+	want := []string{"deleted", "alive"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+	s, err := v.Read("kv2/app")
+	if err != nil {
+		t.Fatalf("Read after undelete: %v", err)
+	}
+	if s.Get("password") != "two" {
+		t.Errorf("password = %q, want %q", s.Get("password"), "two")
+	}
+}
+
+func TestUndeleteRestoresANamedVersion(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv2")
+	fv.setV2("kv2/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+	fv.deleteV2("kv2/app", 1)
+
+	if err := v.Undelete("kv2/app^1"); err != nil {
+		t.Fatalf("Undelete: %v", err)
+	}
+
+	got := fv.v2States("kv2/app")
+	want := []string{"alive", "alive"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("version states = %v, want %v", got, want)
+	}
+	s, err := v.Read("kv2/app^1")
+	if err != nil {
+		t.Fatalf("Read of the restored version: %v", err)
+	}
+	if s.Get("password") != "one" {
+		t.Errorf("password = %q, want %q", s.Get("password"), "one")
+	}
+}
+
+// Deletion works on whole versions, so a path naming a key has nothing
+// Undelete could restore on its own.
+func TestUndeleteRefusesAKey(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv2")
+	fv.setV2("kv2/app", map[string]string{"password": "one"})
+
+	err := v.Undelete("kv2/app:password")
+	if err == nil {
+		t.Fatal("Undelete of a key returned nil, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "cannot undelete specific key") {
+		t.Errorf("error %q should say a key cannot be undeleted", err)
+	}
+}
+
+func TestUndeleteOfAMissingSecret(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv2")
+
+	err := v.Undelete("kv2/nowhere")
+	assertSecretNotFound(t, err)
+}
+
+// The version errors below are plain errors on purpose: Undelete is called
+// from the tree walk, and MoveCopyTree drops walk errors that answer to
+// IsNotFound, so an error that did would vanish without a word.
+func TestUndeleteOfADestroyedVersion(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv2")
+	fv.setV2("kv2/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+	fv.destroyV2("kv2/app", 1)
+
+	err := v.Undelete("kv2/app^1")
+	if err == nil {
+		t.Fatal("Undelete of a destroyed version returned nil, want an error")
+	}
+	want := vault.VersionNotFoundMessage("kv2/app", 1, "destroyed")
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err, want)
+	}
+	if vault.IsNotFound(err) {
+		t.Error("the error answers to IsNotFound, and the tree walk would drop it")
+	}
+}
+
+// A version below the oldest the metadata still lists was trimmed away, and
+// trimming destroys.
+func TestUndeleteOfATrimmedVersion(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv2")
+	fv.setV2("kv2/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+		map[string]string{"password": "three"},
+	)
+	fv.trimV2("kv2/app", 2)
+
+	err := v.Undelete("kv2/app^1")
+	if err == nil {
+		t.Fatal("Undelete of a trimmed version returned nil, want an error")
+	}
+	want := vault.VersionNotFoundMessage("kv2/app", 1, "destroyed")
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err, want)
+	}
+	if vault.IsNotFound(err) {
+		t.Error("the error answers to IsNotFound, and the tree walk would drop it")
+	}
+}
+
+func TestUndeleteOfAVersionNeverWritten(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv2")
+	fv.setV2("kv2/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+
+	err := v.Undelete("kv2/app^5")
+	if err == nil {
+		t.Fatal("Undelete of an unwritten version returned nil, want an error")
+	}
+	want := vault.VersionNotFoundMessage("kv2/app", 5, "")
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err, want)
+	}
+	if vault.IsNotFound(err) {
+		t.Error("the error answers to IsNotFound, and the tree walk would drop it")
+	}
+}

--- a/pkg/vault/explain_not_found_test.go
+++ b/pkg/vault/explain_not_found_test.go
@@ -1,0 +1,123 @@
+// ExplainNotFound narrows a not-found error from Read after the fact: when
+// the secret exists and only its newest version cannot be read, it says
+// which version and what became of it. It must narrow nothing else -- not a
+// foreign error, not a versioned path the caller already named, not a
+// secret with no history, and not a 404 whose newest version turns out to
+// be alive -- because a wrong explanation is worse than none.
+
+package vault_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+func TestExplainNotFoundNamesADeletedLatestVersion(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv2")
+	fv.setV2("kv2/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+	fv.deleteV2("kv2/app", 2)
+
+	_, err := v.Read("kv2/app")
+	assertSecretNotFound(t, err)
+
+	got := v.ExplainNotFound("kv2/app", err)
+	want := vault.VersionNotFoundMessage("kv2/app", 2, "deleted")
+	if got.Error() != want {
+		t.Errorf("explained error = %q, want %q", got, want)
+	}
+	//The narrowed error keeps its kind: exists, gen, and friends still
+	// branch on IsSecretNotFound.
+	if !vault.IsSecretNotFound(got) {
+		t.Error("the explanation stopped answering to IsSecretNotFound")
+	}
+}
+
+func TestExplainNotFoundNamesADestroyedLatestVersion(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv2")
+	fv.setV2("kv2/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+	fv.destroyV2("kv2/app", 2)
+
+	_, err := v.Read("kv2/app")
+	assertSecretNotFound(t, err)
+
+	got := v.ExplainNotFound("kv2/app", err)
+	want := vault.VersionNotFoundMessage("kv2/app", 2, "destroyed")
+	if got.Error() != want {
+		t.Errorf("explained error = %q, want %q", got, want)
+	}
+	if !vault.IsSecretNotFound(got) {
+		t.Error("the explanation stopped answering to IsSecretNotFound")
+	}
+}
+
+// An error that is not a secret-not-found is none of ExplainNotFound's
+// business, nil included.
+func TestExplainNotFoundLeavesOtherErrorsAlone(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+
+	boom := errors.New("connection refused")
+	if got := v.ExplainNotFound("secret/app", boom); got != boom {
+		t.Errorf("ExplainNotFound rewrote a foreign error into %q", got)
+	}
+	if got := v.ExplainNotFound("secret/app", nil); got != nil {
+		t.Errorf("ExplainNotFound turned nil into %q", got)
+	}
+}
+
+// A read that named a version already got the most specific answer there
+// is, from notFoundReading; explaining it again could only say less.
+func TestExplainNotFoundLeavesAVersionedPathAlone(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv2")
+	fv.setV2("kv2/app", map[string]string{"password": "one"})
+	fv.deleteV2("kv2/app", 1)
+
+	err := vault.NewSecretNotFoundError("kv2/app")
+	if got := v.ExplainNotFound("kv2/app^1", err); got != err {
+		t.Errorf("ExplainNotFound rewrote a versioned miss into %q", got)
+	}
+}
+
+// No history means the secret itself is the best answer.
+func TestExplainNotFoundOnASecretWithNoHistory(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv2")
+
+	err := vault.NewSecretNotFoundError("kv2/nowhere")
+	if got := v.ExplainNotFound("kv2/nowhere", err); got != err {
+		t.Errorf("ExplainNotFound rewrote a plain miss into %q", got)
+	}
+}
+
+// A 404 with an alive newest version was about something else entirely, and
+// blaming the version would send the reader to `safe versions` for nothing.
+func TestExplainNotFoundWhenTheLatestVersionIsAlive(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv2")
+	fv.setV2("kv2/app",
+		map[string]string{"password": "one"},
+		map[string]string{"password": "two"},
+	)
+	fv.deleteV2("kv2/app", 1)
+
+	err := vault.NewSecretNotFoundError("kv2/app")
+	if got := v.ExplainNotFound("kv2/app", err); got != err {
+		t.Errorf("ExplainNotFound blamed an alive version: %q", got)
+	}
+}

--- a/pkg/vault/find_signing_ca_test.go
+++ b/pkg/vault/find_signing_ca_test.go
@@ -1,0 +1,225 @@
+// FindSigningCA picks the authority for every x509 command that signs:
+// named explicitly with --signed-by it must exist and be a CA; left unnamed,
+// a self-signed certificate answers for itself, and otherwise the `ca`
+// sibling is tried - but only accepted when it actually signed the
+// certificate, since renewing under a stranger would silently change the
+// issuer.
+
+package vault_test
+
+import (
+	"crypto/x509"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudfoundry-community/safe/pkg/vault"
+)
+
+// reparse swaps the in-memory template for the certificate as signed.
+// FindSigningCA checks signatures from the parsed fields, and every
+// certificate it meets in earnest was read back out of the Vault, where
+// those fields are always filled in.
+func reparse(t *testing.T, x *vault.X509) {
+	t.Helper()
+	parsed, err := x509.ParseCertificate(x.Certificate.Raw)
+	if err != nil {
+		t.Fatalf("parse the signed certificate: %v", err)
+	}
+	x.Certificate = parsed
+}
+
+// caNamed builds a self-signed CA. ed25519 keeps the many certificates
+// these tests mint cheap.
+func caNamed(t *testing.T, cn string) *vault.X509 {
+	t.Helper()
+	ca, err := vault.NewCertificate("CN="+cn, []string{cn},
+		[]string{"key_cert_sign", "crl_sign"}, "",
+		vault.KeySpec{Algorithm: "ed25519"})
+	if err != nil {
+		t.Fatalf("NewCertificate: %v", err)
+	}
+	ca.MakeCA()
+	if err := ca.Sign(ca, 24*time.Hour); err != nil {
+		t.Fatalf("self-sign %s: %v", cn, err)
+	}
+	reparse(t, ca)
+	return ca
+}
+
+// leafSignedBy builds a non-CA certificate signed by the given authority.
+func leafSignedBy(t *testing.T, ca *vault.X509) *vault.X509 {
+	t.Helper()
+	leaf, err := vault.NewCertificate("CN=leaf", []string{"leaf"},
+		[]string{"digital_signature"}, "",
+		vault.KeySpec{Algorithm: "ed25519"})
+	if err != nil {
+		t.Fatalf("NewCertificate: %v", err)
+	}
+	if err := ca.Sign(leaf, 24*time.Hour); err != nil {
+		t.Fatalf("sign the leaf: %v", err)
+	}
+	reparse(t, leaf)
+	return leaf
+}
+
+// writeCert stores a certificate where the Vault under test can read it.
+func writeCert(t *testing.T, v *vault.Vault, path string, x *vault.X509) {
+	t.Helper()
+	s, err := x.Secret(false)
+	if err != nil {
+		t.Fatalf("Secret: %v", err)
+	}
+	if err := v.Write(path, s); err != nil {
+		t.Fatalf("Write %s: %v", path, err)
+	}
+}
+
+// A certificate named as its own authority signs itself; nothing is read.
+func TestFindSigningCANamedAsItself(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+	ca := caNamed(t, "self")
+
+	got, path, err := v.FindSigningCA(ca, "secret/ca", "secret/ca")
+	if err != nil {
+		t.Fatalf("FindSigningCA: %v", err)
+	}
+	if got != ca || path != "secret/ca" {
+		t.Errorf("returned %v at %q, want the certificate itself at secret/ca", got, path)
+	}
+}
+
+func TestFindSigningCAReadsANamedAuthority(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+	ca := caNamed(t, "authority")
+	leaf := leafSignedBy(t, ca)
+	writeCert(t, v, "secret/ca", ca)
+
+	got, path, err := v.FindSigningCA(leaf, "secret/leaf", "secret/ca")
+	if err != nil {
+		t.Fatalf("FindSigningCA: %v", err)
+	}
+	if path != "secret/ca" {
+		t.Errorf("path = %q, want secret/ca", path)
+	}
+	if cn := got.Certificate.Subject.CommonName; cn != "authority" {
+		t.Errorf("returned CN %q, want authority", cn)
+	}
+}
+
+func TestFindSigningCARefusesANamedNonCA(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+	ca := caNamed(t, "authority")
+	leaf := leafSignedBy(t, ca)
+	writeCert(t, v, "secret/notca", leafSignedBy(t, ca))
+
+	_, _, err := v.FindSigningCA(leaf, "secret/leaf", "secret/notca")
+	if err == nil {
+		t.Fatal("FindSigningCA accepted a plain certificate as an authority")
+	}
+	if !strings.Contains(err.Error(), "secret/notca is not a certificate authority") {
+		t.Errorf("error %q should name secret/notca as no authority", err)
+	}
+}
+
+func TestFindSigningCAReportsAMissingNamedAuthority(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+	ca := caNamed(t, "authority")
+	leaf := leafSignedBy(t, ca)
+
+	_, _, err := v.FindSigningCA(leaf, "secret/leaf", "secret/absent")
+	if err == nil {
+		t.Fatal("FindSigningCA returned nil for an authority that is not there")
+	}
+	assertSecretNotFound(t, err)
+}
+
+// With no authority named, a self-signed certificate is its own.
+func TestFindSigningCAKeepsASelfSignedCert(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+	ca := caNamed(t, "self")
+
+	got, path, err := v.FindSigningCA(ca, "secret/ca", "")
+	if err != nil {
+		t.Fatalf("FindSigningCA: %v", err)
+	}
+	if got != ca || path != "secret/ca" {
+		t.Errorf("returned %v at %q, want the certificate itself at secret/ca", got, path)
+	}
+}
+
+// With no authority named, the `ca` sibling that signed the certificate is
+// the guess that gets accepted.
+func TestFindSigningCAFindsTheCASibling(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+	ca := caNamed(t, "sibling")
+	leaf := leafSignedBy(t, ca)
+	writeCert(t, v, "secret/x/ca", ca)
+
+	got, path, err := v.FindSigningCA(leaf, "secret/x/cert", "")
+	if err != nil {
+		t.Fatalf("FindSigningCA: %v", err)
+	}
+	if path != "secret/x/ca" {
+		t.Errorf("path = %q, want secret/x/ca", path)
+	}
+	if cn := got.Certificate.Subject.CommonName; cn != "sibling" {
+		t.Errorf("returned CN %q, want sibling", cn)
+	}
+}
+
+func TestFindSigningCAWithNoSiblingToGuess(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+	ca := caNamed(t, "authority")
+	leaf := leafSignedBy(t, ca)
+
+	_, _, err := v.FindSigningCA(leaf, "secret/x/cert", "")
+	if err == nil {
+		t.Fatal("FindSigningCA guessed an authority out of nothing")
+	}
+	if !strings.Contains(err.Error(), "no signing authority provided and no 'ca' sibling found") {
+		t.Errorf("error %q should say no authority was found", err)
+	}
+}
+
+// A sibling that is not the issuer is rejected: signing under it would hand
+// back a certificate with a different issuer than it went in with.
+func TestFindSigningCARefusesAStrangerSibling(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+	issuer := caNamed(t, "issuer")
+	stranger := caNamed(t, "stranger")
+	leaf := leafSignedBy(t, issuer)
+	writeCert(t, v, "secret/x/ca", stranger)
+
+	_, _, err := v.FindSigningCA(leaf, "secret/x/cert", "")
+	if err == nil {
+		t.Fatal("FindSigningCA accepted a sibling that did not sign the certificate")
+	}
+	if !strings.Contains(err.Error(), "--signed-by") {
+		t.Errorf("error %q should point at --signed-by", err)
+	}
+}
+
+func TestFindSigningCARefusesANonCASibling(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+	ca := caNamed(t, "authority")
+	leaf := leafSignedBy(t, ca)
+	writeCert(t, v, "secret/x/ca", leafSignedBy(t, ca))
+
+	_, _, err := v.FindSigningCA(leaf, "secret/x/cert", "")
+	if err == nil {
+		t.Fatal("FindSigningCA accepted a plain certificate sibling as an authority")
+	}
+	if !strings.Contains(err.Error(), "secret/x/ca is not a certificate authority") {
+		t.Errorf("error %q should name secret/x/ca as no authority", err)
+	}
+}

--- a/pkg/vault/httptest_helper_test.go
+++ b/pkg/vault/httptest_helper_test.go
@@ -8,6 +8,8 @@
 //
 //	GET  /v1/sys/internal/ui/mounts — mount discovery, with each mount's version
 //	GET  /v1/auth/token/lookup-self — token validity check (200 OK)
+//	POST /v1/auth/token/renew-self  — lease renewal (used by RenewLease)
+//	PUT/DELETE /v1/sys/generate-root/{attempt,update} — root token generation
 //	GET  /v1/sys/mounts            — list mounts (used by Mounts)
 //	POST /v1/sys/mounts/<path>     — enable a mount (used by AddMount)
 //	GET  /v1/<mount>/*             — read secret
@@ -22,6 +24,7 @@
 package vault_test
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"maps"
 	"net/http"
@@ -73,6 +76,20 @@ type fakeVault struct {
 	progress    int      // keys submitted so far this unseal attempt
 	rootToken   string   // returned by sys/init
 	initKeys    []string // returned by sys/init
+
+	// renewFails makes auth/token/renew-self answer 403, modeling a token
+	// that cannot renew itself.
+	renewFails bool
+
+	// genRoot models the sys/generate-root/attempt and /update endpoints.
+	// The fake plays a Vault old enough to accept the client's own OTP, so
+	// vaultkv XORs the encoded token with it and formats the result as a
+	// UUID. genRootToken is the plaintext token handed out on completion; it
+	// must be as long as the 16-byte OTP, and defaults to fakeRootToken.
+	genRootActive   bool
+	genRootOTP      []byte
+	genRootProgress int    // keys submitted so far; threshold completes it
+	genRootToken    []byte // plaintext token to encode, nil for the default
 
 	// rekey models the sys/rekey/init and sys/rekey/update endpoints.
 	rekeyActive   bool
@@ -264,6 +281,13 @@ func (f *fakeVault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case p == "/v1/auth/token/lookup-self" && r.Method == http.MethodGet:
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"id":"test-token"}}`))
+
+	case p == "/v1/auth/token/renew-self" && r.Method == http.MethodPost:
+		f.handleTokenRenewSelf(w)
+
+	case p == "/v1/sys/generate-root/attempt",
+		p == "/v1/sys/generate-root/update":
+		f.handleGenerateRoot(w, r)
 
 	case p == "/v1/sys/mounts" && r.Method == http.MethodGet:
 		w.Header().Set("Content-Type", "application/json")
@@ -553,6 +577,112 @@ func (f *fakeVault) handleSys(w http.ResponseWriter, r *http.Request) {
 
 	default:
 		jsonErr(w, http.StatusNotFound, "unhandled sys path: "+p)
+	}
+}
+
+// fakeRootToken is the plaintext root token generate-root hands out when a
+// test does not choose one. It is 16 bytes because vaultkv's OTP is, and
+// the fake encodes the token by XOR against that OTP.
+const fakeRootToken = "0123456789abcdef"
+
+// handleTokenRenewSelf models auth/token/renew-self, which RenewLease posts
+// to with no body worth speaking of.
+func (f *fakeVault) handleTokenRenewSelf(w http.ResponseWriter) {
+	f.mu.RLock()
+	fails := f.renewFails
+	f.mu.RUnlock()
+	if fails {
+		jsonErr(w, http.StatusForbidden, "permission denied")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"auth":{"client_token":"test-token"}}`))
+}
+
+// handleGenerateRoot models the generate-root flow the way a Vault old
+// enough to accept the client's OTP ran it: the attempt stores the OTP the
+// client made up, each update submits one key, and reaching the unseal
+// threshold answers with the token XORed against that OTP. vaultkv then
+// undoes the XOR and formats the 16 bytes as a UUID.
+func (f *fakeVault) handleGenerateRoot(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	writeJSON := func(v any) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(v)
+	}
+	stateJSON := func(complete bool, encodedToken string) map[string]any {
+		return map[string]any{
+			"started":       true,
+			"nonce":         "genroot-nonce",
+			"progress":      f.genRootProgress,
+			"required":      f.threshold,
+			"complete":      complete,
+			"encoded_token": encodedToken,
+		}
+	}
+
+	switch {
+	case r.URL.Path == "/v1/sys/generate-root/attempt" && r.Method == http.MethodDelete:
+		f.genRootActive = false
+		f.genRootProgress = 0
+		w.WriteHeader(http.StatusNoContent)
+
+	case r.URL.Path == "/v1/sys/generate-root/attempt" && r.Method == http.MethodPut:
+		var body struct {
+			OTP string `json:"otp"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			jsonErr(w, http.StatusBadRequest, "invalid json")
+			return
+		}
+		otp, err := base64.StdEncoding.DecodeString(body.OTP)
+		if err != nil || len(otp) == 0 {
+			jsonErr(w, http.StatusBadRequest, "otp must be base64")
+			return
+		}
+		f.genRootActive = true
+		f.genRootProgress = 0
+		f.genRootOTP = otp
+		writeJSON(stateJSON(false, ""))
+
+	case r.URL.Path == "/v1/sys/generate-root/update" && r.Method == http.MethodPut:
+		if !f.genRootActive {
+			jsonErr(w, http.StatusBadRequest, "no root generation in progress")
+			return
+		}
+		var body struct {
+			Key   string `json:"key"`
+			Nonce string `json:"nonce"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			jsonErr(w, http.StatusBadRequest, "invalid json")
+			return
+		}
+		if body.Nonce != "genroot-nonce" {
+			jsonErr(w, http.StatusBadRequest, "incorrect nonce supplied")
+			return
+		}
+		f.genRootProgress++
+		if f.genRootProgress < f.threshold {
+			writeJSON(stateJSON(false, ""))
+			return
+		}
+
+		token := f.genRootToken
+		if token == nil {
+			token = []byte(fakeRootToken)
+		}
+		encoded := make([]byte, len(token))
+		for i := range token {
+			encoded[i] = token[i] ^ f.genRootOTP[i]
+		}
+		f.genRootActive = false
+		writeJSON(stateJSON(true, base64.StdEncoding.EncodeToString(encoded)))
+
+	default:
+		jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
 	}
 }
 

--- a/pkg/vault/httptest_helper_test.go
+++ b/pkg/vault/httptest_helper_test.go
@@ -15,9 +15,10 @@
 //	DELETE /v1/<mount>/*           — delete secret
 //	LIST /v1/<mount>/*             — list secrets (uses X-List-Method or PROPFIND-style)
 //
-// Every KV mount the fake serves is version 1. A version 2 mount answers on
-// different paths again -- data/, metadata/, delete/, undelete/, destroy/ --
-// and is not modelled here.
+// Every KV mount added with mount() is version 1. A version 2 mount answers
+// on different paths again -- data/, metadata/, delete/, undelete/,
+// destroy/ -- and is modelled in httptest_kv2_helper_test.go; add one with
+// mountV2().
 package vault_test
 
 import (
@@ -46,6 +47,10 @@ type fakeMount struct {
 type fakeVault struct {
 	mu   sync.RWMutex
 	data map[string]map[string]string // path → key → value
+
+	// v2data holds the version histories of secrets on KV v2 mounts, keyed
+	// by their full path. See httptest_kv2_helper_test.go.
+	v2data map[string]*fakeV2History
 
 	// mounts holds the KV mounts the fake serves, keyed by mount name with no
 	// slashes. A Vault has more than one mount and safe reaches all of them
@@ -81,6 +86,7 @@ type fakeVault struct {
 func newFakeVault() *fakeVault {
 	return &fakeVault{
 		data:      make(map[string]map[string]string),
+		v2data:    make(map[string]*fakeV2History),
 		mounts:    map[string]fakeMount{"secret": {typ: "kv", version: 1}},
 		forbidden: make(map[string]bool),
 		pki:       make(map[string]bool),
@@ -108,6 +114,13 @@ func (f *fakeVault) mountFor(path string) (name string, sub string, ok bool) {
 		return "", "", false
 	}
 	return name, strings.Trim(sub, "/"), true
+}
+
+// mountVersion returns the KV version of a mount, or 0 if there is none.
+func (f *fakeVault) mountVersion(name string) int {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.mounts[name].version
 }
 
 // forbid makes list and get requests for a secret path return 403.
@@ -312,6 +325,11 @@ func (f *fakeVault) handleEnableMount(w http.ResponseWriter, r *http.Request) {
 }
 
 func (f *fakeVault) handleKV(w http.ResponseWriter, r *http.Request, mount, subpath string) {
+	if f.mountVersion(mount) == 2 {
+		f.handleKVv2(w, r, mount, subpath)
+		return
+	}
+
 	// LIST is sent as GET with ?list=true or as PROPFIND-alike.
 	// vaultkv sends it as a GET with ?list=true query param for v1.
 	isList := r.Method == "LIST" || r.URL.Query().Get("list") == "true"

--- a/pkg/vault/httptest_kv2_helper_test.go
+++ b/pkg/vault/httptest_kv2_helper_test.go
@@ -1,0 +1,334 @@
+// The KV v2 half of the fake Vault server in httptest_helper_test.go. A v2
+// mount answers on data/, metadata/, delete/, undelete/, and destroy/ paths
+// and keeps a version history per secret rather than a single value, which
+// is what makes DeleteVersions, Undelete, and the version explanations of
+// ExplainNotFound reachable in a test at all.
+//
+// Version numbers count from fakeV2History.first, normally 1. trimV2 raises
+// it the way Vault's max_versions trimming drops the oldest versions from
+// the metadata, which is the one way a real history starts above 1.
+//
+// Endpoints handled, all under a mount added with mountV2:
+//
+//	GET    /v1/<mount>/data/<path>     — read a version (?version=0 is latest)
+//	PUT    /v1/<mount>/data/<path>     — write a new version
+//	DELETE /v1/<mount>/data/<path>     — mark the latest version deleted
+//	GET    /v1/<mount>/metadata/<path> — version history
+//	POST   /v1/<mount>/delete/<path>   — mark named versions deleted
+//	POST   /v1/<mount>/undelete/<path> — unmark named versions
+//	POST   /v1/<mount>/destroy/<path>  — mark named versions destroyed
+package vault_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// fakeV2Version is one version of a secret on a KV v2 mount.
+type fakeV2Version struct {
+	data      map[string]string
+	deleted   bool
+	destroyed bool
+}
+
+// fakeV2History is the version history of one secret on a v2 mount.
+type fakeV2History struct {
+	first    uint // number of versions[0]; 1 until trimV2 raises it
+	versions []*fakeV2Version
+}
+
+// mountV2 adds a KV version 2 mount. Secrets under it live in f.v2data and
+// are seeded with setV2 rather than set.
+func (f *fakeVault) mountV2(name string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.mounts[strings.Trim(name, "/")] = fakeMount{typ: "kv", version: 2}
+}
+
+// setV2 appends one version per map given, oldest first, at a literal Vault
+// path. Calling it twice on the same path keeps appending.
+func (f *fakeVault) setV2(path string, values ...map[string]string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, kv := range values {
+		f.appendV2Locked(path, kv)
+	}
+}
+
+// appendV2Locked adds a version. Callers hold f.mu.
+func (f *fakeVault) appendV2Locked(path string, kv map[string]string) uint {
+	h := f.v2data[path]
+	if h == nil {
+		h = &fakeV2History{first: 1}
+		f.v2data[path] = h
+	}
+	cp := make(map[string]string, len(kv))
+	for k, v := range kv {
+		cp[k] = v
+	}
+	h.versions = append(h.versions, &fakeV2Version{data: cp})
+	return h.first + uint(len(h.versions)) - 1
+}
+
+// deleteV2 marks versions deleted, which is reversible.
+func (f *fakeVault) deleteV2(path string, versions ...uint) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, n := range versions {
+		if v := f.v2VersionLocked(path, n); v != nil {
+			v.deleted = true
+		}
+	}
+}
+
+// destroyV2 marks versions destroyed, which is not.
+func (f *fakeVault) destroyV2(path string, versions ...uint) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, n := range versions {
+		if v := f.v2VersionLocked(path, n); v != nil {
+			v.destroyed = true
+		}
+	}
+}
+
+// trimV2 drops every version numbered below newFirst, the way Vault's
+// max_versions setting trims the oldest versions out of the metadata.
+func (f *fakeVault) trimV2(path string, newFirst uint) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	h := f.v2data[path]
+	if h == nil || newFirst <= h.first {
+		return
+	}
+	drop := newFirst - h.first
+	if int(drop) >= len(h.versions) {
+		h.versions = nil
+	} else {
+		h.versions = h.versions[drop:]
+	}
+	h.first = newFirst
+}
+
+// v2States reports each version of a path as "alive", "deleted", or
+// "destroyed", oldest first, for assertions.
+func (f *fakeVault) v2States(path string) []string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	h := f.v2data[path]
+	if h == nil {
+		return nil
+	}
+	var out []string
+	for _, v := range h.versions {
+		switch {
+		case v.destroyed:
+			out = append(out, "destroyed")
+		case v.deleted:
+			out = append(out, "deleted")
+		default:
+			out = append(out, "alive")
+		}
+	}
+	return out
+}
+
+// v2VersionLocked returns version n of a path, or nil. Callers hold f.mu.
+func (f *fakeVault) v2VersionLocked(path string, n uint) *fakeV2Version {
+	h := f.v2data[path]
+	if h == nil || n < h.first {
+		return nil
+	}
+	idx := int(n - h.first)
+	if idx >= len(h.versions) {
+		return nil
+	}
+	return h.versions[idx]
+}
+
+// v2LatestLocked returns the newest version and its number. Callers hold f.mu.
+func (f *fakeVault) v2LatestLocked(path string) (*fakeV2Version, uint) {
+	h := f.v2data[path]
+	if h == nil || len(h.versions) == 0 {
+		return nil, 0
+	}
+	return h.versions[len(h.versions)-1], h.first + uint(len(h.versions)) - 1
+}
+
+// handleKVv2 routes /v1/<mount>/<verb>/<path> for a version 2 mount.
+func (f *fakeVault) handleKVv2(w http.ResponseWriter, r *http.Request, mount, subpath string) {
+	verb, rest, _ := strings.Cut(subpath, "/")
+	path := mount
+	if rest != "" {
+		path += "/" + strings.Trim(rest, "/")
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	switch verb {
+	case "data":
+		f.serveV2Data(w, r, path)
+	case "metadata":
+		f.serveV2Metadata(w, r, path)
+	case "delete":
+		f.applyToVersions(w, r, path, func(v *fakeV2Version) {
+			if !v.destroyed {
+				v.deleted = true
+			}
+		})
+	case "undelete":
+		f.applyToVersions(w, r, path, func(v *fakeV2Version) {
+			//A destroyed version is gone for good and undelete cannot
+			// resurrect it, which is what Vault does too.
+			if !v.destroyed {
+				v.deleted = false
+			}
+		})
+	case "destroy":
+		f.applyToVersions(w, r, path, func(v *fakeV2Version) {
+			v.destroyed = true
+		})
+	default:
+		jsonErr(w, http.StatusNotFound, "")
+	}
+}
+
+// serveV2Data answers reads, writes, and the versionless delete. Callers
+// hold f.mu.
+func (f *fakeVault) serveV2Data(w http.ResponseWriter, r *http.Request, path string) {
+	switch r.Method {
+	case http.MethodPut, http.MethodPost:
+		var body struct {
+			Data map[string]string `json:"data"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			jsonErr(w, http.StatusBadRequest, "invalid json")
+			return
+		}
+		n := f.appendV2Locked(path, body.Data)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": v2VersionJSON(&fakeV2Version{}, n),
+		})
+
+	case http.MethodDelete:
+		//No version named deletes the latest.
+		if v, _ := f.v2LatestLocked(path); v != nil && !v.destroyed {
+			v.deleted = true
+		}
+		w.WriteHeader(http.StatusNoContent)
+
+	case http.MethodGet:
+		number := uint(0)
+		if q := r.URL.Query().Get("version"); q != "" {
+			parsed, err := strconv.ParseUint(q, 10, 64)
+			if err != nil {
+				jsonErr(w, http.StatusBadRequest, "invalid version")
+				return
+			}
+			number = uint(parsed)
+		}
+
+		var v *fakeV2Version
+		if number == 0 {
+			v, number = f.v2LatestLocked(path)
+		} else {
+			v = f.v2VersionLocked(path, number)
+		}
+		//A deleted or destroyed version still has metadata, but its data is
+		// gone; Vault answers 404, and vaultkv discards the body of any
+		// non-2xx response, so a bare 404 carries the same signal.
+		if v == nil || v.deleted || v.destroyed {
+			jsonErr(w, http.StatusNotFound, "")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"data":     v.data,
+				"metadata": v2VersionJSON(v, number),
+			},
+		})
+
+	default:
+		jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+// serveV2Metadata answers the version history read that Versions and the
+// not-found explanations rely on. Callers hold f.mu.
+func (f *fakeVault) serveV2Metadata(w http.ResponseWriter, r *http.Request, path string) {
+	if r.Method != http.MethodGet {
+		jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	h := f.v2data[path]
+	if h == nil || len(h.versions) == 0 {
+		jsonErr(w, http.StatusNotFound, "")
+		return
+	}
+
+	versions := map[string]any{}
+	for i, v := range h.versions {
+		n := h.first + uint(i)
+		versions[strconv.FormatUint(uint64(n), 10)] = v2VersionJSON(v, n)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"data": map[string]any{
+			"created_time":    fakeV2Time,
+			"updated_time":    fakeV2Time,
+			"current_version": h.first + uint(len(h.versions)) - 1,
+			"oldest_version":  h.first,
+			"max_versions":    0,
+			"versions":        versions,
+		},
+	})
+}
+
+// applyToVersions runs fn over every version named in the request body. An
+// empty list is a no-op rather than an error, matching Vault. Callers hold
+// f.mu.
+func (f *fakeVault) applyToVersions(w http.ResponseWriter, r *http.Request, path string, fn func(*fakeV2Version)) {
+	if r.Method != http.MethodPost && r.Method != http.MethodPut {
+		jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var body struct {
+		Versions []uint `json:"versions"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonErr(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	for _, n := range body.Versions {
+		if v := f.v2VersionLocked(path, n); v != nil {
+			fn(v)
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// fakeV2Time is the timestamp every version reports. Times are not what any
+// of the tests assert on; the string only has to parse as RFC3339.
+const fakeV2Time = "2020-01-01T00:00:00Z"
+
+// v2VersionJSON renders one version the way the metadata and data endpoints
+// carry it. A deleted version reports a deletion_time, which is how vaultkv
+// tells deletion apart from life.
+func v2VersionJSON(v *fakeV2Version, number uint) map[string]any {
+	deletion := ""
+	if v.deleted {
+		deletion = fakeV2Time
+	}
+	return map[string]any{
+		"created_time":  fakeV2Time,
+		"deletion_time": deletion,
+		"destroyed":     v.destroyed,
+		"version":       number,
+	}
+}

--- a/pkg/vault/renew_root_seal_test.go
+++ b/pkg/vault/renew_root_seal_test.go
@@ -1,0 +1,100 @@
+// RenewLease, NewRootToken, and SaveSealKeys are the three token-and-seal
+// operations safe runs against a live Vault: `safe renew` keeps the current
+// token alive, `safe rekey` can mint a new root token from unseal keys, and
+// init stores the unseal keys under secret/vault/seal/keys. Each is tested
+// against the fake's auth and sys endpoints.
+
+package vault_test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenewLease(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+
+	if err := v.RenewLease(); err != nil {
+		t.Fatalf("RenewLease: %v", err)
+	}
+}
+
+func TestRenewLeaseReportsARefusal(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.renewFails = true
+
+	if err := v.RenewLease(); err == nil {
+		t.Fatal("RenewLease returned nil for a token that cannot renew itself")
+	}
+}
+
+// Submitting the unseal threshold's worth of keys mints the token. The fake
+// encodes fakeRootToken against the client's one-time pad, and vaultkv
+// formats the decoded 16 bytes as a UUID, so the expectation is the hex of
+// "0123456789abcdef" in UUID grouping.
+func TestNewRootToken(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.threshold = 3
+
+	token, err := v.NewRootToken([]string{"key-a", "key-b", "key-c"})
+	if err != nil {
+		t.Fatalf("NewRootToken: %v", err)
+	}
+
+	want := "30313233-3435-3637-3839-616263646566"
+	if token != want {
+		t.Errorf("token = %q, want %q", token, want)
+	}
+}
+
+func TestNewRootTokenWithTooFewKeys(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.threshold = 3
+
+	_, err := v.NewRootToken([]string{"key-a", "key-b"})
+	if err == nil {
+		t.Fatal("NewRootToken returned nil below the threshold")
+	}
+	if !strings.Contains(err.Error(), "not enough keys") {
+		t.Errorf("error %q should say there were not enough keys", err)
+	}
+}
+
+func TestSaveSealKeys(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+
+	if err := v.SaveSealKeys([]string{"first", "second"}); err != nil {
+		t.Fatalf("SaveSealKeys: %v", err)
+	}
+
+	kv := mustGetSecret(t, fv, "secret/vault/seal/keys")
+	if len(kv) != 2 || kv["key1"] != "first" || kv["key2"] != "second" {
+		t.Errorf("stored keys = %v, want key1=first key2=second", kv)
+	}
+}
+
+// Saving again replaces the whole secret, so keys from a larger earlier set
+// do not linger past a rekey to fewer shares.
+func TestSaveSealKeysReplacesTheOldSet(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/vault/seal/keys", map[string]string{
+		"key1": "stale",
+		"key2": "stale",
+		"key3": "stale",
+	})
+
+	if err := v.SaveSealKeys([]string{"fresh"}); err != nil {
+		t.Fatalf("SaveSealKeys: %v", err)
+	}
+
+	kv := mustGetSecret(t, fv, "secret/vault/seal/keys")
+	if len(kv) != 1 || kv["key1"] != "fresh" {
+		t.Errorf("stored keys = %v, want only key1=fresh", kv)
+	}
+}

--- a/pkg/vault/strongbox_test.go
+++ b/pkg/vault/strongbox_test.go
@@ -1,0 +1,97 @@
+// Strongbox asks the strongbox agent beside the Vault for the seal state of
+// every node. The agent's port is fixed: StrongboxURL keeps only the host of
+// the Vault URL and always appends :8484, so the only way to stand in for it
+// is to actually listen there. The test binds 127.0.0.1:8484 -- the host a
+// fake Vault answers on -- and skips if the port is taken, rather than fail
+// on a machine that runs a real strongbox or anything else there.
+//
+// The subtests share that one listener and must not run in parallel with
+// each other; there is only one port 8484.
+
+package vault_test
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestStrongbox(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:8484")
+	if err != nil {
+		t.Skipf("cannot listen on 127.0.0.1:8484, the one port Strongbox calls: %s", err)
+	}
+
+	//The handler swaps per subtest; the mutex keeps the swap and the serving
+	// goroutine's read apart.
+	var mu sync.Mutex
+	var respond func(w http.ResponseWriter)
+	serve := func(fn func(w http.ResponseWriter)) {
+		mu.Lock()
+		defer mu.Unlock()
+		respond = fn
+	}
+
+	srv := &httptest.Server{
+		Listener: ln,
+		Config: &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/strongbox" {
+				http.NotFound(w, r)
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			respond(w)
+		})},
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	//The fake Vault also answers on 127.0.0.1, so the strongbox derived from
+	// its URL is the server above.
+	v, _ := newTestVault(t)
+
+	t.Run("reports each node's seal state", func(t *testing.T) {
+		serve(func(w http.ResponseWriter) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"10.0.0.1":"sealed","10.0.0.2":"unsealed"}`))
+		})
+
+		m, err := v.Strongbox()
+		if err != nil {
+			t.Fatalf("Strongbox: %v", err)
+		}
+		if len(m) != 2 || m["10.0.0.1"] != "sealed" || m["10.0.0.2"] != "unsealed" {
+			t.Errorf("Strongbox = %v, want the two nodes and their states", m)
+		}
+	})
+
+	t.Run("a non-200 answer names the code and the URL", func(t *testing.T) {
+		serve(func(w http.ResponseWriter) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		_, err := v.Strongbox()
+		if err == nil {
+			t.Fatal("Strongbox returned nil for a 500")
+		}
+		for _, want := range []string{"500", "http://127.0.0.1:8484/strongbox"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q should mention %q", err, want)
+			}
+		}
+	})
+
+	t.Run("an unparseable answer is an error", func(t *testing.T) {
+		serve(func(w http.ResponseWriter) {
+			_, _ = w.Write([]byte("not json"))
+		})
+
+		if _, err := v.Strongbox(); err == nil {
+			t.Fatal("Strongbox returned nil for a body that is not JSON")
+		}
+	})
+}

--- a/pkg/vault/tree_helpers_test.go
+++ b/pkg/vault/tree_helpers_test.go
@@ -1,0 +1,108 @@
+package vault
+
+// Secrets.Append and the two Basename methods are the seams between the
+// tree walk and everything that renders it: export appends every entry the
+// walk yields through Append, and Draw labels each node with its Basename.
+// A key node's name carries the key in path:key syntax with the key segment
+// escaped (see workGet), so its basename has to come back unescaped -- a
+// colon in a key name must survive the round trip.
+
+import (
+	"testing"
+)
+
+func TestSecretsAppend(t *testing.T) {
+	t.Parallel()
+
+	var s Secrets
+	s.Append(SecretEntry{Path: "secret/a"})
+	s.Append(SecretEntry{Path: "secret/b"})
+
+	if len(s) != 2 {
+		t.Fatalf("len = %d, want 2", len(s))
+	}
+	if s[0].Path != "secret/a" || s[1].Path != "secret/b" {
+		t.Errorf("entries out of order: %q, %q", s[0].Path, s[1].Path)
+	}
+}
+
+func TestSecretEntryBasename(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "nested", path: "secret/foo/bar", want: "bar"},
+		{name: "directly under the mount", path: "secret/foo", want: "foo"},
+		{name: "a bare mount", path: "secret", want: "secret"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SecretEntry{Path: tc.path}.Basename()
+			if got != tc.want {
+				t.Errorf("Basename(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSecretTreeBasename(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		tree secretTree
+		want string
+	}{
+		{
+			name: "the root of the walk",
+			tree: secretTree{Type: treeTypeRoot, Name: "/"},
+			want: "/",
+		},
+		{
+			name: "a directory keeps its trailing slash",
+			tree: secretTree{Type: treeTypeDir, Name: "secret/sub/"},
+			want: "sub/",
+		},
+		{
+			name: "a directory named without one gains it",
+			tree: secretTree{Type: treeTypeDir, Name: "secret/sub"},
+			want: "sub/",
+		},
+		{
+			name: "a secret",
+			tree: secretTree{Type: treeTypeSecret, Name: "secret/foo/bar"},
+			want: "bar",
+		},
+		{
+			name: "a secret that is also a directory",
+			tree: secretTree{Type: treeTypeDirAndSecret, Name: "secret/foo"},
+			want: "foo",
+		},
+		{
+			name: "a key",
+			tree: secretTree{Type: treeTypeKey, Name: EncodePath("secret/foo", "pass", 0)},
+			want: "pass",
+		},
+		{
+			name: "a key with a colon in its name",
+			tree: secretTree{Type: treeTypeKey, Name: EncodePath("secret/foo", "user:pass", 0)},
+			want: "user:pass",
+		},
+		{
+			name: "a version node has no name of its own",
+			tree: secretTree{Type: treeTypeVersion, Name: "secret/foo", Version: 2},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.tree.Basename()
+			if got != tc.want {
+				t.Errorf("Basename() of %q = %q, want %q", tc.tree.Name, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds behavior-focused tests for every Vault-API-facing function in `pkg/vault` that had zero coverage on develop, and extends the package's fake Vault server to KV v2 to make the version operations testable:

- `DeleteVersions` and `Undelete` (vault.go) — one, several, and v1 versions deleted; the latest and a named version restored; refusals for a key path, a missing secret, and destroyed, trimmed, or never-written versions, including that those version errors stay plain errors so `MoveCopyTree`'s walk cannot drop them.
- `ExplainNotFound` (vault.go) — names a deleted or destroyed newest version, keeps `IsSecretNotFound`, and leaves foreign errors, nil, versioned paths, history-less secrets, and alive-latest misses untouched.
- `FindSigningCA` (vault.go) — every branch: self-named, named authority, named non-CA, missing authority, self-signed cert, the accepted `ca` sibling, no sibling, a sibling that never signed the certificate (pointed at `--signed-by`), and a non-CA sibling.
- `SaveSealKeys` (vault.go) — writes `keyN` entries and replaces a stale larger set.
- `NewRootToken` (root.go) and `RenewLease` (renew.go) — root token minted from the threshold's worth of keys via the generate-root attempt/update flow, the not-enough-keys refusal, and lease renewal with its 403 refusal.
- `Strongbox` (strongbox.go) — node seal-state map, the error naming code and URL on a non-200, and an unparseable body.
- `Secrets.Append`, `SecretEntry.Basename`, and `secretTree.Basename` (tree.go) — every node type's label, including a key whose name holds a colon, stored escaped in the node name and returned unescaped.

## Why

These functions back `safe rm`/`safe undelete`, the not-found explanations, every x509 command that signs, `safe renew`, root token generation, seal-key storage, and the strongbox status display — none of them had a single test. The KV v2 half of the fake (`httptest_kv2_helper_test.go`) is reusable test infrastructure: any future `pkg/vault` test can now stand up a v2 mount with seeded version histories (`mountV2`, `setV2`, `deleteV2`, `destroyV2`, `trimV2`, `v2States`) and cover version-aware behavior black-box, the same way the existing v1 fake is used.

## Notes

- `Strongbox`'s port is hard-wired: `StrongboxURL` keeps only the Vault host and always appends `:8484`, so no injected fake can stand in. The test binds `127.0.0.1:8484` itself (skipping if the port is taken) and covers the success, non-200, and bad-JSON paths; the debug-dump lines and the request-construction error remain uncovered.
- The `FindSigningCA` helpers reparse certificates after signing because `X509.Sign` fills `Certificate.Raw` without reparsing, so a freshly built template has empty `Signature`/`RawTBSCertificate`; every certificate `FindSigningCA` meets in earnest was read back out of the Vault, where those fields are populated.
- No non-test files were changed and no dependencies were added.

## Verification

- `make check` (lint, vet, staticcheck, tests, engine-lib tests) — green
- `go test -race -count=1 ./...` — green
- `pkg/vault` statement coverage 72.2% → 77.5%; all ten target functions now covered (`RenewLease` 100%, `DeleteVersions` 100%, `ExplainNotFound` 100%, `Append`/both `Basename`s 100%, `Undelete` 91.7%, `FindSigningCA` 92.6%, `SaveSealKeys` 83.3%, `NewRootToken` 73.3%, `Strongbox` 62.1% — the remainders are network-failure plumbing, debug dumps, and vaultkv-internal error paths)
