### PR TITLE
Fix local port race that inits foreign vaults

### DIFF
--- a/internal/cli/concurrency_test.go
+++ b/internal/cli/concurrency_test.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
 	"strings"
 	"syscall"
 	"testing"
@@ -26,39 +25,56 @@ import (
 
 var fleetNames = []string{"alpha", "beta", "gamma", "delta"}
 
-type localProc struct {
-	name   string
-	cmd    *exec.Cmd
-	output *lockedBuffer
+// fleetMember is one fleet process plus the means to start it over, for the
+// single failure a member may honestly retry (see awaitFleetReady).
+type fleetMember struct {
+	*localProc
+	relaunch func() *localProc
 }
 
 // startFleet launches one `safe local --memory` per name against a shared
 // home, all at once.
-func startFleet(t *testing.T, home, engine string, extraFor func(name string) []string) []*localProc {
+func startFleet(t *testing.T, home, engine string, extraFor func(name string) []string) []*fleetMember {
 	t.Helper()
-	fleet := make([]*localProc, 0, len(fleetNames))
+	fleet := make([]*fleetMember, 0, len(fleetNames))
 	for _, name := range fleetNames {
 		var extra []string
 		if extraFor != nil {
 			extra = extraFor(name)
 		}
-		cmd, output, _ := startSafeLocal(t, home, engine, name, extra...)
-		fleet = append(fleet, &localProc{name: name, cmd: cmd, output: output})
+		launch := func() *localProc {
+			return startSafeLocal(t, home, engine, name, extra...)
+		}
+		fleet = append(fleet, &fleetMember{localProc: launch(), relaunch: launch})
 	}
 	return fleet
 }
 
 // awaitFleetReady waits for every process to print its "Now targeting" line.
-func awaitFleetReady(t *testing.T, fleet []*localProc) {
+// A member that dies fails the test right away, in the process's own words,
+// instead of sitting out the deadline -- with one exception: an engine that
+// lost to machine load, taking longer to listen than cmdLocal waits, is
+// started over a bounded number of times. Any other death is a finding.
+func awaitFleetReady(t *testing.T, fleet []*fleetMember) {
 	t.Helper()
 	deadline := time.Now().Add(60 * time.Second)
-	for _, p := range fleet {
+	for _, m := range fleet {
+		restarts := 0
 		for {
-			if strings.Contains(p.output.String(), "Now targeting") {
+			if strings.Contains(m.output.String(), "Now targeting") {
 				break
 			}
+			if m.exited() {
+				out := m.output.String()
+				if strings.Contains(out, "begin listening") && restarts < 2 {
+					restarts++
+					m.localProc = m.relaunch()
+					continue
+				}
+				t.Fatalf("%s exited before becoming ready:\n%s", m.name, out)
+			}
 			if time.Now().After(deadline) {
-				t.Fatalf("%s did not become ready:\n%s", p.name, p.output.String())
+				t.Fatalf("%s did not become ready:\n%s", m.name, m.output.String())
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
@@ -66,18 +82,14 @@ func awaitFleetReady(t *testing.T, fleet []*localProc) {
 }
 
 // stopFleet interrupts every process group and waits for the exits.
-func stopFleet(t *testing.T, fleet []*localProc) {
+func stopFleet(t *testing.T, fleet []*fleetMember) {
 	t.Helper()
-	for _, p := range fleet {
-		_ = syscall.Kill(-p.cmd.Process.Pid, syscall.SIGINT)
+	for _, m := range fleet {
+		_ = syscall.Kill(-m.cmd.Process.Pid, syscall.SIGINT)
 	}
-	for _, p := range fleet {
-		done := make(chan error, 1)
-		go func() { done <- p.cmd.Wait() }()
-		select {
-		case <-done:
-		case <-time.After(20 * time.Second):
-			t.Errorf("%s did not exit after SIGINT:\n%s", p.name, p.output.String())
+	for _, m := range fleet {
+		if _, ok := m.waitExit(20 * time.Second); !ok {
+			t.Errorf("%s did not exit after SIGINT:\n%s", m.name, m.output.String())
 		}
 	}
 }

--- a/internal/cli/local_isolation_test.go
+++ b/internal/cli/local_isolation_test.go
@@ -52,11 +52,65 @@ func decoyVault(t *testing.T) (*httptest.Server, *atomic.Int64) {
 	return srv, &hits
 }
 
+// localProc is one `safe local` process under test. done is closed once the
+// single reaper goroutine has collected the exit, after which waitErr holds
+// it; every consumer -- tests, fleet teardown, the launch cleanup -- reads
+// that instead of calling Wait themselves, so nothing races over the one
+// Wait a process allows, and pollers can tell a death from a slow start.
+type localProc struct {
+	name    string
+	cmd     *exec.Cmd
+	output  *lockedBuffer
+	tmpDir  string
+	done    chan struct{}
+	waitErr error
+}
+
+// exited reports whether the process has been reaped.
+func (p *localProc) exited() bool {
+	select {
+	case <-p.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// waitExit waits up to d for the exit and returns it; ok is false on
+// timeout, and the caller decides how loudly that fails.
+func (p *localProc) waitExit(d time.Duration) (err error, ok bool) {
+	select {
+	case <-p.done:
+		return p.waitErr, true
+	case <-time.After(d):
+		return nil, false
+	}
+}
+
+// awaitLocalReady waits for the "Now targeting" line, failing fast with the
+// process's own words if it dies first instead of sitting out the deadline.
+func awaitLocalReady(t *testing.T, p *localProc, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for {
+		if strings.Contains(p.output.String(), "Now targeting") {
+			return
+		}
+		if p.exited() {
+			t.Fatalf("%s exited before becoming ready:\n%s", p.name, p.output.String())
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s did not become ready:\n%s", p.name, p.output.String())
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
 // startSafeLocal runs `safe local --memory --as <name>` in its own process
 // group under the given home, so the whole tree (safe plus the server child)
-// can be torn down without orphans. The process gets a private TMPDIR (also
-// returned) so tests can check exactly which temp files it leaves behind.
-func startSafeLocal(t *testing.T, home, engine, name string, extra ...string) (*exec.Cmd, *lockedBuffer, string) {
+// can be torn down without orphans. The process gets a private TMPDIR so
+// tests can check exactly which temp files it leaves behind.
+func startSafeLocal(t *testing.T, home, engine, name string, extra ...string) *localProc {
 	t.Helper()
 	args := append([]string{"local", "--memory", "--engine", engine, "--as", name}, extra...)
 	tmpDir := t.TempDir()
@@ -75,11 +129,16 @@ func startSafeLocal(t *testing.T, home, engine, name string, extra ...string) (*
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("starting safe local: %v", err)
 	}
+	p := &localProc{name: name, cmd: cmd, output: &output, tmpDir: tmpDir, done: make(chan struct{})}
+	go func() {
+		p.waitErr = cmd.Wait()
+		close(p.done)
+	}()
 	t.Cleanup(func() {
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-		_ = cmd.Wait()
+		<-p.done
 	})
-	return cmd, &output, tmpDir
+	return p
 }
 
 func readSafercAt(t *testing.T, home string) (rc.Config, bool) {
@@ -108,40 +167,25 @@ func TestLocalNeverTouchesConfiguredTarget(t *testing.T) {
 		t.Fatalf("seeding ~/.saferc: %v", err)
 	}
 
-	cmd, output, _ := startSafeLocal(t, home, engine, "isolated")
+	p := startSafeLocal(t, home, engine, "isolated")
 
 	// "Now targeting" is printed once setup is complete and safe has settled
 	// into waiting on its server; interrupting before that point exercises
 	// the setup error paths instead of the teardown.
-	deadline := time.Now().Add(30 * time.Second)
-	ready := false
-	for time.Now().Before(deadline) {
-		if strings.Contains(output.String(), "Now targeting") {
-			ready = true
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if !ready {
-		t.Fatalf("safe local did not become ready:\n%s", output.String())
-	}
+	awaitLocalReady(t, p, 30*time.Second)
 	if cfg, ok := readSafercAt(t, home); !ok || cfg.Vaults["isolated"] == nil || cfg.Vaults["isolated"].Token == "" {
 		t.Errorf("ready without a stored token for the temporary target")
 	}
 
 	// Wind the server down the way Ctrl-C would: SIGINT to the process
 	// group. safe ignores it; the server exits; safe cleans up.
-	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
-	done := make(chan error, 1)
-	go func() { done <- cmd.Wait() }()
-	select {
-	case <-done:
-	case <-time.After(15 * time.Second):
-		t.Errorf("safe local did not exit after SIGINT:\n%s", output.String())
+	_ = syscall.Kill(-p.cmd.Process.Pid, syscall.SIGINT)
+	if _, ok := p.waitExit(15 * time.Second); !ok {
+		t.Errorf("safe local did not exit after SIGINT:\n%s", p.output.String())
 	}
 
 	if n := hits.Load(); n != 0 {
-		t.Errorf("the configured target received %d requests from safe local; want 0\n%s", n, output.String())
+		t.Errorf("the configured target received %d requests from safe local; want 0\n%s", n, p.output.String())
 	}
 
 	// And the teardown removed the temporary target, restoring `prod`.
@@ -176,23 +220,20 @@ func TestLocalAbortsWhenConfigUnwritable(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(home, 0700) })
 
-	cmd, output, _ := startSafeLocal(t, home, engine, "isolated")
+	p := startSafeLocal(t, home, engine, "isolated")
 
-	done := make(chan error, 1)
-	go func() { done <- cmd.Wait() }()
-	select {
-	case err := <-done:
-		if err == nil {
-			t.Errorf("safe local exited zero with an unwritable config:\n%s", output.String())
-		}
-	case <-time.After(30 * time.Second):
-		t.Fatalf("safe local did not abort with an unwritable config:\n%s", output.String())
+	err, ok := p.waitExit(30 * time.Second)
+	if !ok {
+		t.Fatalf("safe local did not abort with an unwritable config:\n%s", p.output.String())
+	}
+	if err == nil {
+		t.Errorf("safe local exited zero with an unwritable config:\n%s", p.output.String())
 	}
 
 	if n := hits.Load(); n != 0 {
-		t.Errorf("the configured target received %d requests; want 0\n%s", n, output.String())
+		t.Errorf("the configured target received %d requests; want 0\n%s", n, p.output.String())
 	}
-	if !strings.Contains(output.String(), ".saferc") {
-		t.Errorf("abort message does not name the config file:\n%s", output.String())
+	if !strings.Contains(p.output.String(), ".saferc") {
+		t.Errorf("abort message does not name the config file:\n%s", p.output.String())
 	}
 }

--- a/internal/cli/local_port_test.go
+++ b/internal/cli/local_port_test.go
@@ -11,8 +11,10 @@ package cli
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -86,6 +88,65 @@ func TestLocalExplicitPortHeldFailsAccurately(t *testing.T) {
 	// No half-registered target may survive the failed start.
 	if cfg, ok := readSafercAt(t, home); ok {
 		if _, found := cfg.Vaults["pinned"]; found {
+			t.Errorf("failed start left a target in ~/.saferc")
+		}
+	}
+}
+
+// strangerVault answers on a port of our choosing like a live,
+// already-initialized vault, and records every Init it receives.
+func strangerVault(t *testing.T) (int, *atomic.Int64) {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("binding the stranger's port: %v", err)
+	}
+	var inits atomic.Int64
+	srv := &http.Server{
+		ReadHeaderTimeout: 5 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if strings.HasSuffix(r.URL.Path, "/sys/init") && r.Method != http.MethodGet {
+				inits.Add(1)
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"errors":["Vault is already initialized"]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"initialized":true,"sealed":false,"standby":false}`))
+		}),
+	}
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return l.Addr().(*net.TCPAddr).Port, &inits
+}
+
+// A stranger already answering on the chosen port must be refused, never
+// initialized. The child loses the bind and says so, but not instantly --
+// and an answer on the port arrives before the child has even tried. If
+// that answer counts as readiness, safe sends Init to a vault it never
+// started, which is the incident, replayed deterministically.
+func TestLocalRefusesStrangerOnExplicitPort(t *testing.T) {
+	engine := localEngine(t)
+	port, inits := strangerVault(t)
+
+	home := t.TempDir()
+	p := startSafeLocal(t, home, engine, "usurped", "--port", fmt.Sprintf("%d", port))
+
+	err, ok := p.waitExit(30 * time.Second)
+	if !ok {
+		t.Fatalf("safe local did not exit with a stranger on its port:\n%s", p.output.String())
+	}
+	if err == nil {
+		t.Errorf("safe local exited zero with a stranger on its port:\n%s", p.output.String())
+	}
+	if n := inits.Load(); n != 0 {
+		t.Errorf("the stranger received %d Init calls; want 0\n%s", n, p.output.String())
+	}
+	if !strings.Contains(p.output.String(), fmt.Sprintf("port %d is already in use", port)) {
+		t.Errorf("failure does not diagnose the held port %d:\n%s", port, p.output.String())
+	}
+	if cfg, ok := readSafercAt(t, home); ok {
+		if _, found := cfg.Vaults["usurped"]; found {
 			t.Errorf("failed start left a target in ~/.saferc")
 		}
 	}

--- a/internal/cli/local_port_test.go
+++ b/internal/cli/local_port_test.go
@@ -40,35 +40,20 @@ func TestLocalAutoScanAvoidsHeldPort(t *testing.T) {
 	held := holdPort(t)
 
 	home := t.TempDir()
-	cmd, output, _ := startSafeLocal(t, home, engine, "dodger")
+	p := startSafeLocal(t, home, engine, "dodger")
 
-	deadline := time.Now().Add(30 * time.Second)
-	ready := false
-	for time.Now().Before(deadline) {
-		if strings.Contains(output.String(), "Now targeting") {
-			ready = true
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if !ready {
-		t.Fatalf("safe local did not become ready:\n%s", output.String())
-	}
+	awaitLocalReady(t, p, 30*time.Second)
 	cfg, ok := readSafercAt(t, home)
 	if !ok || cfg.Vaults["dodger"] == nil {
-		t.Fatalf("no registered target after readiness:\n%s", output.String())
+		t.Fatalf("no registered target after readiness:\n%s", p.output.String())
 	}
 	if url := cfg.Vaults["dodger"].URL; strings.HasSuffix(url, fmt.Sprintf(":%d", held)) {
 		t.Errorf("safe local claims the held port: %s", url)
 	}
 
-	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
-	done := make(chan error, 1)
-	go func() { done <- cmd.Wait() }()
-	select {
-	case <-done:
-	case <-time.After(15 * time.Second):
-		t.Errorf("safe local did not exit after SIGINT:\n%s", output.String())
+	_ = syscall.Kill(-p.cmd.Process.Pid, syscall.SIGINT)
+	if _, ok := p.waitExit(15 * time.Second); !ok {
+		t.Errorf("safe local did not exit after SIGINT:\n%s", p.output.String())
 	}
 }
 
@@ -80,20 +65,17 @@ func TestLocalExplicitPortHeldFailsAccurately(t *testing.T) {
 	held := holdPort(t)
 
 	home := t.TempDir()
-	cmd, output, _ := startSafeLocal(t, home, engine, "pinned", "--port", fmt.Sprintf("%d", held))
+	p := startSafeLocal(t, home, engine, "pinned", "--port", fmt.Sprintf("%d", held))
 
-	done := make(chan error, 1)
-	go func() { done <- cmd.Wait() }()
-	select {
-	case err := <-done:
-		if err == nil {
-			t.Errorf("safe local exited zero with its port held:\n%s", output.String())
-		}
-	case <-time.After(30 * time.Second):
-		t.Fatalf("safe local did not exit with its port held:\n%s", output.String())
+	err, ok := p.waitExit(30 * time.Second)
+	if !ok {
+		t.Fatalf("safe local did not exit with its port held:\n%s", p.output.String())
+	}
+	if err == nil {
+		t.Errorf("safe local exited zero with its port held:\n%s", p.output.String())
 	}
 
-	out := output.String()
+	out := p.output.String()
 	if !strings.Contains(out, fmt.Sprintf("port %d is already in use", held)) {
 		t.Errorf("failure does not diagnose the held port %d:\n%s", held, out)
 	}
@@ -118,27 +100,24 @@ func TestLocalRetryLoopIsBounded(t *testing.T) {
 	held := holdPort(t)
 
 	home := t.TempDir()
-	cmd, output, tmpDir := startSafeLocal(t, home, engine, "bounded",
+	p := startSafeLocal(t, home, engine, "bounded",
 		"--listener", fmt.Sprintf("address=127.0.0.1:%d", held))
 
-	done := make(chan error, 1)
-	go func() { done <- cmd.Wait() }()
-	select {
-	case err := <-done:
-		if err == nil {
-			t.Errorf("safe local exited zero with its listener address held:\n%s", output.String())
-		}
-	case <-time.After(60 * time.Second):
-		t.Fatalf("retry loop did not terminate:\n%s", output.String())
+	exitErr, ok := p.waitExit(60 * time.Second)
+	if !ok {
+		t.Fatalf("retry loop did not terminate:\n%s", p.output.String())
+	}
+	if exitErr == nil {
+		t.Errorf("safe local exited zero with its listener address held:\n%s", p.output.String())
 	}
 
-	if !strings.Contains(output.String(), "10 attempts") {
-		t.Errorf("failure does not report the bounded attempts:\n%s", output.String())
+	if !strings.Contains(p.output.String(), "10 attempts") {
+		t.Errorf("failure does not report the bounded attempts:\n%s", p.output.String())
 	}
 
 	// Every attempt's temp config file must be cleaned up. The process ran
 	// with a private TMPDIR, so anything left there is safe's own leak.
-	leftovers, err := filepath.Glob(filepath.Join(tmpDir, "kazoo*"))
+	leftovers, err := filepath.Glob(filepath.Join(p.tmpDir, "kazoo*"))
 	if err != nil {
 		t.Fatalf("glob: %v", err)
 	}

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -122,9 +122,13 @@ func launchLocalServer(engine Engine, params localConfigParams) (*localServer, e
 // An answer on the port is not readiness by itself. If the child lost the
 // bind race, whatever won it answers there instead -- and treating that
 // stranger as ready is how a safe once fed Init to a vault it never started.
-// Readiness is an answer, plus our child alive, plus no bind failure in its
-// output. The probe carries its own short timeout so a holder that accepts
-// and never speaks HTTP cannot stall the poll.
+// The child's own account of a bind failure closes most of that hole but
+// arrives asynchronously: a stranger who already holds the port answers the
+// first probe before the child has even tried to bind. So readiness demands
+// positive proof of ownership -- the child's startup banner, which both
+// Vault and OpenBao print only after their listen(2) succeeded -- plus an
+// answer on the port. The probe carries its own short timeout so a holder
+// that accepts and never speaks HTTP cannot stall the poll.
 func waitLocalReady(engine Engine, port int, srv *localServer) error {
 	const maxStartupWait = 5 * time.Second
 	const betweenChecksWait = 250 * time.Millisecond
@@ -140,29 +144,32 @@ func waitLocalReady(engine Engine, port int, srv *localServer) error {
 		default:
 		}
 
-		resp, err := probe.Get(localVaultURL(port) + "/v1/sys/seal-status")
-		if err == nil {
-			_ = resp.Body.Close()
-			if isAddrInUse(srv.output.String()) {
-				// Someone else answered; our child lost the bind and is on
-				// its way out. Reap it and report its own account.
-				waitErr := <-srv.echan
-				return fmt.Errorf("%s exited before it became ready: %s", engine.Title(), engineStartupError(srv.output.String(), waitErr))
-			}
-			select {
-			case waitErr := <-srv.echan:
-				return fmt.Errorf("%s exited before it became ready: %s", engine.Title(), engineStartupError(srv.output.String(), waitErr))
-			default:
+		// The child's word outranks anything the port says: once it reports
+		// the bind failed, whoever answers there is a stranger. Reap the
+		// child and report its own account.
+		if isAddrInUse(srv.output.String()) {
+			waitErr := <-srv.echan
+			return fmt.Errorf("%s exited before it became ready: %s", engine.Title(), engineStartupError(srv.output.String(), waitErr))
+		}
+
+		if strings.Contains(srv.output.String(), "server started!") {
+			resp, err := probe.Get(localVaultURL(port) + "/v1/sys/seal-status")
+			if err == nil {
+				_ = resp.Body.Close()
 				return nil
 			}
+			lastErr = err
 		}
-		lastErr = err
 
 		if time.Since(begin) > maxStartupWait {
-			if msg := strings.TrimSpace(srv.output.String()); msg != "" {
-				return fmt.Errorf("Timed out waiting for %s to begin listening: %s\n%s", engine.Title(), lastErr, msg)
+			reason := "it never reported its listener up"
+			if lastErr != nil {
+				reason = lastErr.Error()
 			}
-			return fmt.Errorf("Timed out waiting for %s to begin listening: %s", engine.Title(), lastErr)
+			if msg := strings.TrimSpace(srv.output.String()); msg != "" {
+				return fmt.Errorf("Timed out waiting for %s to begin listening: %s\n%s", engine.Title(), reason, msg)
+			}
+			return fmt.Errorf("Timed out waiting for %s to begin listening: %s", engine.Title(), reason)
 		}
 
 		time.Sleep(betweenChecksWait)

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -130,7 +130,11 @@ func launchLocalServer(engine Engine, params localConfigParams) (*localServer, e
 // answer on the port. The probe carries its own short timeout so a holder
 // that accepts and never speaks HTTP cannot stall the poll.
 func waitLocalReady(engine Engine, port int, srv *localServer) error {
-	const maxStartupWait = 5 * time.Second
+	// The ceiling is generous because it is not the usual way out: a server
+	// that fails exits, and the exit is caught on the spot. The timeout only
+	// catches one that hangs without a word, and a loaded machine can make
+	// an honest startup look like that for longer than you would think.
+	const maxStartupWait = 30 * time.Second
 	const betweenChecksWait = 250 * time.Millisecond
 	probe := &http.Client{Timeout: time.Second}
 	begin := time.Now()

--- a/internal/cli/server_local_run_test.go
+++ b/internal/cli/server_local_run_test.go
@@ -15,6 +15,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -144,6 +145,9 @@ func TestFakeLocalVaultHelper(t *testing.T) {
 	}
 	srv := &http.Server{Handler: handler, ReadHeaderTimeout: 5 * time.Second}
 	go func() { _ = srv.Serve(ln) }()
+	// The real engines announce a successful bind this way, and readiness in
+	// waitLocalReady requires seeing it.
+	fmt.Println("==> Vault server started! Log data will stream in below:")
 	<-done
 	os.Exit(0)
 }


### PR DESCRIPTION
## What

Three commits, found by chasing an intermittent failure in the #59 fleet tests under load:

1. **Test infra**: `startSafeLocal` now owns the single `Wait` a process allows and publishes the exit through a closed channel. Readiness polls fail immediately in the process's own words when it dies, instead of burning the 60-second fleet deadline and blaming it. A fleet member whose engine lost to machine load is restarted a bounded number of times.

2. **Production fix — the #59 incident was still reachable.** `waitLocalReady` accepted "an answer on the port + child alive + no bind failure in the child's output" as readiness. The child's bind-failure report arrives asynchronously: a stranger already holding the port answers the first probe before the child has even *tried* to bind. `safe local` then registered the target and sent `Init(1,1)` to a vault it never started. Observed live in the fleet tests (`400 Bad Request: Vault is already initialized`), then reproduced deterministically by the new `TestLocalRefusesStrangerOnExplicitPort`: an already-initialized fake vault holding the chosen port received a real `Init` from `safe local`, which also left the dead target in `.saferc` and misdiagnosed the failure. Readiness now requires positive proof of ownership — the `server started!` banner both Vault and OpenBao print only after `listen(2)` succeeds — plus an answer on the port. The bind-failure report is honored the moment it lands.

3. **Startup timeout 5s → 30s.** Five seconds covered engine spawn + bind + banner, and full-suite load alone blows through it, producing spurious "Timed out waiting for Vault to begin listening" deaths (this was the residual suite flake). A failing server exits and is reported on the spot, so the ceiling only affects a silently hanging one.

## Verification

- New regression test red before commit 2 (stranger received `Init`, target leaked into `.saferc`, wrong diagnosis), green after.
- Every commit individually green on the internal/cli suite.
- `make check` and `go test -race -count=1 ./...` green at head.
- Stress that previously failed ~1 in 3: two rounds of three concurrent full-suite runs — all six green.
