### PR TITLE
Pin rc lock and atomic write edge cases

### DIFF
--- a/pkg/rc/atomic_test.go
+++ b/pkg/rc/atomic_test.go
@@ -108,6 +108,24 @@ func TestWriteFileAtomicFailureKeepsOriginal(t *testing.T) {
 	}
 }
 
+// A bare filename has no directory component; the temp file must land in
+// the working directory ("."), not fail or stray elsewhere.
+func TestWriteFileAtomicBareFilename(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := writeFileAtomic("saferc", []byte("here"), 0600); err != nil {
+		t.Fatalf("writeFileAtomic: %s", err)
+	}
+
+	b, err := os.ReadFile("saferc")
+	if err != nil {
+		t.Fatalf("read back: %s", err)
+	}
+	if string(b) != "here" {
+		t.Errorf("content = %q, want %q", b, "here")
+	}
+}
+
 func TestWriteFileAtomicRejectsMissingDir(t *testing.T) {
 	err := writeFileAtomic(filepath.Join(t.TempDir(), "no", "such", "dir", "f"), []byte("x"), 0600)
 	if err == nil {

--- a/pkg/rc/lock_test.go
+++ b/pkg/rc/lock_test.go
@@ -101,6 +101,36 @@ func TestWithLockExcludesConcurrentWriters(t *testing.T) {
 	}
 }
 
+// A sidecar that cannot be opened -- here, an existing file with no access
+// bits -- must fail with the plain lock error, not the timeout advice: no
+// amount of waiting fixes it, and telling the user another safe holds it
+// would lie. (A directory will not do as the obstacle: flock happily locks
+// a directory opened read-only.)
+func TestWithLockFailsWhenSidecarUnopenable(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("file permissions do not bind root")
+	}
+	setHome(t)
+
+	if err := os.WriteFile(lockPath(), nil, 0000); err != nil {
+		t.Fatalf("seeding unopenable sidecar: %s", err)
+	}
+
+	err := withLock(func() error {
+		t.Error("fn ran without the lock")
+		return nil
+	})
+	if err == nil {
+		t.Fatalf("withLock succeeded with an unopenable %s", lockPath())
+	}
+	if !strings.Contains(err.Error(), lockPath()) {
+		t.Errorf("error %q does not name the lock file", err)
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Errorf("unopenable sidecar misreported as a timeout: %q", err)
+	}
+}
+
 func TestWithLockTimesOutWhenHeld(t *testing.T) {
 	setHome(t)
 	shortenLockWaits(t)


### PR DESCRIPTION
Two small tests closing the last portably-reachable untested branches in the `.saferc` locking code from #59. No production changes.

## What is pinned

**`writeFileAtomic` with a bare filename.** The `dir == ""` default drops the temp file in the working directory. Nothing in production passes a relative path today, but the function's whole contract is "temp file in the target's own directory, then rename" — the default is part of that contract, and this pins it.

**`withLock` when the sidecar cannot be opened.** An existing `~/.saferc.lock` with no access bits makes the open itself fail. That must surface as the plain lock error, not the timeout message — the timeout text tells the user another safe may be holding the lock, which would send them hunting for a process that does not exist. (A directory as the obstacle does not work for this test: `flock(2)` happily locks a directory opened read-only, which the test now documents.)

## What remains uncovered, deliberately

- The mid-write failure arms of `writeFileAtomic` (chmod/write/sync/close on the temp file) — not portably triggerable without fault injection.
- `withLock`'s `!locked && err == nil` fallback — gofrs/flock's `TryLockContext` cannot return that combination; the branch is defensive.
- `userHomeDir`'s Windows arm — structural on a unix-only CI.

## Verification

`make check` and `go test -race -count=1 ./...` green on the branch. Coverage confirms both target blocks now execute (`pkg/rc` 85.3% → 86.2%).
