### PR TITLE
Remediate adversarial review findings since v1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,43 @@ hosts* sharing one home directory are not serialized against each
 other.  Writes are still atomic there, so `~/.saferc` cannot be
 corrupted; a simultaneous change from another host can be lost.
 
+### Strongbox targets
+
+A target that has a [Strongbox](https://github.com/starkandwayne/strongbox)
+seal-state service running alongside it (typically on `:8484`)
+needs that recorded so `safe status`, `safe seal`, and `safe
+unseal` know to ask Strongbox about the whole cluster instead of
+just the one node the target's URL points at.  Record it with
+`-s`/`--strongbox` when you create or update the target:
+
+```
+safe target --strongbox https://vault.example.com myvault
+```
+
+`--no-strongbox` is still accepted, and is the default for a
+target created without either flag.
+
+Older versions of `safe` recorded this the other way around, with
+a `no_strongbox` key and Strongbox on by default.  `safe` still
+reads that key when it is present in a `~/.saferc` written by one
+of those versions, and translates it the first time the config is
+read: `no_strongbox: true` carries forward as an explicit
+opt-out, and `no_strongbox: false` carries forward as Strongbox
+enabled — the same meaning either spelling had before.  The next
+command that rewrites `~/.saferc` (`safe target`, `safe auth`,
+`safe local`, and so on) persists that as the new `strongbox` key
+and drops `no_strongbox`; nothing needs to be recreated by hand.
+
+That translation only fires when the key is actually in the file.
+The old default being *on* meant most targets that had Strongbox
+never wrote `no_strongbox` at all, so a `~/.saferc` with neither
+key is ambiguous: it could be a target that never had Strongbox,
+or one that had it under the old default and simply never
+recorded the key.  `safe` resolves that ambiguity in favor of the
+new opt-in default (off) rather than guessing, so a target that
+relied on the old default needs a one-time `safe target --strongbox`
+after upgrading.
+
 Proxies
 -------
 

--- a/ci/scripts/tests
+++ b/ci/scripts/tests
@@ -320,6 +320,11 @@ cleanup() {
   # assertion had failed yet -- a suite that could not even download its
   # server would report green.
   local status=$?
+  # This handler ends in exit, which on a signal (INT/QUIT/TERM) fires the
+  # EXIT trap in turn. Clearing every trap here, once entered, keeps that
+  # second firing from running the whole cleanup -- rm -rf t/ and the
+  # pass/fail banner -- a second time.
+  trap - INT QUIT TERM EXIT
   export HOME=${old_home}
   rm -rf t/
   kill_running_engine

--- a/ci/scripts/tests
+++ b/ci/scripts/tests
@@ -22,6 +22,20 @@ engine_startup_mode "$ENGINE" >/dev/null || {
   echo >&2 "ENGINE must be one of: vault, bao (got '${ENGINE}')"
   exit 1
 }
+# _start_engine_config, the startup path for ENGINE=bao, drives the server's
+# HTTP API directly with curl and parses its JSON with jq. Neither is needed
+# by _start_engine_dev, which only greps a log file, so the check is scoped
+# to the engines that actually take that path rather than added unconditionally.
+if [[ "$(engine_startup_mode "$ENGINE")" == config ]]; then
+  missing=()
+  for dep in curl jq; do
+    command -v "$dep" >/dev/null 2>&1 || missing+=("$dep")
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo >&2 "missing required command(s) for ENGINE=${ENGINE}: ${missing[*]}"
+    exit 1
+  fi
+fi
 # Pin safe's own engine resolution to the one under test, so `safe vault`
 # passthroughs reach the downloaded binary rather than whatever the host has.
 export SAFE_ENGINE="$ENGINE"
@@ -392,14 +406,22 @@ EOF
     dump_log 1
     exit 3
   fi
-  curl -sS -X PUT http://127.0.0.1:8198/v1/sys/unseal \
-    -d "{\"key\":\"$unseal_key\"}" >/dev/null
+  if ! curl -sS -f -X PUT http://127.0.0.1:8198/v1/sys/unseal \
+      -d "{\"key\":\"$unseal_key\"}" >/dev/null; then
+    failed "could not unseal ${ENGINE}"
+    dump_log 1
+    exit 3
+  fi
   # Non-dev mode does not mount secret/, so create it at KV v1 to match what
   # the -dev server leaves behind; the unmount and remount below then runs the
   # same way on both engines.
-  curl -sS -X POST -H "X-Vault-Token: $root_token" \
-    http://127.0.0.1:8198/v1/sys/mounts/secret \
-    -d '{"type":"kv","options":{"version":"1"}}' >/dev/null
+  if ! curl -sS -f -X POST -H "X-Vault-Token: $root_token" \
+      http://127.0.0.1:8198/v1/sys/mounts/secret \
+      -d '{"type":"kv","options":{"version":"1"}}' >/dev/null; then
+    failed "could not mount secret/ on ${ENGINE}"
+    dump_log 1
+    exit 3
+  fi
 }
 
 restart_engine_server() {

--- a/internal/cli/concurrency_test.go
+++ b/internal/cli/concurrency_test.go
@@ -26,10 +26,13 @@ import (
 var fleetNames = []string{"alpha", "beta", "gamma", "delta"}
 
 // fleetMember is one fleet process plus the means to start it over, for the
-// single failure a member may honestly retry (see awaitFleetReady).
+// single failure a member may honestly retry (see awaitFleetReady), and when
+// this attempt was launched, to tell that failure apart from a readiness
+// regression producing the same message.
 type fleetMember struct {
 	*localProc
-	relaunch func() *localProc
+	relaunch  func() *localProc
+	startedAt time.Time
 }
 
 // startFleet launches one `safe local --memory` per name against a shared
@@ -45,7 +48,7 @@ func startFleet(t *testing.T, home, engine string, extraFor func(name string) []
 		launch := func() *localProc {
 			return startSafeLocal(t, home, engine, name, extra...)
 		}
-		fleet = append(fleet, &fleetMember{localProc: launch(), relaunch: launch})
+		fleet = append(fleet, &fleetMember{localProc: launch(), relaunch: launch, startedAt: time.Now()})
 	}
 	return fleet
 }
@@ -53,8 +56,19 @@ func startFleet(t *testing.T, home, engine string, extraFor func(name string) []
 // awaitFleetReady waits for every process to print its "Now targeting" line.
 // A member that dies fails the test right away, in the process's own words,
 // instead of sitting out the deadline -- with one exception: an engine that
-// lost to machine load, taking longer to listen than cmdLocal waits, is
-// started over a bounded number of times. Any other death is a finding.
+// lost to machine load is started over, a bounded number of times.
+//
+// That one exception used to be granted on message text alone: cmdLocal's
+// own startup-timeout message ("...begin listening...") is what a genuine
+// slow start under load produces, but it is also exactly what a readiness
+// regression produces -- a shorter effective timeout, a changed banner, a
+// probe pointed at the wrong address. All of those would go green here on
+// message text alone. A member that ran the whole maxStartupWait budget
+// before dying honestly waited it out; one that died in a fraction of that
+// did not, and text-matching the same message would have retried it into
+// passing regardless of why. Only the former is retried; the latter fails
+// immediately, elapsed time and all, so a fast failure with this exact
+// wording still reads as the finding it is.
 func awaitFleetReady(t *testing.T, fleet []*fleetMember) {
 	t.Helper()
 	deadline := time.Now().Add(60 * time.Second)
@@ -66,12 +80,14 @@ func awaitFleetReady(t *testing.T, fleet []*fleetMember) {
 			}
 			if m.exited() {
 				out := m.output.String()
-				if strings.Contains(out, "begin listening") && restarts < 2 {
+				elapsed := time.Since(m.startedAt)
+				if strings.Contains(out, "begin listening") && elapsed >= maxStartupWait && restarts < 2 {
 					restarts++
 					m.localProc = m.relaunch()
+					m.startedAt = time.Now()
 					continue
 				}
-				t.Fatalf("%s exited before becoming ready:\n%s", m.name, out)
+				t.Fatalf("%s exited after %s before becoming ready:\n%s", m.name, elapsed, out)
 			}
 			if time.Now().After(deadline) {
 				t.Fatalf("%s did not become ready:\n%s", m.name, m.output.String())
@@ -224,7 +240,7 @@ func TestConcurrentLocalExplicitPorts(t *testing.T) {
 
 	for _, name := range fleetNames {
 		if v, found := cfg.Vaults[name]; found {
-			want := localVaultURL(ports[name])
+			want := localVaultURL(fmt.Sprintf("127.0.0.1:%d", ports[name]))
 			if v.URL != want {
 				t.Errorf("target %q at %s, want %s", name, v.URL, want)
 			}

--- a/internal/cli/keygen.go
+++ b/internal/cli/keygen.go
@@ -52,6 +52,13 @@ func readGenTargets(args []string) ([]genTarget, error) {
 			if vault.PathHasKey(key) {
 				return nil, fmt.Errorf("For secret `%s` and key `%s`: key cannot contain a key", path, key)
 			}
+			//A caret in the key argument names a version the same way it does
+			// in the PATH:KEY form, and that form refuses it; this one wrote a
+			// literal key named e.g. "pw^2" instead, which safe's own
+			// path:key^version syntax then cannot read back.
+			if err := assertWritableKeyPath(key); err != nil {
+				return nil, err
+			}
 			args = args[2:]
 		}
 		targets = append(targets, genTarget{path: path, key: key})

--- a/internal/cli/keygen_version_test.go
+++ b/internal/cli/keygen_version_test.go
@@ -45,6 +45,24 @@ func TestCmdGenRefusesAVersionOnTheKey(t *testing.T) {
 	}
 }
 
+// The separate-key form can carry the version on the KEY argument instead
+// of the path, and that form went unchecked: PATH:KEY refuses it, but
+// PATH KEY wrote a literal key named "pw^2" -- unreadable through safe's own
+// path:key^version syntax -- because only PathHasKey was checked on the key
+// argument, not PathHasVersion.
+func TestCmdGenRefusesAVersionOnTheSeparateKeyArgument(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newKeygenCLI(t)
+	c.opt.Gen.Policy = defaultGenPolicy
+	assertVersionRefused(t, c.cmdGen("gen", "secret/g", `pw^2`))
+
+	if kv := fv.get("secret/g"); len(kv) != 0 {
+		t.Errorf("secret/g = %v, want nothing written", kv)
+	}
+}
+
 // The separate-key form carries the version on the path. This already
 // failed, but only once Write was reached, after the password had been
 // generated.

--- a/internal/cli/local_port_test.go
+++ b/internal/cli/local_port_test.go
@@ -152,6 +152,139 @@ func TestLocalRefusesStrangerOnExplicitPort(t *testing.T) {
 	}
 }
 
+// compliantStrangerVault answers on a port of our choosing as a fully
+// functional, already-listening Vault -- init, unseal, mount, and the
+// handshake write all succeed -- and counts every request. Unlike
+// strangerVault (which refuses Init), this one lets a misdirected safe local
+// complete its whole lifecycle against it undetected, which is what proves a
+// fix reaches the address the child actually renders rather than the one
+// --port named.
+func compliantStrangerVault(t *testing.T) (port int, hits *atomic.Int64) {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("binding the stranger's port: %v", err)
+	}
+	var n atomic.Int64
+	srv := &http.Server{
+		ReadHeaderTimeout: 5 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			n.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case r.URL.Path == "/v1/sys/init" && r.Method == http.MethodPut:
+				_, _ = w.Write([]byte(`{"keys":["stranger-key"],"keys_base64":["stranger-key"],"root_token":"stranger-root"}`))
+			case r.URL.Path == "/v1/sys/unseal" && r.Method == http.MethodPut:
+				_, _ = w.Write([]byte(`{"sealed":false}`))
+			case r.URL.Path == "/v1/sys/mounts" && r.Method == http.MethodGet:
+				_, _ = w.Write([]byte(`{"data":{}}`))
+			case strings.HasPrefix(r.URL.Path, "/v1/sys/mounts/") && r.Method == http.MethodPost:
+				w.WriteHeader(http.StatusNoContent)
+			case r.URL.Path == "/v1/secret/handshake":
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				_, _ = w.Write([]byte(`{"initialized":false,"sealed":true}`))
+			}
+		}),
+	}
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return l.Addr().(*net.TCPAddr).Port, &n
+}
+
+// A --listener address= override decouples the actual bind from --port. The
+// probe, the client, and the registered target must all follow the rendered
+// address, not the port -- a stranger sitting on the --port value must
+// receive nothing, and the real (fake) engine, bound at the overridden
+// address, must get the whole lifecycle instead.
+func TestLocalTargetsRenderedListenerAddressNotPort(t *testing.T) {
+	installFakeLocalVault(t)
+	strangerPort, hits := compliantStrangerVault(t)
+	enginePort := freePort(t)
+
+	home := t.TempDir()
+	p := startSafeLocal(t, home, "vault", "listener-override",
+		"--port", fmt.Sprintf("%d", strangerPort),
+		"--listener", fmt.Sprintf("address=127.0.0.1:%d", enginePort))
+
+	awaitLocalReady(t, p, 30*time.Second)
+
+	if n := hits.Load(); n != 0 {
+		t.Errorf("the stranger on --port received %d requests; want 0\n%s", n, p.output.String())
+	}
+
+	cfg, ok := readSafercAt(t, home)
+	if !ok || cfg.Vaults["listener-override"] == nil {
+		t.Fatalf("no registered target after readiness:\n%s", p.output.String())
+	}
+	want := fmt.Sprintf("http://127.0.0.1:%d", enginePort)
+	if got := cfg.Vaults["listener-override"].URL; got != want {
+		t.Errorf("registered target URL: got %q, want %q (the rendered listener address)", got, want)
+	}
+
+	_ = syscall.Kill(-p.cmd.Process.Pid, syscall.SIGINT)
+	if _, ok := p.waitExit(15 * time.Second); !ok {
+		t.Errorf("safe local did not exit after SIGINT:\n%s", p.output.String())
+	}
+}
+
+// A MountExists or AddMount failure must kill the engine it already
+// initialized and unsealed, the same as every other post-launch failure --
+// not leave it running, reparented to init, holding a live root token that
+// is sitting in ~/.saferc. The fake engine deliberately does not exit on its
+// own for either failure (see server_local_run_test.go), so a quiet port
+// here can only mean safe's own die() reached it.
+func TestLocalMountFailureKillsEngine(t *testing.T) {
+	for _, fail := range []string{"mounts-list", "mounts-create"} {
+		t.Run(fail, func(t *testing.T) {
+			installFakeLocalVault(t)
+			t.Setenv("SAFE_FAKE_VAULT_FAIL", fail)
+			home := t.TempDir()
+			port := freePort(t)
+			p := startSafeLocal(t, home, "vault", "local-"+fail, "--port", fmt.Sprintf("%d", port))
+
+			err, ok := p.waitExit(30 * time.Second)
+			if !ok {
+				t.Fatalf("safe local did not exit after the mount failure:\n%s", p.output.String())
+			}
+			if err == nil {
+				t.Errorf("safe local exited zero after the mount failure:\n%s", p.output.String())
+			}
+			if !strings.Contains(p.output.String(), "shutting down") {
+				t.Errorf("expected a shutdown notice, got:\n%s", p.output.String())
+			}
+
+			deadline := time.Now().Add(5 * time.Second)
+			for {
+				client := &http.Client{Timeout: 500 * time.Millisecond}
+				resp, getErr := client.Get(fmt.Sprintf("http://127.0.0.1:%d/v1/sys/health", port))
+				if getErr != nil {
+					break
+				}
+				_ = resp.Body.Close()
+				if time.Now().After(deadline) {
+					t.Fatalf("engine still answering on :%d after safe local's exit", port)
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			leftovers, globErr := filepath.Glob(filepath.Join(p.tmpDir, "kazoo*"))
+			if globErr != nil {
+				t.Fatalf("glob: %v", globErr)
+			}
+			if len(leftovers) > 0 {
+				t.Errorf("%d temp config files leaked: %v", len(leftovers), leftovers)
+			}
+
+			if cfg, ok := readSafercAt(t, home); ok {
+				if _, found := cfg.Vaults["local-"+fail]; found {
+					t.Errorf("failed start left a target in ~/.saferc")
+				}
+			}
+		})
+	}
+}
+
 // A listener override pinning the address to a held port defeats every
 // retry; the loop must run its bounded course and then say what it tried.
 // (This is also the only deterministic way to drive the retry path: the

--- a/internal/cli/local_signal_test.go
+++ b/internal/cli/local_signal_test.go
@@ -1,0 +1,127 @@
+//go:build unix
+
+package cli
+
+// `safe local` must tear itself down -- kill its engine, remove its temp
+// config, restore the previous target -- on every signal that ends it, not
+// just the SIGINT a terminal Ctrl-C sends. These tests deliver SIGTERM and
+// SIGQUIT directly to the safe process (never the engine child, which only
+// die() may kill), and separately confirm SIGINT still reaches the normal
+// engine-driven shutdown path when the previously-current target carries CA
+// certificates.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// A signal that ends `safe local` before it has torn down must leave neither
+// its engine nor its temp config behind.
+func TestLocalTerminalSignalsTearDownTheEngine(t *testing.T) {
+	for name, sig := range map[string]syscall.Signal{
+		"SIGTERM": syscall.SIGTERM,
+		"SIGQUIT": syscall.SIGQUIT,
+	} {
+		t.Run(name, func(t *testing.T) {
+			installFakeLocalVault(t)
+			// The fake must not exit on its own once the handshake lands --
+			// otherwise the normal echan-driven shutdown could win the race
+			// and the test would prove nothing about the signal path.
+			t.Setenv("SAFE_FAKE_VAULT_FAIL", "hang")
+			home := t.TempDir()
+			p := startSafeLocal(t, home, "vault", "signal-"+strings.ToLower(name))
+
+			awaitLocalReady(t, p, 30*time.Second)
+
+			// Signal only the safe process, never the process group: an
+			// engine that outlives this is safe's own doing (or not), not
+			// the signal reaching it directly.
+			if err := p.cmd.Process.Signal(sig); err != nil {
+				t.Fatalf("delivering %s: %v", name, err)
+			}
+			if _, ok := p.waitExit(15 * time.Second); !ok {
+				t.Fatalf("safe local did not exit after %s:\n%s", name, p.output.String())
+			}
+
+			if !strings.Contains(p.output.String(), "shutting down") {
+				t.Errorf("expected a shutdown notice after %s, got:\n%s", name, p.output.String())
+			}
+
+			if cfg, ok := readSafercAt(t, home); ok {
+				if _, found := cfg.Vaults["signal-"+strings.ToLower(name)]; found {
+					t.Errorf("%s left the temporary target in ~/.saferc", name)
+				}
+			}
+
+			leftovers, err := filepath.Glob(filepath.Join(p.tmpDir, "kazoo*"))
+			if err != nil {
+				t.Fatalf("glob: %v", err)
+			}
+			if len(leftovers) > 0 {
+				t.Errorf("%d temp config files leaked after %s: %v", len(leftovers), name, leftovers)
+			}
+		})
+	}
+}
+
+// A previously-current target carrying ca_certs used to re-arm SIGINT
+// delivery through rc.Apply's temp-CA-cert cleanup handler, which killed
+// safe local outside its own teardown -- displacing the operator's real
+// target with a dead temporary one. SIGINT must still reach the normal,
+// engine-driven shutdown path (the engine dies from the signal too, since it
+// is delivered to the whole process group; that unblocks cmdLocal's own
+// wait) and restore `alpha` as current.
+func TestLocalSIGINTIgnoredEvenWithCACertCurrentTarget(t *testing.T) {
+	installFakeLocalVault(t)
+	home := t.TempDir()
+	saferc := `version: 1
+current: alpha
+vaults:
+  alpha:
+    url: https://alpha.example.com
+    token: token-alpha
+    ca_certs:
+      - |
+        -----BEGIN CERTIFICATE-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+        -----END CERTIFICATE-----
+`
+	if err := os.WriteFile(filepath.Join(home, ".saferc"), []byte(saferc), 0600); err != nil {
+		t.Fatalf("seeding ~/.saferc: %v", err)
+	}
+
+	p := startSafeLocal(t, home, "vault", "sigint-cacert")
+	awaitLocalReady(t, p, 30*time.Second)
+
+	// The whole group: a terminal Ctrl-C reaches both safe (ignored) and the
+	// engine child (which has no handler of its own and dies of it,
+	// unblocking cmdLocal's wait on srv.echan).
+	if err := syscall.Kill(-p.cmd.Process.Pid, syscall.SIGINT); err != nil {
+		t.Fatalf("delivering SIGINT to the group: %v", err)
+	}
+	if _, ok := p.waitExit(15 * time.Second); !ok {
+		t.Fatalf("safe local did not exit after SIGINT:\n%s", p.output.String())
+	}
+
+	if !strings.Contains(p.output.String(), "terminated normally") {
+		t.Errorf("expected the normal engine-driven shutdown, not a bare kill:\n%s", p.output.String())
+	}
+
+	cfg, ok := readSafercAt(t, home)
+	if !ok {
+		t.Fatalf("no ~/.saferc after teardown:\n%s", p.output.String())
+	}
+	if _, found := cfg.Vaults["sigint-cacert"]; found {
+		t.Errorf("temporary target still present after teardown")
+	}
+	if cfg.Current != "alpha" {
+		t.Errorf("current = %q after teardown, want %q\n%s", cfg.Current, "alpha", p.output.String())
+	}
+	if cfg.Vaults["alpha"] == nil || cfg.Vaults["alpha"].Token != "token-alpha" {
+		t.Errorf("the previously-current target was not left intact")
+	}
+}

--- a/internal/cli/ls_liveness_test.go
+++ b/internal/cli/ls_liveness_test.go
@@ -149,6 +149,45 @@ func TestListDoesNotLookUpFolders(t *testing.T) {
 	}
 }
 
+// A token that can list and read the data of a folder's secrets, but was
+// never granted read on their metadata, used to list the folder before the
+// liveness check moved to the metadata endpoint. It has to be able to list
+// the folder still: a 403 on the metadata lookup falls back to the data read
+// the check used to make, rather than aborting the whole listing.
+func TestListFallsBackToADataReadWhenMetadataIsForbidden(t *testing.T) {
+	isolateHome(t)
+	fv := walkFixture(t)
+	fv.denyMetadataGet("secret/app/db")
+	c := newTestCLI(t)
+
+	fv.forgetRequests()
+	got := lsOut(t, c, "secret/app")
+
+	if !sameEntries(got, []string{"api", "db"}) {
+		t.Errorf("ls secret/app = %v, want [api db] with the fallback keeping db", got)
+	}
+	if reads := dataReads(fv); reads != 1 {
+		t.Errorf("ls fell back with %d data reads, want 1 (only for the "+
+			"secret denied metadata):\n%s", reads, strings.Join(fv.requests(), "\n"))
+	}
+}
+
+// The fallback still drops a secret that is not there at all, on either
+// endpoint, rather than treating a metadata 403 as automatic liveness.
+func TestListFallbackStillOmitsASecretMissingFromBothEndpoints(t *testing.T) {
+	isolateHome(t)
+	fv := walkFixture(t)
+	fv.denyMetadataGet("secret/app/db")
+	fv.deleteV2("secret/app/db", 2)
+	c := newTestCLI(t)
+
+	got := lsOut(t, c, "secret/app")
+
+	if !sameEntries(got, []string{"api"}) {
+		t.Errorf("ls secret/app = %v, want [api] with the deleted, forbidden-metadata db left out", got)
+	}
+}
+
 // sameEntries compares two listings without caring about order.
 func sameEntries(got, want []string) bool {
 	if len(got) != len(want) {

--- a/internal/cli/misc.go
+++ b/internal/cli/misc.go
@@ -106,6 +106,9 @@ const envvarsHelp = `@G{[SCRIPTING]}
   Encrypted private keys are not supported. Password authentication is also not
   supported.
 
+  A username or private key path containing special characters must be
+  percent-encoded in the URL, e.g. '%40' for '@'.
+
   Your known_hosts file is used to verify the remote ssh server's host key. If no
   key for the given server is present, you will be prompted to add the key. If no
   TTY when no host key is present, safe will return with a failure.
@@ -113,7 +116,13 @@ const envvarsHelp = `@G{[SCRIPTING]}
 `
 
 func (c *CLI) cmdEnvvars(command string, args ...string) error {
-	_, _ = fmt.Printf(envvarsHelp)
+	//envvarsHelp is handed to go-ansi's Printf as a format string, the same
+	// way Runner.Help hands help.Description to ansi.Fprintf, and for the
+	// same reason: it is how the @G{...} markup in it is read. A bare '%' in
+	// the text would then be taken for the start of a verb, so it goes
+	// through the same escapePercent Runner.Help applies before either one
+	// reaches a formatter.
+	_, _ = fmt.Printf(escapePercent(envvarsHelp))
 	return nil
 }
 

--- a/internal/cli/misc_smoke_test.go
+++ b/internal/cli/misc_smoke_test.go
@@ -86,6 +86,28 @@ func TestCmdEnvvars_OutputContainsSafeAllProxy(t *testing.T) {
 	}
 }
 
+// safe help envvars renders its Description through escapePercent
+// specifically because the body is handed to go-ansi's Printf as a format
+// string, and a bare '%' in it is read as the start of a verb. safe envvars
+// prints the same constant through a different path that skipped that step,
+// so the percent-encoding example the help text gives ('%40') mangled into
+// go-ansi's missing-verb marker instead of appearing literally.
+func TestCmdEnvvars_RendersAPercentSignLiterally(t *testing.T) {
+	// No t.Parallel — captureStdout mutates os.Stdout.
+	c := &CLI{opt: &Options{}, r: NewRunner()}
+	out := captureStdout(t, func() {
+		if err := c.cmdEnvvars("envvars"); err != nil {
+			t.Fatalf("cmdEnvvars returned unexpected error: %v", err)
+		}
+	})
+	if strings.Contains(out, "MISSING") {
+		t.Errorf("cmdEnvvars mangled a '%%' in its own help text:\n%s", out)
+	}
+	if !strings.Contains(out, "%40") {
+		t.Errorf("expected the literal percent-encoding example '%%40' in the output, got:\n%s", out)
+	}
+}
+
 func TestCmdEnvvars_ReturnsNil(t *testing.T) {
 	// No t.Parallel — captureStdout mutates os.Stdout.
 	c := &CLI{opt: &Options{}, r: NewRunner()}

--- a/internal/cli/option_persist_test.go
+++ b/internal/cli/option_persist_test.go
@@ -1,0 +1,38 @@
+package cli
+
+// cmdOption must not announce "updated <opt>" until the change has actually
+// been persisted through rc.Update. Printing during argument parsing tells the
+// operator the option changed even when the write later fails, leaving safe's
+// reported state and the on-disk config disagreeing.
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestCmdOptionDoesNotClaimSuccessWhenPersistFails makes HOME unwritable so the
+// atomic config write fails at persist time (rc.Apply still reads the absent
+// ~/.saferc as an empty config). The command must report the error and must
+// not have printed "updated".
+func TestCmdOptionDoesNotClaimSuccessWhenPersistFails(t *testing.T) {
+	isolateHome(t)
+	home := os.Getenv("HOME")
+	if err := os.Chmod(home, 0o500); err != nil {
+		t.Fatalf("chmod home: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(home, 0o700) })
+
+	c := newTestCLI(t)
+	var err error
+	out := captureStdout(t, func() {
+		err = c.cmdOption("option", "manage-vault-token=on")
+	})
+
+	if err == nil {
+		t.Fatal("expected a persist error, got nil")
+	}
+	if strings.Contains(out, "updated") {
+		t.Errorf("must not claim 'updated' when the write failed; stdout was %q", out)
+	}
+}

--- a/internal/cli/pr_read_error_test.go
+++ b/internal/cli/pr_read_error_test.go
@@ -1,0 +1,27 @@
+package cli
+
+// pr() must surface a read error rather than swallowing it and returning an
+// empty string. A terminal read failure that reads as "" is indistinguishable
+// from an empty value, and in the confirm loop it spins forever.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cloudfoundry-community/safe/pkg/prompt"
+)
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) {
+	return 0, fmt.Errorf("simulated read failure")
+}
+
+func TestPrSurfacesReadError(t *testing.T) {
+	prompt.SetReader(failingReader{})
+	t.Cleanup(func() { prompt.SetReader(nil) })
+
+	if _, err := pr("value", false, true); err == nil {
+		t.Fatal("pr must surface a read error, not return an empty string")
+	}
+}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -1241,6 +1241,7 @@ func (c *CLI) cmdOption(command string, args ...string) error {
 	}
 
 	changes := map[string]bool{}
+	updated := make([]string, 0, len(args))
 	for _, arg := range args {
 		argSplit := strings.Split(arg, "=")
 		if len(argSplit) != 2 {
@@ -1269,7 +1270,7 @@ func (c *CLI) cmdOption(command string, args ...string) error {
 			if opt.opt == optionKey {
 				found = true
 				changes[opt.opt] = optionVal
-				_, _ = fmt.Printf("updated @G{%s}\n", opt.opt)
+				updated = append(updated, opt.opt)
 				break
 			}
 		}
@@ -1279,12 +1280,19 @@ func (c *CLI) cmdOption(command string, args ...string) error {
 		}
 	}
 
-	return rc.Update(func(c *rc.Config) error {
+	if err := rc.Update(func(c *rc.Config) error {
 		for _, field := range optionFields(&c.Options) {
 			if val, ok := changes[field.opt]; ok {
 				*field.val = val
 			}
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	for _, opt := range updated {
+		_, _ = fmt.Printf("updated @G{%s}\n", opt)
+	}
+	return nil
 }

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -411,10 +411,23 @@ func (c *CLI) cmdLs(command string, args ...string) error {
 							if vault.IsNotFound(err) {
 								continue
 							}
-
-							return err
-						}
-						if len(versions) == 0 || !versions[len(versions)-1].Alive() {
+							if !vaultkv.IsForbidden(err) {
+								return err
+							}
+							//A policy can grant list and read-the-data
+							// without also granting read-the-metadata, and
+							// such a token could list this folder before the
+							// liveness check moved to the metadata endpoint.
+							// Fall back to the read the check used to make,
+							// rather than aborting the whole listing on a
+							// capability it does not strictly need.
+							if _, err := v.Read(vault.EncodePath(child, "", 0)); err != nil {
+								if vault.IsNotFound(err) {
+									continue
+								}
+								return err
+							}
+						} else if len(versions) == 0 || !versions[len(versions)-1].Alive() {
 							continue
 						}
 					}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -71,7 +71,10 @@ func (c *CLI) writeHelper(prompt bool, insecure bool, command string, args ...st
 			continue
 		}
 		if missing {
-			v = pr(k, prompt, insecure)
+			v, err = pr(k, prompt, insecure)
+			if err != nil {
+				return err
+			}
 		}
 		err = s.Set(k, v, opt.SkipIfExists)
 		if err != nil {
@@ -549,7 +552,10 @@ func (c *CLI) cmdValues(command string, args ...string) error {
 		values = append(values, value)
 	}
 	if len(values) == 0 {
-		value := pr("value", false, true)
+		value, err := pr("value", false, true)
+		if err != nil {
+			return err
+		}
 		if value == "" {
 			return fmt.Errorf("no values specified to search for")
 		}

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -22,9 +23,9 @@ import (
 )
 
 // localVaultURL is where the server cmdLocal starts can be reached: loopback,
-// plain HTTP, on the port cmdLocal chose.
-func localVaultURL(port int) string {
-	return fmt.Sprintf("http://127.0.0.1:%d", port)
+// plain HTTP, on the address cmdLocal is actually talking to.
+func localVaultURL(address string) string {
+	return fmt.Sprintf("http://%s", address)
 }
 
 // connectLocal builds a client aimed at the server cmdLocal launched --
@@ -34,15 +35,60 @@ func localVaultURL(port int) string {
 // started, and no state of ~/.saferc (stale, lost to a concurrent writer, or
 // corrupted) may aim those calls anywhere else. Init against a foreign vault
 // is the incident this guards against.
-func connectLocal(port int, token string) (*vault.Vault, error) {
+func connectLocal(address string, token string) (*vault.Vault, error) {
 	return vault.NewVault(vault.VaultConfig{
-		URL:   localVaultURL(port),
+		URL:   localVaultURL(address),
 		Token: token,
 	})
 }
 
+// effectiveListenerAddress mirrors buildLocalConfig's listener defaults so
+// the probe, the client, and the registered target all follow the address
+// the rendered config actually tells the engine to bind -- not p.port, which
+// a --listener address= override can point at somewhere else entirely.
+// tlsEnabled reports whether the effective tls_disable value turns TLS on;
+// cmdLocal's automatically-managed listener only ever speaks plain HTTP, so
+// a caller seeing tlsEnabled must refuse rather than guess at a scheme.
+func effectiveListenerAddress(port int, overrides []string) (address string, tlsEnabled bool, err error) {
+	defaults := []hclField{
+		{key: "address", val: strconv.Quote(fmt.Sprintf("127.0.0.1:%d", port))},
+		{key: "tls_disable", val: "1"},
+	}
+	fields, err := applyConfigKV(defaults, overrides)
+	if err != nil {
+		return "", false, err
+	}
+
+	address = fmt.Sprintf("127.0.0.1:%d", port)
+	tlsDisabled := true
+	for _, f := range fields {
+		switch f.key {
+		case "address":
+			if unquoted, uerr := strconv.Unquote(f.val); uerr == nil {
+				address = unquoted
+			} else {
+				address = f.val
+			}
+		case "tls_disable":
+			tlsDisabled = f.val == "1" || f.val == "true"
+		}
+	}
+	return address, !tlsDisabled, nil
+}
+
 // localPortScanStart is where automatic port selection begins scanning.
 const localPortScanStart = 8201
+
+// maxStartupWait bounds how long waitLocalReady waits for the launched
+// server to report its listener up. The ceiling is generous because it is
+// not the usual way out: a server that fails exits, and the exit is caught
+// on the spot. The timeout only catches one that hangs without a word, and a
+// loaded machine can make an honest startup look like that for longer than
+// you would think. Package level (not local to waitLocalReady) so tests that
+// need to tell a genuinely slow start from a fast readiness regression --
+// both of which produce the same "begin listening" timeout message -- can
+// measure against the same ceiling production code waits on.
+const maxStartupWait = 30 * time.Second
 
 // findCandidatePort returns the first port at or after start that accepts a
 // loopback bind, probing with the same listen(2) the server child performs.
@@ -129,13 +175,14 @@ func launchLocalServer(engine Engine, params localConfigParams) (*localServer, e
 // Vault and OpenBao print only after their listen(2) succeeded -- plus an
 // answer on the port. The probe carries its own short timeout so a holder
 // that accepts and never speaks HTTP cannot stall the poll.
-func waitLocalReady(engine Engine, port int, srv *localServer) error {
-	// The ceiling is generous because it is not the usual way out: a server
-	// that fails exits, and the exit is caught on the spot. The timeout only
-	// catches one that hangs without a word, and a loaded machine can make
-	// an honest startup look like that for longer than you would think.
-	const maxStartupWait = 30 * time.Second
+func waitLocalReady(engine Engine, address string, srv *localServer) error {
 	const betweenChecksWait = 250 * time.Millisecond
+	// Bounds how long we wait for a child that has already reported its own
+	// bind failure to actually exit. Both installed engines do so
+	// immediately; this is only for a wedged one -- e.g. a hung shutdown --
+	// that would otherwise block the poll forever, with SIGINT already
+	// ignored so nothing at the terminal lets safe out of it either.
+	const bindFailureExitWait = 5 * time.Second
 	probe := &http.Client{Timeout: time.Second}
 	begin := time.Now()
 	var lastErr error
@@ -152,12 +199,24 @@ func waitLocalReady(engine Engine, port int, srv *localServer) error {
 		// the bind failed, whoever answers there is a stranger. Reap the
 		// child and report its own account.
 		if isAddrInUse(srv.output.String()) {
-			waitErr := <-srv.echan
-			return fmt.Errorf("%s exited before it became ready: %s", engine.Title(), engineStartupError(srv.output.String(), waitErr))
+			select {
+			case waitErr := <-srv.echan:
+				return fmt.Errorf("%s exited before it became ready: %s", engine.Title(), engineStartupError(srv.output.String(), waitErr))
+			case <-time.After(bindFailureExitWait):
+				// It reported the bind failure but did not leave. Do not
+				// wait out that promise forever -- reap it ourselves and say
+				// so plainly, rather than pretend this was the ordinary case
+				// above.
+				killErr := srv.cmd.Process.Kill()
+				if killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+					return fmt.Errorf("%s reported its listener address was already in use and did not exit within %s; killing it also failed: %s", engine.Title(), bindFailureExitWait, killErr)
+				}
+				return fmt.Errorf("%s reported its listener address was already in use and did not exit within %s; it has been killed", engine.Title(), bindFailureExitWait)
+			}
 		}
 
 		if strings.Contains(srv.output.String(), "server started!") {
-			resp, err := probe.Get(localVaultURL(port) + "/v1/sys/seal-status")
+			resp, err := probe.Get(localVaultURL(address) + "/v1/sys/seal-status")
 			if err == nil {
 				_ = resp.Body.Close()
 				return nil
@@ -178,6 +237,30 @@ func waitLocalReady(engine Engine, port int, srv *localServer) error {
 
 		time.Sleep(betweenChecksWait)
 	}
+}
+
+// restoreTarget removes name from ~/.saferc and restores previous as current
+// if name was current -- provided the entry there still names this process's
+// own server, matched by url. Two `safe local` runs can collide on a name
+// faster than either can register (see the collision check inside cmdLocal's
+// registration below); a teardown that deleted unconditionally would erase
+// the survivor's target and the root token stored on it. It is shared by
+// cmdLocal's normal shutdown and by die(), so a startup failure after
+// registration leaves ~/.saferc exactly as clean as a normal exit does.
+func restoreTarget(name, previous, url string) error {
+	return rc.Update(func(c *rc.Config) error {
+		if existing, found := c.Vaults[name]; found && existing.URL != url {
+			return nil
+		}
+		if c.Current == name {
+			c.Current = ""
+			if _, found, _ := c.Find(previous); found {
+				c.Current = previous
+			}
+		}
+		delete(c.Vaults, name)
+		return nil
+	})
 }
 
 func (c *CLI) cmdLocal(command string, args ...string) error {
@@ -204,6 +287,16 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 		}
 	}
 
+	// A TLS-enabling override cannot be auto-targeted: the probe and the
+	// client cmdLocal builds for its own server speak plain HTTP only, so
+	// there is no scheme to guess and no cert to trust. Refuse before
+	// anything is spawned rather than fail confusingly mid-startup.
+	if _, tlsEnabled, addrErr := effectiveListenerAddress(port, opt.Local.Listener); addrErr != nil {
+		return addrErr
+	} else if tlsEnabled {
+		return fmt.Errorf("--listener may not enable TLS for `safe local`: the automatically-managed listener speaks plain HTTP only (leave tls_disable at its default)")
+	}
+
 	keys := make([]string, 0)
 	if !opt.Local.Memory {
 		opt.Local.File = filepath.ToSlash(opt.Local.File)
@@ -215,6 +308,7 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 	signal.Ignore(syscall.SIGINT)
 
 	var srv *localServer
+	var name, previous, registeredURL string
 	die := func(err error) {
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "@R{!! %s}\n", err)
@@ -230,15 +324,39 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 			}
 			_ = os.Remove(srv.cfgFile)
 		}
+		if registeredURL != "" {
+			// A die() after registration must leave ~/.saferc exactly as a
+			// normal exit would: the temporary target gone, and whatever the
+			// operator had selected before restored as current.
+			if err := restoreTarget(name, previous, registeredURL); err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "@R{!! Unable to remove '%s' from ~/.saferc: %s}\n", name, err)
+				_, _ = fmt.Fprintf(os.Stderr, "@R{!! Remove it by hand with} @C{safe targets delete %s}\n", name)
+			}
+		}
 		rc.Cleanup()
 		os.Exit(1)
 	}
 
-	cfg, err := rc.Apply("")
+	// SIGTERM and SIGQUIT must reach this same teardown -- Signals() would
+	// otherwise restore the terminal and exit bare, leaving the child engine,
+	// its temp config, and the registered target all behind. SIGINT stays
+	// ignored above: a terminal delivers it to the whole foreground process
+	// group, so the child sees it too and its own exit drives the normal
+	// shutdown path below.
+	setLocalTeardown(func(os.Signal) { die(nil) })
+	defer setLocalTeardown(nil)
+
+	// rc.Read(), not rc.Apply(""): cmdLocal only needs the parsed config, not
+	// Apply's environment side effects. Apply, when the current target
+	// carries ca_certs, writes them to a temp file and installs its own
+	// os.Interrupt handler -- re-arming SIGINT delivery after the Ignore
+	// above and killing safe local before its teardown runs the moment the
+	// configured target happens to use a private CA.
+	cfg, err := rc.Read()
 	if err != nil {
 		return err
 	}
-	name := opt.Local.As
+	name = opt.Local.As
 	if name == "" {
 		name = RandomName()
 		var n int
@@ -256,15 +374,21 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 			die(fmt.Errorf("You already have '%s' as a Vault target", name))
 		}
 	}
-	previous := cfg.Current
+	previous = cfg.Current
 
 	// Launch, retrying on the one failure that is safe to retry: the child's
 	// own report that the port was taken. The bind probe above narrows the
 	// race but cannot close it -- only the server's listen(2) is
 	// authoritative. A losing attempt exits immediately, so a retry costs
 	// milliseconds.
+	var address string
 	const maxPortAttempts = 10
 	for attempt := 1; ; attempt++ {
+		address, _, err = effectiveListenerAddress(port, opt.Local.Listener)
+		if err != nil {
+			return err
+		}
+
 		srv, err = launchLocalServer(engine, localConfigParams{
 			port:       port,
 			memory:     opt.Local.Memory,
@@ -277,7 +401,7 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 			return err
 		}
 
-		startupErr := waitLocalReady(engine, port, srv)
+		startupErr := waitLocalReady(engine, address, srv)
 		if startupErr == nil {
 			break
 		}
@@ -302,27 +426,36 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 		die(startupErr)
 	}
 
-	v, err := connectLocal(port, "")
+	v, err := connectLocal(address, "")
 	if err != nil {
 		die(fmt.Errorf("Unable to build a client for the local %s server: %w", engine.Title(), err))
 	}
 
-	// Registered only now that the server is up on a port that is final: a
-	// failed or retried launch must not leave a target pointing at nothing.
+	// Registered only now that the server is up on an address that is final:
+	// a failed or retried launch must not leave a target pointing at nothing.
+	// The collision check runs inside this same locked mutation, not against
+	// the snapshot read above: two concurrent `safe local` runs landing on
+	// the same name -- an explicit --as twice, or a rare RandomName()
+	// collision -- must not let the second overwrite the first's entry and
+	// its root token.
 	if err := rc.Update(func(c *rc.Config) error {
+		if _, found := c.Vaults[name]; found {
+			return fmt.Errorf("You already have '%s' as a Vault target", name)
+		}
 		return c.SetTarget(name, rc.Vault{
-			URL:        localVaultURL(port),
+			URL:        localVaultURL(address),
 			SkipVerify: false,
 		})
 	}); err != nil {
 		// Nothing irreversible has happened yet: kill the server rather
 		// than leave one running that no config file points at.
-		die(fmt.Errorf("Unable to register '%s' in ~/.saferc: %w", name, err))
+		die(err)
 	}
+	registeredURL = localVaultURL(address)
 	// Outputs of the decision just made, for anything spawned from here on.
-	// Never read back as inputs: the client above was built from the port
-	// directly.
-	_ = os.Setenv("VAULT_ADDR", localVaultURL(port))
+	// Never read back as inputs: the client above was built from the
+	// address directly.
+	_ = os.Setenv("VAULT_ADDR", localVaultURL(address))
 
 	token := ""
 	if len(keys) == 0 {
@@ -354,24 +487,24 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 		// to reach it instead. The token going to stderr is deliberate: this
 		// flow already prints the seal key, and the server is loopback-only.
 		_, _ = fmt.Fprintf(os.Stderr, "@R{!! Unable to save the root token in ~/.saferc: %s}\n", err)
-		_, _ = fmt.Fprintf(os.Stderr, "@R{!! The %s server at} @C{%s} @R{is still running.}\n", engine.Title(), localVaultURL(port))
+		_, _ = fmt.Fprintf(os.Stderr, "@R{!! The %s server at} @C{%s} @R{is still running.}\n", engine.Title(), localVaultURL(address))
 		_, _ = fmt.Fprintf(os.Stderr, "@R{!! Its root token is} @M{%s}\n", token)
-		_, _ = fmt.Fprintf(os.Stderr, "@R{!! To reach it:} @C{safe target %s %s && safe auth token}\n", name, localVaultURL(port))
+		_, _ = fmt.Fprintf(os.Stderr, "@R{!! To reach it:} @C{safe target %s %s && safe auth token}\n", name, localVaultURL(address))
 	}
-	v, err = connectLocal(port, token)
+	v, err = connectLocal(address, token)
 	if err != nil {
-		return fmt.Errorf("Unable to build a client for the local %s server: %w", engine.Title(), err)
+		die(fmt.Errorf("Unable to build a client for the local %s server: %w", engine.Title(), err))
 	}
 
 	exists, err := v.MountExists("secret")
 	if err != nil {
-		return fmt.Errorf("Could not list mounts: %w", err)
+		die(fmt.Errorf("Could not list mounts: %w", err))
 	}
 
 	if !exists {
 		err := v.AddMount("secret", 2)
 		if err != nil {
-			return fmt.Errorf("Could not add `secret' mount: %w", err)
+			die(fmt.Errorf("Could not add `secret' mount: %w", err))
 		}
 		_, _ = fmt.Printf("safe has mounted the @C{secret} backend\n\n")
 	}
@@ -381,7 +514,7 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 	_ = v.Write("secret/handshake", s)
 
 	if !opt.Quiet {
-		_, _ = fmt.Fprintf(os.Stderr, "Now targeting (temporary) @Y{%s} at @C{%s}\n", name, localVaultURL(port))
+		_, _ = fmt.Fprintf(os.Stderr, "Now targeting (temporary) @Y{%s} at @C{%s}\n", name, localVaultURL(address))
 		if opt.Local.Memory {
 			_, _ = fmt.Fprintf(os.Stderr, "@R{This %s server is MEMORY-BACKED!}\n", engine.Title())
 			_, _ = fmt.Fprintf(os.Stderr, "If you want to @Y{retain your secrets} be sure to @C{safe export}.\n")
@@ -395,19 +528,7 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 	err = <-srv.echan
 	_ = os.Remove(srv.cfgFile)
 	_, _ = fmt.Fprintf(os.Stderr, "%s terminated normally, cleaning up...\n", engine.Title())
-	if updateErr := rc.Update(func(c *rc.Config) error {
-		// Evaluated against the state as it is now, not as it was at
-		// startup: if another process has moved `current` to its own
-		// target in the meantime, it is left alone.
-		if c.Current == name {
-			c.Current = ""
-			if _, found, _ := c.Find(previous); found {
-				c.Current = previous
-			}
-		}
-		delete(c.Vaults, name)
-		return nil
-	}); updateErr != nil {
+	if updateErr := restoreTarget(name, previous, registeredURL); updateErr != nil {
 		// The server is already gone; the config entry is now stale. Say
 		// so, but let the server's own exit status be what is returned.
 		_, _ = fmt.Fprintf(os.Stderr, "@R{!! Unable to remove '%s' from ~/.saferc: %s}\n", name, updateErr)

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -462,11 +462,6 @@ func (c *CLI) cmdInit(command string, args ...string) error {
 	if opt.UseTarget != "" {
 		target = opt.UseTarget
 	}
-	if err := rc.Update(func(c *rc.Config) error {
-		return c.SetTokenFor(target, token)
-	}); err != nil {
-		return err
-	}
 	_ = os.Setenv("VAULT_TOKEN", token)
 	v = connect(true)
 
@@ -518,6 +513,19 @@ func (c *CLI) cmdInit(command string, args ...string) error {
 		}
 
 		_, _ = fmt.Printf("\n")
+	}
+
+	// Persisting the token is best-effort from here on: Vault has already
+	// handed out the unseal keys and root token above, exactly once, and a
+	// config-write failure -- most commonly no target selected at all, the
+	// documented VAULT_ADDR-only workflow -- must never be what decides
+	// whether the operator sees them, or the Vault they just initialized
+	// goes permanently sealed for want of a ~/.saferc entry.
+	if err := rc.Update(func(c *rc.Config) error {
+		return c.SetTokenFor(target, token)
+	}); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "@R{!! Unable to save the root token in ~/.saferc: %s}\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "@R{!! You are still authenticated to it for this session.}\n")
 	}
 
 	if !opt.Init.Sealed {

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -310,7 +310,11 @@ func (c *CLI) cmdLocal(command string, args ...string) error {
 	if !opt.Local.Memory {
 		opt.Local.File = filepath.ToSlash(opt.Local.File)
 		if _, err := os.Stat(opt.Local.File); err == nil || !os.IsNotExist(err) {
-			keys = append(keys, pr("Unseal Key", false, true))
+			key, err := pr("Unseal Key", false, true)
+			if err != nil {
+				return err
+			}
+			keys = append(keys, key)
 		}
 	}
 
@@ -809,7 +813,11 @@ func (c *CLI) cmdUnseal(command string, args ...string) error {
 	keys := make([]string, nkeys)
 
 	for i := range nkeys {
-		keys[i] = pr(fmt.Sprintf("Key #%d", i+1), false, true)
+		key, err := pr(fmt.Sprintf("Key #%d", i+1), false, true)
+		if err != nil {
+			return err
+		}
+		keys[i] = key
 	}
 
 	for _, addr := range addrs {

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -239,6 +239,15 @@ func waitLocalReady(engine Engine, address string, srv *localServer) error {
 	}
 }
 
+// hintStrongboxOff tells the operator, once and to stderr only, that a
+// seal/unseal/status command checked only the one address it was given --
+// not the rest of a Strongbox-fronted cluster -- because the target does not
+// carry strongbox: true. It never blocks and never changes what the command
+// itself returns.
+func hintStrongboxOff() {
+	_, _ = fmt.Fprintf(os.Stderr, "@Y{Strongbox is off for this target: only the targeted address was checked, not the whole cluster. Enable it with} @C{--strongbox}@Y{ on} @C{safe target}@Y{.}\n")
+}
+
 // restoreTarget removes name from ~/.saferc and restores previous as current
 // if name was current -- provided the entry there still names this process's
 // own server, matched by url. Two `safe local` runs can collide on a name
@@ -772,6 +781,7 @@ func (c *CLI) cmdUnseal(command string, args ...string) error {
 			}
 		}
 	} else {
+		hintStrongboxOff()
 		isSealed, err := v.Sealed()
 		if err != nil {
 			return err
@@ -842,6 +852,7 @@ func (c *CLI) cmdSeal(command string, args ...string) error {
 			}
 		}
 	} else {
+		hintStrongboxOff()
 		isSealed, err := v.Sealed()
 		if err != nil {
 			return err

--- a/internal/cli/server_local_run_test.go
+++ b/internal/cli/server_local_run_test.go
@@ -109,7 +109,10 @@ func TestFakeLocalVaultHelper(t *testing.T) {
 			if os.Getenv("SAFE_FAKE_VAULT_FAIL") == "mounts-list" {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = w.Write([]byte(`{"errors":["mount listing is down"]}`))
-				scheduleExit(&exitOnce, done)
+				// Deliberately does not scheduleExit: whether this process
+				// goes away is exactly what the die()-path tests need to
+				// observe, and it must be safe's kill that ends it, not a
+				// self-timeout that would pass regardless.
 				return
 			}
 			_, _ = w.Write([]byte(`{"data":{}}`))
@@ -118,7 +121,7 @@ func TestFakeLocalVaultHelper(t *testing.T) {
 			if os.Getenv("SAFE_FAKE_VAULT_FAIL") == "mounts-create" {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = w.Write([]byte(`{"errors":["mount creation is down"]}`))
-				scheduleExit(&exitOnce, done)
+				// See the mounts-list branch above: no scheduleExit here either.
 				return
 			}
 			w.WriteHeader(http.StatusNoContent)
@@ -129,9 +132,14 @@ func TestFakeLocalVaultHelper(t *testing.T) {
 		case r.URL.Path == "/v1/secret/handshake" &&
 			(r.Method == http.MethodPut || r.Method == http.MethodPost):
 			w.WriteHeader(http.StatusNoContent)
-			// The handshake write is the last thing cmdLocal asks of the
-			// Vault; shut down shortly after so the response gets out first.
-			scheduleExit(&exitOnce, done)
+			if os.Getenv("SAFE_FAKE_VAULT_FAIL") != "hang" {
+				// The handshake write is the last thing cmdLocal asks of the
+				// Vault; shut down shortly after so the response gets out
+				// first. "hang" skips this: a signal-teardown test needs
+				// cmdLocal still waiting on this process when the signal
+				// arrives, not racing its own on-schedule exit.
+				scheduleExit(&exitOnce, done)
+			}
 
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -313,29 +321,12 @@ exit 0
 	}
 }
 
-func TestCmdLocal_MountListFailureSurfaces(t *testing.T) {
-	// No t.Parallel — captureStderr mutates os.Stderr.
-	isolateHome(t)
-	installFakeLocalVault(t)
-	t.Setenv("SAFE_FAKE_VAULT_FAIL", "mounts-list")
-	c := localCLI(t)
-	c.opt.Local.Memory = true
-	c.opt.Local.Port = freePort(t)
-	c.opt.Local.As = "local-lsfail-test"
-
-	var err error
-	captureStdout(t, func() {
-		captureStderr(t, func() {
-			err = c.cmdLocal("local")
-		})
-	})
-	if err == nil {
-		t.Fatal("expected the mount-listing failure to surface, got nil")
-	}
-	if !strings.Contains(err.Error(), "Could not list mounts") {
-		t.Errorf("unexpected error wording: %v", err)
-	}
-}
+// TestCmdLocal_MountListFailureSurfaces and TestCmdLocal_MountCreateFailureSurfaces
+// used to call cmdLocal in-process and assert on its returned error. Now that
+// a mount-listing or mount-creation failure routes through die() (os.Exit),
+// calling cmdLocal in-process would end this test binary instead of just the
+// one case; see TestLocalMountFailureKillsEngine (local_port_test.go), which
+// drives the same failures through the built safe binary instead.
 
 // The paths through die() end in os.Exit, so they can only be observed from
 // outside the process: run the built safe binary against a vault whose
@@ -376,29 +367,5 @@ exit 1
 	}
 	if !strings.Contains(stderr.String(), "Error parsing config: oops") {
 		t.Errorf("expected Vault's own complaint relayed, got:\n%s", stderr.String())
-	}
-}
-
-func TestCmdLocal_MountCreateFailureSurfaces(t *testing.T) {
-	// No t.Parallel — captureStderr mutates os.Stderr.
-	isolateHome(t)
-	installFakeLocalVault(t)
-	t.Setenv("SAFE_FAKE_VAULT_FAIL", "mounts-create")
-	c := localCLI(t)
-	c.opt.Local.Memory = true
-	c.opt.Local.Port = freePort(t)
-	c.opt.Local.As = "local-mkfail-test"
-
-	var err error
-	captureStdout(t, func() {
-		captureStderr(t, func() {
-			err = c.cmdLocal("local")
-		})
-	})
-	if err == nil {
-		t.Fatal("expected the mount-creation failure to surface, got nil")
-	}
-	if !strings.Contains(err.Error(), "Could not add") {
-		t.Errorf("unexpected error wording: %v", err)
 	}
 }

--- a/internal/cli/server_local_test.go
+++ b/internal/cli/server_local_test.go
@@ -93,6 +93,27 @@ func TestCmdLocal_MalformedConfigPairErrors(t *testing.T) {
 	}
 }
 
+// A --listener override that turns TLS on cannot be auto-targeted: the probe
+// and client cmdLocal builds for its own server speak plain HTTP only, so
+// guessing a scheme or trusting a self-signed cert is not on the table. This
+// must be refused before a server is even spawned.
+func TestCmdLocal_ListenerOverrideEnablingTLSIsRefused(t *testing.T) {
+	isolateHome(t)
+	installFakeVaultVersionOnly(t, "Vault v1.15.4")
+	c := localCLI(t)
+	c.opt.Local.Memory = true
+	c.opt.Local.Port = 8219
+	c.opt.Local.Listener = []string{"tls_disable=0"}
+
+	err := c.cmdLocal("local")
+	if err == nil {
+		t.Fatal("expected an error for a --listener override that enables TLS, got nil")
+	}
+	if !strings.Contains(err.Error(), "TLS") {
+		t.Errorf("unexpected error wording: %v", err)
+	}
+}
+
 func TestCmdLocal_MalformedListenerPairErrorsWithOldVault(t *testing.T) {
 	isolateHome(t)
 	// A pre-0.8 Vault takes the legacy "backend" storage-key branch before

--- a/internal/cli/sig.go
+++ b/internal/cli/sig.go
@@ -3,10 +3,37 @@ package cli
 import (
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	"golang.org/x/term"
 )
+
+// localTeardownMu guards localTeardownFn, the hook a running `safe local`
+// installs so SIGTERM/SIGQUIT reach its own cleanup -- killing the child
+// engine, removing its temp config, and restoring the previous target --
+// instead of Signals()'s bare terminal-restore-and-exit. Only one command
+// runs at a time in this process, so a single package-level slot is enough.
+var (
+	localTeardownMu sync.Mutex
+	localTeardownFn func(os.Signal)
+)
+
+// setLocalTeardown installs fn as the signal-driven teardown for a running
+// `safe local`. Pass nil to clear it once the command is done -- after that
+// point there is nothing left for a signal to tear down, and Signals() must
+// go back to exiting bare for every other command.
+func setLocalTeardown(fn func(os.Signal)) {
+	localTeardownMu.Lock()
+	defer localTeardownMu.Unlock()
+	localTeardownFn = fn
+}
+
+func localTeardown() func(os.Signal) {
+	localTeardownMu.Lock()
+	defer localTeardownMu.Unlock()
+	return localTeardownFn
+}
 
 func Signals() {
 	//When stdin is not a terminal there is no state to put back, and prev is
@@ -20,7 +47,19 @@ func Signals() {
 
 	s := make(chan os.Signal, 1)
 	signal.Notify(s, syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT)
-	for range s {
+	for sig := range s {
+		// A running `safe local` owns its own teardown -- its child engine,
+		// temp config, and registered target need cleaning up in a way this
+		// generic handler knows nothing about. SIGINT never reaches here for
+		// it (ignored deliberately, see cmdLocal), so this only fires for
+		// SIGTERM/SIGQUIT while one is active.
+		if fn := localTeardown(); fn != nil {
+			fn(sig)
+			// fn is contracted to end the process itself, the same way
+			// die() already does for every other `safe local` failure path.
+			// Falling through to the bare exit below is the safety net for
+			// a hook that does not, not the expected route.
+		}
 		if prev != nil {
 			_ = term.Restore(int(os.Stdin.Fd()), prev)
 		}

--- a/internal/cli/strongbox_hint_test.go
+++ b/internal/cli/strongbox_hint_test.go
@@ -1,0 +1,110 @@
+package cli
+
+// safe seal, safe unseal, and safe status only ever probe the one address
+// they are pointed at unless the target carries strongbox: true, in which
+// case they fan out across the whole cluster via the Strongbox seal-state
+// service. A target without Strongbox gets a one-line stderr hint that only
+// the targeted node was checked, and how to turn cluster-wide checking on --
+// so an operator reading "unsealed" does not read it as "the cluster is
+// unsealed" when only one node was ever asked.
+
+import (
+	"strings"
+	"testing"
+)
+
+// singleTarget writes a ~/.saferc naming one target at f's URL, opting into
+// Strongbox when asked.
+func singleTarget(t *testing.T, f *fakeSealVault, strongbox bool) {
+	t.Helper()
+	body := "version: 1\ncurrent: solo\nvaults:\n  solo:\n    url: " + f.url + "\n    token: solo-token\n"
+	if strongbox {
+		body += "    strongbox: true\n"
+	}
+	writeSaferc(t, body)
+}
+
+func TestCmdStatusHintsStrongboxOffWhenNotEnabled(t *testing.T) {
+	isolateHome(t)
+	f := newSealFake(t, false)
+	singleTarget(t, f, false)
+	c := newTestCLI(t)
+
+	stderr := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			if err := c.cmdStatus("status"); err != nil {
+				t.Fatalf("cmdStatus: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(stderr, "Strongbox") {
+		t.Errorf("expected a Strongbox visibility hint on stderr, got:\n%s", stderr)
+	}
+}
+
+func TestCmdStatusNoHintWhenStrongboxEnabled(t *testing.T) {
+	isolateHome(t)
+	f := newSealFake(t, false)
+	singleTarget(t, f, true)
+	c := newTestCLI(t)
+
+	stderr := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			// fakeSealVault does not implement /v1/sys/strongbox, so this
+			// errors -- the point here is only that the no-Strongbox hint,
+			// which belongs to the other branch, never fires.
+			_ = c.cmdStatus("status")
+		})
+	})
+	if strings.Contains(stderr, "Strongbox is off") {
+		t.Errorf("did not expect the no-Strongbox hint for a Strongbox-enabled target, got:\n%s", stderr)
+	}
+}
+
+func TestCmdUnsealHintsStrongboxOffWhenNotEnabled(t *testing.T) {
+	isolateHome(t)
+	// Already unsealed: cmdUnseal takes its early return before it would
+	// ever prompt for a key.
+	f := newSealFake(t, false)
+	singleTarget(t, f, false)
+	c := newTestCLI(t)
+
+	stdout := captureStdout(t, func() {
+		var stderr string
+		stderr = captureStderr(t, func() {
+			if err := c.cmdUnseal("unseal"); err != nil {
+				t.Fatalf("cmdUnseal: %v", err)
+			}
+		})
+		if !strings.Contains(stderr, "Strongbox") {
+			t.Errorf("expected a Strongbox visibility hint on stderr, got:\n%s", stderr)
+		}
+	})
+	if !strings.Contains(stdout, "already unsealed") {
+		t.Errorf("expected the already-unsealed message, got:\n%s", stdout)
+	}
+}
+
+func TestCmdSealHintsStrongboxOffWhenNotEnabled(t *testing.T) {
+	isolateHome(t)
+	// Already sealed: cmdSeal's retry loop never runs, so this returns
+	// without needing an unseal/reseal round trip.
+	f := newSealFake(t, true)
+	singleTarget(t, f, false)
+	c := newTestCLI(t)
+
+	stdout := captureStdout(t, func() {
+		var stderr string
+		stderr = captureStderr(t, func() {
+			if err := c.cmdSeal("seal"); err != nil {
+				t.Fatalf("cmdSeal: %v", err)
+			}
+		})
+		if !strings.Contains(stderr, "Strongbox") {
+			t.Errorf("expected a Strongbox visibility hint on stderr, got:\n%s", stderr)
+		}
+	})
+	if !strings.Contains(stdout, "already sealed") {
+		t.Errorf("expected the already-sealed message, got:\n%s", stdout)
+	}
+}

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -400,6 +400,7 @@ func (c *CLI) cmdStatus(command string, args ...string) error {
 			statuses = append(statuses, status{addr, state == "sealed"})
 		}
 	} else {
+		hintStrongboxOff()
 		isSealed, err := v.Sealed()
 		if err != nil {
 			return err

--- a/internal/cli/token_target_test.go
+++ b/internal/cli/token_target_test.go
@@ -7,6 +7,7 @@ package cli
 // not ask them to clear.
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -87,6 +88,74 @@ func TestCmdAuthStoresTheTokenOnTheTargetNamedByDashT(t *testing.T) {
 	}
 	if cfg.Current != "alpha" {
 		t.Errorf("current target: got %q, want alpha", cfg.Current)
+	}
+}
+
+// safe init with only VAULT_ADDR set -- no ~/.saferc target at all, the
+// documented environment-variable workflow -- must still print the unseal
+// keys and root token. Vault hands them out exactly once; a config-store
+// failure after Init must never be what decides whether the operator sees
+// them, or the vault it just initialized is unrecoverable.
+func TestCmdInitPrintsKeysWhenNoTargetIsSelected(t *testing.T) {
+	isolateHome(t)
+	f := newSealFake(t, true)
+	t.Setenv("VAULT_ADDR", f.url)
+	c := newTestCLI(t)
+	c.opt.Init.Sealed = true
+
+	var err error
+	var stderr string
+	stdout := captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			err = c.cmdInit("init")
+		})
+	})
+	if err != nil {
+		t.Fatalf("cmdInit returned an error with no target selected: %v\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "Initial Root Token") || !strings.Contains(stdout, f.rootToken) {
+		t.Errorf("expected the root token printed even with no target selected, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "Unseal Key") {
+		t.Errorf("expected the unseal key printed even with no target selected, got:\n%s", stdout)
+	}
+	if !strings.Contains(stderr, "Unable to save the root token") {
+		t.Errorf("expected a warning that the token could not be stored, got:\n%s", stderr)
+	}
+}
+
+// The --json form of the same scenario: no target selected, so there is
+// nowhere in ~/.saferc to store the token, but the machine-readable output
+// must still carry it.
+func TestCmdInitPrintsJSONWhenNoTargetIsSelected(t *testing.T) {
+	isolateHome(t)
+	f := newSealFake(t, true)
+	t.Setenv("VAULT_ADDR", f.url)
+	c := newTestCLI(t)
+	c.opt.Init.Sealed = true
+	c.opt.Init.JSON = true
+
+	var err error
+	stdout := captureStdout(t, func() {
+		captureStderr(t, func() {
+			err = c.cmdInit("init")
+		})
+	})
+	if err != nil {
+		t.Fatalf("cmdInit returned an error with no target selected: %v", err)
+	}
+	var out struct {
+		Keys  []string `json:"seal_keys"`
+		Token string   `json:"root_token"`
+	}
+	if jsonErr := json.Unmarshal([]byte(stdout), &out); jsonErr != nil {
+		t.Fatalf("stdout did not parse as JSON: %v\nstdout:\n%s", jsonErr, stdout)
+	}
+	if out.Token != f.rootToken {
+		t.Errorf("root_token: got %q, want %q", out.Token, f.rootToken)
+	}
+	if len(out.Keys) == 0 {
+		t.Errorf("expected seal_keys to be populated, got none")
 	}
 }
 

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -122,21 +122,27 @@ func assertWritablePaths(paths ...string) error {
 	return nil
 }
 
-func pr(label string, confirm bool, secure bool) string {
+func pr(label string, confirm bool, secure bool) (string, error) {
 	if !confirm {
 		if secure {
-			return prompt.Secure("%s: ", label)
+			return prompt.SecureE("%s: ", label)
 		}
-		return prompt.Normal("%s: ", label)
+		return prompt.NormalE("%s: ", label)
 	}
 
 	for {
-		a := prompt.Secure("%s @Y{[hidden]:} ", label)
-		b := prompt.Secure("%s @C{[confirm]:} ", label)
+		a, err := prompt.SecureE("%s @Y{[hidden]:} ", label)
+		if err != nil {
+			return "", err
+		}
+		b, err := prompt.SecureE("%s @C{[confirm]:} ", label)
+		if err != nil {
+			return "", err
+		}
 
 		if a == b && a != "" {
 			_, _ = ansi.Fprintf(os.Stderr, "\n")
-			return a
+			return a, nil
 		}
 		_, _ = ansi.Fprintf(os.Stderr, "\n@Y{oops, try again }(Ctrl-C to cancel)\n\n")
 	}

--- a/internal/cli/vault_fake_test.go
+++ b/internal/cli/vault_fake_test.go
@@ -42,6 +42,10 @@ type cliFakeVault struct {
 	// plaintext it never prints, and a flag that promises to skip a lookup
 	// has to actually skip it. Neither shows up in the output.
 	log []string
+	//forbidMetadataGet names version 2 paths whose metadata GET (not list)
+	// answers 403, for tests simulating a token without metadata-read
+	// capability. See denyMetadataGet.
+	forbidMetadataGet map[string]bool
 }
 
 // fakeVersion is one version of a version 2 secret. A version is alive until

--- a/internal/cli/vault_fake_v2_test.go
+++ b/internal/cli/vault_fake_v2_test.go
@@ -36,6 +36,18 @@ func newCLIFakeV2(t *testing.T) *cliFakeVault {
 	return fv
 }
 
+// denyMetadataGet makes a metadata GET (not list) for path answer 403,
+// simulating a token that can list and read a secret's data but was never
+// granted read on its metadata.
+func (f *cliFakeVault) denyMetadataGet(path string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.forbidMetadataGet == nil {
+		f.forbidMetadataGet = map[string]bool{}
+	}
+	f.forbidMetadataGet[path] = true
+}
+
 // setV2 appends one version per map given, oldest first, at a literal Vault
 // path. Calling it twice on the same path keeps appending.
 func (f *cliFakeVault) setV2(path string, values ...map[string]string) {
@@ -234,6 +246,12 @@ func (f *cliFakeVault) serveV2Metadata(w http.ResponseWriter, r *http.Request, p
 			return
 		}
 		writeJSON(w, map[string]any{"data": map[string]any{"keys": keys}})
+		return
+	}
+
+	if r.Method == http.MethodGet && f.forbidMetadataGet[path] {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"errors":["permission denied"]}`))
 		return
 	}
 

--- a/internal/cli/x509.go
+++ b/internal/cli/x509.go
@@ -157,7 +157,7 @@ func (c *CLI) cmdX509Issue(command string, args ...string) error {
 	// command line — replaces the authority with the certificate it just
 	// signed, taking its private key, its serial number, and its revocation
 	// list with it, and everything it ever issued becomes unverifiable.
-	if args[0] == opt.X509.Issue.SignedBy {
+	if vault.Canonicalize(args[0]) == vault.Canonicalize(opt.X509.Issue.SignedBy) {
 		return fmt.Errorf("refusing to overwrite the signing authority %s with the certificate it signs", args[0])
 	}
 
@@ -366,7 +366,14 @@ func (c *CLI) cmdX509Reissue(command string, args ...string) error {
 	if err != nil {
 		return err
 	}
-	if caPath != args[0] {
+	//caPath and args[0] can spell the same secret differently (a leading or
+	// trailing slash); FindSigningCA compares them as raw strings and, not
+	// recognizing the alias, reads the authority as a second, separate copy.
+	// Saving that copy back is then a second write to the record the
+	// reissued certificate below is about to overwrite anyway — one that
+	// carries a serial-counter increment the final write does not, since it
+	// lands on a copy that is discarded rather than the one that is saved.
+	if vault.Canonicalize(caPath) != vault.Canonicalize(args[0]) {
 		err = ca.SaveTo(v, caPath, false)
 		if err != nil {
 			return err
@@ -477,7 +484,10 @@ func (c *CLI) cmdX509Renew(command string, args ...string) error {
 	if err != nil {
 		return err
 	}
-	if caPath != args[0] {
+	//See the matching comment in cmdX509Reissue: caPath and args[0] can
+	// spell the same secret differently, and the raw comparison here has to
+	// see through that or write the same record twice.
+	if vault.Canonicalize(caPath) != vault.Canonicalize(args[0]) {
 		err = ca.SaveTo(v, caPath, false)
 		if err != nil {
 			return err

--- a/internal/cli/x509_issue_target_test.go
+++ b/internal/cli/x509_issue_target_test.go
@@ -38,6 +38,55 @@ func TestIssueRefusesToOverwriteItsOwnSigningCA(t *testing.T) {
 	}
 }
 
+// A trailing slash on the signing authority's path names the same secret,
+// so the refusal has to fire for it too.
+func TestIssueRefusesToOverwriteItsOwnSigningCATrailingSlash(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeCert(t, fv, "secret/ca", newCA(t, "root"))
+	before := fv.get("secret/ca")
+
+	c := newX509CLI(t)
+	c.opt.X509.Issue.Name = []string{"leaf.example.com"}
+	c.opt.X509.Issue.SignedBy = "secret/ca/"
+
+	err := c.cmdX509Issue("x509 issue", "secret/ca")
+	if err == nil {
+		t.Fatal("issue onto its own CA (trailing slash) = nil, want an error")
+	}
+
+	after := fv.get("secret/ca")
+	for _, attr := range []string{"certificate", "key", "serial", "crl"} {
+		if after[attr] != before[attr] {
+			t.Errorf("the CA's %s attribute changed", attr)
+		}
+	}
+}
+
+// A leading slash on the destination names the same secret too.
+func TestIssueRefusesToOverwriteItsOwnSigningCALeadingSlash(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeCert(t, fv, "secret/ca", newCA(t, "root"))
+	before := fv.get("secret/ca")
+
+	c := newX509CLI(t)
+	c.opt.X509.Issue.Name = []string{"leaf.example.com"}
+	c.opt.X509.Issue.SignedBy = "secret/ca"
+
+	err := c.cmdX509Issue("x509 issue", "/secret/ca")
+	if err == nil {
+		t.Fatal("issue onto its own CA (leading slash) = nil, want an error")
+	}
+
+	after := fv.get("secret/ca")
+	for _, attr := range []string{"certificate", "key", "serial", "crl"} {
+		if after[attr] != before[attr] {
+			t.Errorf("the CA's %s attribute changed", attr)
+		}
+	}
+}
+
 // Issuing somewhere else under the same authority is untouched.
 func TestIssueUnderACAWritesBothPaths(t *testing.T) {
 	isolateHome(t)

--- a/internal/cli/x509_sibling_ca_test.go
+++ b/internal/cli/x509_sibling_ca_test.go
@@ -120,3 +120,60 @@ func TestRenewUnderTheSiblingThatSignedItWorks(t *testing.T) {
 		t.Errorf("issuer = %q, want signer", got)
 	}
 }
+
+// A --signed-by that spells the certificate's own path differently (a
+// trailing slash) names the same secret. The authority and the certificate
+// being reissued are then the same underlying record, so saving the
+// authority separately from the reissued certificate is a second, redundant
+// write to that record — and, because the CA object read a second time
+// under the differently-spelled path is not the same in-memory copy as the
+// certificate being reissued, its serial counter increment never reaches
+// what finally gets saved. One write, not two.
+func TestReissueSkipsRedundantSaveWhenSignedByAliasesItself(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeCert(t, fv, "secret/ca", newCA(t, "root"))
+
+	c := newX509CLI(t)
+	c.opt.X509.Reissue.SignedBy = "secret/ca/"
+
+	fv.forgetRequests()
+	if err := c.cmdX509Reissue("x509 reissue", "secret/ca"); err != nil {
+		t.Fatalf("reissue under an aliased signed-by: %v", err)
+	}
+
+	writes := 0
+	for _, r := range fv.requests() {
+		if r == "PUT /v1/secret/ca" {
+			writes++
+		}
+	}
+	if writes != 1 {
+		t.Errorf("writes to secret/ca = %d, want 1", writes)
+	}
+}
+
+// The same aliasing collapses to one write for renew too.
+func TestRenewSkipsRedundantSaveWhenSignedByAliasesItself(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeCert(t, fv, "secret/ca", newCA(t, "root"))
+
+	c := newX509CLI(t)
+	c.opt.X509.Renew.SignedBy = "/secret/ca"
+
+	fv.forgetRequests()
+	if err := c.cmdX509Renew("x509 renew", "secret/ca"); err != nil {
+		t.Fatalf("renew under an aliased signed-by: %v", err)
+	}
+
+	writes := 0
+	for _, r := range fv.requests() {
+		if r == "PUT /v1/secret/ca" {
+			writes++
+		}
+	}
+	if writes != 1 {
+		t.Errorf("writes to secret/ca = %d, want 1", writes)
+	}
+}

--- a/pkg/rc/atomic.go
+++ b/pkg/rc/atomic.go
@@ -19,6 +19,16 @@ import (
 // open is the rename not surviving a power loss -- a stale config, not a
 // corrupt one.
 func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	// os.Rename replaces whatever is at path -- if path is a symlink (a
+	// dotfiles-managed ~/.saferc, ~/.vault-token, ~/.svtoken), that replaces
+	// the link itself and detaches it, not the file it points at. Resolve to
+	// the real file first so the temp file lands next to it and the rename
+	// replaces the real file, leaving the link in place. A path that does not
+	// exist yet (first write) has nothing to resolve; use it as given.
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+
 	dir, base := filepath.Split(path)
 	if dir == "" {
 		dir = "."

--- a/pkg/rc/atomic_test.go
+++ b/pkg/rc/atomic_test.go
@@ -126,6 +126,51 @@ func TestWriteFileAtomicBareFilename(t *testing.T) {
 	}
 }
 
+// A symlinked config (dotfiles-managed ~/.saferc, ~/.vault-token, ~/.svtoken)
+// must stay a symlink after a write: os.Rename replaces whatever is at path,
+// which is the link itself, not what it points at. The write has to land on
+// the link's target so the dotfiles checkout keeps tracking it.
+func TestWriteFileAtomicPreservesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real-saferc")
+	link := filepath.Join(dir, "saferc")
+
+	if err := os.WriteFile(real, []byte("old"), 0600); err != nil {
+		t.Fatalf("seed real file: %s", err)
+	}
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %s", err)
+	}
+
+	if err := writeFileAtomic(link, []byte("new"), 0600); err != nil {
+		t.Fatalf("writeFileAtomic: %s", err)
+	}
+
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat link: %s", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s is no longer a symlink", link)
+	}
+
+	target, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("readlink: %s", err)
+	}
+	if target != real {
+		t.Errorf("symlink target = %q, want %q", target, real)
+	}
+
+	b, err := os.ReadFile(real)
+	if err != nil {
+		t.Fatalf("read real file: %s", err)
+	}
+	if string(b) != "new" {
+		t.Errorf("real file content = %q, want %q", b, "new")
+	}
+}
+
 func TestWriteFileAtomicRejectsMissingDir(t *testing.T) {
 	err := writeFileAtomic(filepath.Join(t.TempDir(), "no", "such", "dir", "f"), []byte("x"), 0600)
 	if err == nil {

--- a/pkg/rc/config.go
+++ b/pkg/rc/config.go
@@ -34,10 +34,39 @@ type Vault struct {
 	SkipVerify bool     `yaml:"skip_verify,omitempty"`
 
 	// Strongbox opts a target into the Strongbox seal-state service on port
-	// :8484. Older configs wrote a no_strongbox key instead; it is ignored on
-	// read, and no target has Strongbox unless it says strongbox: true.
+	// :8484. Older configs wrote a no_strongbox key instead, with the
+	// opposite default: Strongbox was on unless no_strongbox: true.
+	// UnmarshalYAML honors that key when the file has it, so an upgrade
+	// does not silently disarm Strongbox for every pre-existing target; a
+	// file with neither key gets the new opt-in default (false).
 	Strongbox bool   `yaml:"strongbox,omitempty"`
 	Namespace string `yaml:"namespace,omitempty"`
+}
+
+// UnmarshalYAML translates the legacy no_strongbox key into Strongbox when
+// the key is present in the document, and leaves Strongbox at its zero value
+// (the new opt-in default) when it is not. Marshal only ever writes the
+// strongbox key, so the translated intent -- not the legacy key -- is what a
+// subsequent write persists.
+func (v *Vault) UnmarshalYAML(unmarshal func(any) error) error {
+	type vaultAlias Vault
+	if err := unmarshal((*vaultAlias)(v)); err != nil {
+		return err
+	}
+
+	var legacy struct {
+		NoStrongbox *bool `yaml:"no_strongbox"`
+	}
+	// The decoder replays the same node into a second target; unrecognized
+	// keys (url, token, ...) are ignored here just as strongbox is ignored
+	// above by vaultAlias, which has no no_strongbox field.
+	if err := unmarshal(&legacy); err != nil {
+		return err
+	}
+	if legacy.NoStrongbox != nil {
+		v.Strongbox = !*legacy.NoStrongbox
+	}
+	return nil
 }
 
 type oldConfig struct {

--- a/pkg/rc/config.go
+++ b/pkg/rc/config.go
@@ -154,37 +154,47 @@ func (c *Config) write() error {
 		return err
 	}
 
-	if err := writeFileAtomic(saferc(), b, 0600); err != nil {
-		return err
-	}
-
+	// Resolve the current target and marshal ~/.svtoken's content before
+	// replacing any file. c.Vault("") fails when Current names a target that
+	// is missing or ambiguous; catching that here means the failure aborts
+	// with nothing written, instead of leaving ~/.saferc replaced while
+	// ~/.svtoken -- and the token tools like Genesis read from it -- goes
+	// stale and the caller is told the write failed.
 	v, err := c.Vault("")
 	if err != nil {
 		return err
 	}
+
+	var svBytes []byte
+	if v != nil {
+		sv := struct {
+			Vault      string `yaml:"vault"` /* this is different than Vault.URL */
+			Token      string `yaml:"token"`
+			SkipVerify bool   `yaml:"skip_verify"`
+			CACerts    string `yaml:"ca_certs,omitempty"`
+			Namespace  string `yaml:"namespace,omitempty"`
+		}{
+			Vault:      v.URL,
+			Token:      v.Token,
+			SkipVerify: v.SkipVerify,
+			CACerts:    strings.Join(v.CACerts, "\n"),
+			Namespace:  v.Namespace,
+		}
+		svBytes, err = yaml.Marshal(sv)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := writeFileAtomic(saferc(), b, 0600); err != nil {
+		return err
+	}
+
 	if v == nil {
 		if err := os.Remove(svtoken()); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 		return nil
-	}
-
-	sv := struct {
-		Vault      string `yaml:"vault"` /* this is different than Vault.URL */
-		Token      string `yaml:"token"`
-		SkipVerify bool   `yaml:"skip_verify"`
-		CACerts    string `yaml:"ca_certs,omitempty"`
-		Namespace  string `yaml:"namespace,omitempty"`
-	}{
-		Vault:      v.URL,
-		Token:      v.Token,
-		SkipVerify: v.SkipVerify,
-		CACerts:    strings.Join(v.CACerts, "\n"),
-		Namespace:  v.Namespace,
-	}
-	b, err = yaml.Marshal(sv)
-	if err != nil {
-		return err
 	}
 
 	// .vault-token before .svtoken, with both attempted and both reported:
@@ -194,7 +204,7 @@ func (c *Config) write() error {
 	if c.Options.ManageVaultToken {
 		tokenErr = writeFileAtomic(fmt.Sprintf("%s/.vault-token", userHomeDir()), []byte(v.Token), 0600)
 	}
-	return errors.Join(tokenErr, writeFileAtomic(svtoken(), b, 0600))
+	return errors.Join(tokenErr, writeFileAtomic(svtoken(), svBytes, 0600))
 }
 
 // Returns the path of the file that the certificates were written into

--- a/pkg/rc/config_test.go
+++ b/pkg/rc/config_test.go
@@ -114,11 +114,14 @@ options:
 		}
 	})
 
-	t.Run("ignores the no_strongbox key older configs carry", func(t *testing.T) {
+	t.Run("honors the legacy no_strongbox key when present", func(t *testing.T) {
 		home := setHome(t)
-		//Both spellings a pre-opt-in config could hold: true asked for what is
-		// now the default, and false asked for the Strongbox that now takes
-		// strongbox: true to get. Neither target has one.
+		// Pre-opt-in configs wrote no_strongbox with the opposite default:
+		// Strongbox was on unless no_strongbox: true. prod carries the
+		// harmful spelling -- no_strongbox: false meant "yes, Strongbox" --
+		// and must still mean Strongbox. dev's explicit opt-out must still
+		// mean no Strongbox. legacy has neither key at all, which under the
+		// pre-rename default also meant Strongbox.
 		writeFile(t, filepath.Join(home, ".saferc"), `version: 1
 current: prod
 vaults:
@@ -133,10 +136,32 @@ vaults:
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
-		for name, v := range c.Vaults {
-			if v.Strongbox {
-				t.Errorf("%s: got Strongbox, want none without strongbox: true", name)
-			}
+		if v := c.Vaults["prod"]; v == nil || !v.Strongbox {
+			t.Errorf("prod: got Strongbox=%v, want true (no_strongbox: false)", v != nil && v.Strongbox)
+		}
+		if v := c.Vaults["dev"]; v == nil || v.Strongbox {
+			t.Errorf("dev: got Strongbox=%v, want false (no_strongbox: true)", v != nil && v.Strongbox)
+		}
+	})
+
+	t.Run("does not fabricate Strongbox for a config with neither key", func(t *testing.T) {
+		home := setHome(t)
+		// A config written entirely under the new opt-in scheme, or one this
+		// process already rewrote, has neither key. The opt-in default (off)
+		// is deliberate and must not be flipped just because the file is old
+		// enough to be missing the new field.
+		writeFile(t, filepath.Join(home, ".saferc"), `version: 1
+current: prod
+vaults:
+  prod:
+    url: https://vault.prod:8200
+`)
+		c, err := Read()
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if v := c.Vaults["prod"]; v == nil || v.Strongbox {
+			t.Errorf("prod: got Strongbox=%v, want false (no key present)", v != nil && v.Strongbox)
 		}
 	})
 

--- a/pkg/rc/lock.go
+++ b/pkg/rc/lock.go
@@ -56,7 +56,7 @@ func withLock(fn func() error) error {
 	locked, err := fl.TryLockContext(ctx, lockRetryDelay)
 	if err != nil && !locked {
 		if ctx.Err() != nil {
-			return fmt.Errorf("timed out after %s waiting to lock %s (another safe holding it? remove the file only if you are sure none is running)", lockTimeout, lockPath())
+			return fmt.Errorf("timed out after %s waiting to lock %s (another safe is holding it -- find it with `lsof %s`; the lock releases on its own when that process exits, do not remove the lock file)", lockTimeout, lockPath(), lockPath())
 		}
 		return fmt.Errorf("could not lock %s: %w", lockPath(), err)
 	}

--- a/pkg/rc/lock.go
+++ b/pkg/rc/lock.go
@@ -10,9 +10,15 @@ import (
 )
 
 // configMutex serializes writers within one process. flock(2) locks are held
-// per open file description, not per process, so without it two goroutines
-// taking the file lock through separate opens would not conflict -- and two
-// through a shared one would silently succeed together.
+// per open file description, not per process, so two goroutines each taking
+// the lock through their own flock.New (as withLock does on every call)
+// already conflict correctly without any help; what they would not do is
+// queue quietly -- each ends up polling TryLockContext against the other at
+// lockRetryDelay until one gives up or wins, instead of one running while the
+// rest wait. configMutex turns that churn into a plain queue. It also covers
+// the case flock alone cannot: two goroutines sharing one open file
+// description (the same *flock.Flock, or an fd inherited across a fork)
+// would not conflict with themselves at all.
 var configMutex sync.Mutex
 
 // How long a writer waits for whoever holds the lock, and how often it asks

--- a/pkg/rc/lock_test.go
+++ b/pkg/rc/lock_test.go
@@ -155,4 +155,19 @@ func TestWithLockTimesOutWhenHeld(t *testing.T) {
 	if !strings.Contains(err.Error(), lockPath()) {
 		t.Errorf("timeout error %q does not name the lock file", err)
 	}
+
+	// The message must never present removing the lock file as an option:
+	// withLock's own doc comment says the sidecar is created once and never
+	// removed, because unlinking it while the holder is still alive (wedged
+	// on slow I/O, stopped under a debugger -- exactly what produces this
+	// timeout) lets a second writer lock a fresh inode and race the first
+	// inside the critical section. It should instead point at identifying
+	// the holder and note the lock clears itself.
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "if you are sure") || strings.Contains(msg, "remove the file") {
+		t.Errorf("timeout error still offers to remove the lock file: %q", err)
+	}
+	if !strings.Contains(msg, "lsof") {
+		t.Errorf("timeout error %q does not point at identifying the holder", err)
+	}
 }

--- a/pkg/rc/update_test.go
+++ b/pkg/rc/update_test.go
@@ -155,6 +155,36 @@ func TestUpdateUpgradesLegacyConfig(t *testing.T) {
 	}
 }
 
+// A legacy no_strongbox key, once translated into Strongbox on read, must
+// come back out on the next write as the new strongbox key -- not as the
+// legacy key re-emitted, and not lost. That is what makes the translated
+// intent durable instead of re-derived (or re-lost) on every read.
+func TestUpdateCarriesLegacyStrongboxIntentForward(t *testing.T) {
+	setHome(t)
+
+	writeFile(t, saferc(), "version: 1\ncurrent: prod\nvaults:\n  prod:\n    url: http://prod\n    no_strongbox: false\n")
+
+	if err := Update(func(c *Config) error { return nil }); err != nil {
+		t.Fatalf("Update: %s", err)
+	}
+
+	raw := readFile(t, saferc())
+	if strings.Contains(raw, "no_strongbox") {
+		t.Errorf(".saferc still carries the legacy key:\n%s", raw)
+	}
+	if !strings.Contains(raw, "strongbox: true") {
+		t.Errorf(".saferc did not carry Strongbox forward as the new key:\n%s", raw)
+	}
+
+	c, err := Read()
+	if err != nil {
+		t.Fatalf("Read: %s", err)
+	}
+	if v := c.Vaults["prod"]; v == nil || !v.Strongbox {
+		t.Errorf("prod: got Strongbox=%v after rewrite, want true", v != nil && v.Strongbox)
+	}
+}
+
 // manage_vault_token failures must surface (the operator opted in; failing
 // silently leaves the Vault CLI authenticated as someone else), and a failure
 // there must not stop the .svtoken write behind it.

--- a/pkg/rc/update_test.go
+++ b/pkg/rc/update_test.go
@@ -70,6 +70,36 @@ func TestUpdateAppliesDeltaToLatestState(t *testing.T) {
 	}
 }
 
+// A current target that cannot be resolved (renamed away from under it, or a
+// legacy conversion that leaves Current ambiguous) must abort the whole write,
+// not just the trailing ~/.svtoken step: partial application leaves ~/.saferc
+// holding the mutation while ~/.svtoken goes stale, and every subsequent
+// command disagrees with itself about the current target.
+func TestUpdateAbortsWriteWhenCurrentUnresolvable(t *testing.T) {
+	setHome(t)
+
+	writeFile(t, saferc(), "version: 1\ncurrent: ghost\nvaults:\n  keep:\n    url: http://keep\n")
+	writeFile(t, svtoken(), "vault: http://stale\ntoken: stale-token\n")
+
+	beforeRC := readFile(t, saferc())
+	beforeSV := readFile(t, svtoken())
+
+	err := Update(func(c *Config) error {
+		c.Vaults["another"] = &Vault{URL: "http://another"}
+		return nil
+	})
+	if err == nil {
+		t.Fatalf("Update succeeded with an unresolvable current target")
+	}
+
+	if after := readFile(t, saferc()); after != beforeRC {
+		t.Errorf(".saferc changed after aborted write:\n%s", after)
+	}
+	if after := readFile(t, svtoken()); after != beforeSV {
+		t.Errorf(".svtoken changed after aborted write:\n%s", after)
+	}
+}
+
 func TestUpdateMutationErrorAbortsWrite(t *testing.T) {
 	setHome(t)
 

--- a/pkg/vault/colon_key_test.go
+++ b/pkg/vault/colon_key_test.go
@@ -542,6 +542,28 @@ func TestWriteRequiresEncodedColonPath(t *testing.T) {
 	}
 }
 
+// Writing an empty Secret is how a caller clears a path (safe import of an
+// entry with no keys), and it routes through deleteIfPresent. Write already
+// parsed the path:key syntax once; deleteIfPresent must not re-split a
+// literal colon in the resulting secret path as if it were the path:key
+// separator, or it deletes a key from the wrong sibling secret entirely.
+func TestWriteEmptySecretToColonPathDeletesOnlyThatSecret(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.set("secret/host:8200/creds", map[string]string{"user": "admin"})
+	fv.set("secret/host", map[string]string{"alpha": "untouched"})
+
+	err := v.Write(vault.EncodePath("secret/host:8200/creds", "", 0), vault.NewSecret())
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	secretAbsent(t, fv, "secret/host:8200/creds")
+	if kv := mustGetSecret(t, fv, "secret/host"); kv["alpha"] != "untouched" {
+		t.Errorf("sibling secret/host was modified: %v", kv)
+	}
+}
+
 // The tree walk names key nodes "<raw path>:<escaped key>". Basename splits at
 // the last colon not preceded by a backslash, which is always the join colon,
 // so a colon or caret in the path half cannot steal the key. This locks that

--- a/pkg/vault/find_signing_ca_test.go
+++ b/pkg/vault/find_signing_ca_test.go
@@ -8,6 +8,7 @@
 package vault_test
 
 import (
+	"bytes"
 	"crypto/x509"
 	"strings"
 	"testing"
@@ -205,6 +206,32 @@ func TestFindSigningCARefusesAStrangerSibling(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--signed-by") {
 		t.Errorf("error %q should point at --signed-by", err)
+	}
+}
+
+// A CA rotated to a fresh key (what `safe x509 reissue secret/env/ca`
+// ordinarily does) keeps its Subject; every leaf issued under the old key no
+// longer verifies against the new one cryptographically, but the sibling is
+// still the right authority to renew or reissue under. FindSigningCA has to
+// accept it, or the ordinary rotation workflow is blocked for every leaf
+// underneath.
+func TestFindSigningCAAcceptsARotatedSibling(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+	oldCA := caNamed(t, "authority")
+	newCA := caNamed(t, "authority") // same subject, fresh key: a rotation
+	leaf := leafSignedBy(t, oldCA)
+	writeCert(t, v, "secret/x/ca", newCA)
+
+	got, path, err := v.FindSigningCA(leaf, "secret/x/cert", "")
+	if err != nil {
+		t.Fatalf("FindSigningCA: %v", err)
+	}
+	if path != "secret/x/ca" {
+		t.Errorf("path = %q, want secret/x/ca", path)
+	}
+	if !bytes.Equal(got.Certificate.Raw, newCA.Certificate.Raw) {
+		t.Error("FindSigningCA did not return the current (rotated) sibling")
 	}
 }
 

--- a/pkg/vault/find_signing_ca_test.go
+++ b/pkg/vault/find_signing_ca_test.go
@@ -91,6 +91,33 @@ func TestFindSigningCANamedAsItself(t *testing.T) {
 	}
 }
 
+// A --signed-by that spells the certificate's own path differently (a
+// leading or trailing slash, or a doubled one) still names the same secret,
+// and must take the self-signing branch: returning the certificate object
+// itself, not a second, separately-read copy of it. Sign's CA-rotation
+// branch (ca == x) compares the returned CA against the certificate by
+// pointer identity, so treating a differently-spelled alias as reading a
+// distinct authority breaks self-rotation for exactly the spellings the raw
+// comparison happens to miss -- and, since nothing is written at the
+// aliased path in this test, a fall-through to v.Read would fail closed
+// rather than silently pass.
+func TestFindSigningCARecognizesADifferentlySpelledSelfAlias(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+	ca := caNamed(t, "self")
+
+	got, path, err := v.FindSigningCA(ca, "secret/ca/", "secret/ca")
+	if err != nil {
+		t.Fatalf("FindSigningCA: %v", err)
+	}
+	if got != ca {
+		t.Error("FindSigningCA read a second copy instead of recognizing the alias")
+	}
+	if path != "secret/ca/" {
+		t.Errorf("path = %q, want secret/ca/ (the certificate's own path)", path)
+	}
+}
+
 func TestFindSigningCAReadsANamedAuthority(t *testing.T) {
 	t.Parallel()
 	v, _ := newTestVault(t)

--- a/pkg/vault/find_signing_ca_test.go
+++ b/pkg/vault/find_signing_ca_test.go
@@ -175,6 +175,25 @@ func TestFindSigningCAFindsTheCASibling(t *testing.T) {
 	}
 }
 
+// A certificate path with no '/' at all has no sibling to guess: the guess
+// is built by trimming the path back to its parent directory, which does not
+// exist here. It must be reported as no authority found, not panic building
+// the guessed path.
+func TestFindSigningCAWithNoSlashInPathDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	v, _ := newTestVault(t)
+	ca := caNamed(t, "authority")
+	leaf := leafSignedBy(t, ca)
+
+	_, _, err := v.FindSigningCA(leaf, "leaf", "")
+	if err == nil {
+		t.Fatal("FindSigningCA guessed an authority out of nothing")
+	}
+	if !strings.Contains(err.Error(), "no signing authority provided and no 'ca' sibling found") {
+		t.Errorf("error %q should say no authority was found", err)
+	}
+}
+
 func TestFindSigningCAWithNoSiblingToGuess(t *testing.T) {
 	t.Parallel()
 	v, _ := newTestVault(t)

--- a/pkg/vault/httptest_helper_test.go
+++ b/pkg/vault/httptest_helper_test.go
@@ -95,9 +95,15 @@ type fakeVault struct {
 	rekeyActive   bool
 	rekeyNonce    string
 	rekeyRequired int      // existing keys needed to authorize the rekey
-	rekeyProgress int      // existing keys submitted so far
+	rekeyProgress int      // existing keys submitted so far; reset on cancel or completion
 	rekeyShares   int      // new key count to mint on completion
 	rekeyNewKeys  []string // new keys returned on completion
+
+	// rekeyUpdateCalls counts every PUT to /v1/sys/rekey/update the fake has
+	// received, and is never reset. rekeyProgress resets on cancel, so it
+	// cannot tell a test whether a key was ever transmitted before an abort;
+	// this can.
+	rekeyUpdateCalls int
 }
 
 func newFakeVault() *fakeVault {
@@ -549,6 +555,7 @@ func (f *fakeVault) handleSys(w http.ResponseWriter, r *http.Request) {
 		})
 
 	case p == "/v1/sys/rekey/update" && r.Method == http.MethodPut:
+		f.rekeyUpdateCalls++
 		f.rekeyProgress++
 		if f.rekeyProgress >= f.rekeyRequired {
 			keys := f.rekeyNewKeys

--- a/pkg/vault/httptest_kv2_helper_test.go
+++ b/pkg/vault/httptest_kv2_helper_test.go
@@ -172,6 +172,10 @@ func (f *fakeVault) handleKVv2(w http.ResponseWriter, r *http.Request, mount, su
 	case "data":
 		f.serveV2Data(w, r, path)
 	case "metadata":
+		if r.URL.Query().Get("list") == "true" {
+			f.serveV2List(w, r, path)
+			return
+		}
 		f.serveV2Metadata(w, r, path)
 	case "delete":
 		f.applyToVersions(w, r, path, func(v *fakeV2Version) {
@@ -196,8 +200,65 @@ func (f *fakeVault) handleKVv2(w http.ResponseWriter, r *http.Request, mount, su
 	}
 }
 
-// serveV2Data answers reads, writes, and the versionless delete. Callers
+// serveV2List answers a directory listing over a v2 mount's metadata
+// endpoint (the request that vaultkv's V2List sends, ?list=true). It mirrors
+// listUnder, but walks the v2 secret keys rather than the v1 ones. Callers
 // hold f.mu.
+func (f *fakeVault) serveV2List(w http.ResponseWriter, r *http.Request, path string) {
+	if r.Method != http.MethodGet {
+		jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if f.forbidden[path] {
+		jsonErr(w, http.StatusForbidden, "permission denied")
+		return
+	}
+
+	children := f.listUnderV2Locked(path)
+	if len(children) == 0 {
+		jsonErr(w, http.StatusNotFound, "")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"data": map[string]any{
+			"keys": children,
+		},
+	})
+}
+
+// listUnderV2Locked returns immediate children under prefix (relative
+// paths), the v2 counterpart of listUnder. Callers hold f.mu.
+func (f *fakeVault) listUnderV2Locked(prefix string) []string {
+	prefix = strings.TrimRight(prefix, "/") + "/"
+	seen := map[string]bool{}
+	var out []string
+	for p, h := range f.v2data {
+		if h == nil || len(h.versions) == 0 {
+			continue
+		}
+		if !strings.HasPrefix(p, prefix) {
+			continue
+		}
+		rel := strings.TrimPrefix(p, prefix)
+		parts := strings.SplitN(rel, "/", 2)
+		entry := parts[0]
+		if len(parts) == 2 {
+			entry = parts[0] + "/"
+		}
+		if !seen[entry] {
+			seen[entry] = true
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+// serveV2Data answers reads, writes, and the versionless delete. A GET
+// (secret read) on a path marked forbidden 403s, modeling a policy that
+// grants list/metadata on a subtree but denies the data read -- the case
+// workGet has to skip and count rather than aborting the whole walk.
+// Callers hold f.mu.
 func (f *fakeVault) serveV2Data(w http.ResponseWriter, r *http.Request, path string) {
 	switch r.Method {
 	case http.MethodPut, http.MethodPost:
@@ -222,6 +283,10 @@ func (f *fakeVault) serveV2Data(w http.ResponseWriter, r *http.Request, path str
 		w.WriteHeader(http.StatusNoContent)
 
 	case http.MethodGet:
+		if f.forbidden[path] {
+			jsonErr(w, http.StatusForbidden, "permission denied")
+			return
+		}
 		number := uint(0)
 		if q := r.URL.Query().Get("version"); q != "" {
 			parsed, err := strconv.ParseUint(q, 10, 64)

--- a/pkg/vault/path_less_than_order_test.go
+++ b/pkg/vault/path_less_than_order_test.go
@@ -22,6 +22,7 @@ var orderingSample = []string{
 	"secret/a",
 	"secret/a/",
 	"/secret/a",
+	"secret//a",
 	"secret/ab",
 	"secret/a/x",
 	"secret/a/y",

--- a/pkg/vault/proxy.go
+++ b/pkg/vault/proxy.go
@@ -165,15 +165,23 @@ func StartSSHTunnel(conf SOCKS5SSHConfig) (*ssh.Client, error) {
 	var err error
 
 	if !conf.SkipHostKeyValidation {
-		if conf.KnownHostsFile == "" {
+		derivedDefault := conf.KnownHostsFile == ""
+		if derivedDefault {
 			if os.Getenv("HOME") == "" {
 				return nil, fmt.Errorf("no home directory set and no known hosts file explicitly given; cannot validate host key")
 			}
 			conf.KnownHostsFile = filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts")
 		}
 
-		if err = ensureKnownHostsFile(conf.KnownHostsFile); err != nil {
-			return nil, err
+		// Only create the file when its path was derived. A path the caller
+		// named explicitly (SAFE_KNOWN_HOSTS_FILE) must fail hard if it is
+		// missing rather than silently start empty -- see
+		// knownHostsPromptCallback's error below, which is what a missing
+		// explicit file now produces.
+		if derivedDefault {
+			if err = ensureKnownHostsFile(conf.KnownHostsFile); err != nil {
+				return nil, err
+			}
 		}
 
 		hostKeyCallback, err = knownHostsPromptCallback(conf.KnownHostsFile)

--- a/pkg/vault/proxy.go
+++ b/pkg/vault/proxy.go
@@ -20,6 +20,11 @@ import (
 	"golang.org/x/net/http/httpproxy"
 )
 
+// isTerminal reports whether fd is attached to an interactive terminal. A
+// package variable, the same seam prompt.SetReader provides for stdin, so
+// tests can simulate a tty or its absence without a real one.
+var isTerminal = isatty.IsTerminal
+
 type ProxyRouter struct {
 	ProxyConf httpproxy.Config
 }
@@ -329,8 +334,13 @@ Host key verification failed`
 		}
 
 		//If not, then the key doesn't exist in the host key file
-		//Let's see if we can ask the user if they want to add it
-		if !isatty.IsTerminal(os.Stderr.Fd()) || !promptAddNewKnownHost(hostname, remote, key) {
+		//Let's see if we can ask the user if they want to add it. The
+		//prompt reads its answer from stdin, so whether it can run has to
+		//depend on stdin being a terminal -- gating on stderr let a
+		//redirected stdin (`safe -T bastion import < data.json`) be drained
+		//by the prompt loop looking for "yes"/"no" while stderr happened to
+		//be a terminal.
+		if !isTerminal(os.Stdin.Fd()) || !promptAddNewKnownHost(hostname, remote, key) {
 			//If its not a terminal or the user declined, we're rejecting it
 			return fmt.Errorf("host key verification failed: %w", callbackErr)
 		}

--- a/pkg/vault/proxy_known_hosts_file_test.go
+++ b/pkg/vault/proxy_known_hosts_file_test.go
@@ -71,19 +71,22 @@ func TestKnownHostsFileIsLeftAloneWhenPresent(t *testing.T) {
 	}
 }
 
-// TestStartSSHTunnelCreatesKnownHostsFile checks the same through the caller.
-// The tunnel cannot be made here -- the private key is not one -- but the file
-// has to exist by the time that is the reason it fails, because a missing file
-// used to be the reason instead.
-func TestStartSSHTunnelCreatesKnownHostsFile(t *testing.T) {
-	t.Parallel()
-	path := filepath.Join(t.TempDir(), ".ssh", "known_hosts")
+// TestStartSSHTunnelCreatesDerivedKnownHostsFile checks the same through the
+// caller, for the case where no known_hosts file was named at all and safe
+// derives ~/.ssh/known_hosts. The tunnel cannot be made here -- the private
+// key is not one -- but the file has to exist by the time that is the reason
+// it fails, because a missing file used to be the reason instead.
+//
+// t.Setenv forbids t.Parallel, so this test runs serially.
+func TestStartSSHTunnelCreatesDerivedKnownHostsFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".ssh", "known_hosts")
 
 	_, err := StartSSHTunnel(SOCKS5SSHConfig{
-		Host:           "127.0.0.1:22",
-		User:           "someone",
-		PrivateKey:     []byte("this is not a private key"),
-		KnownHostsFile: path,
+		Host:       "127.0.0.1:22",
+		User:       "someone",
+		PrivateKey: []byte("this is not a private key"),
 	})
 	if err == nil {
 		t.Fatal("expected the unusable private key to be refused")
@@ -94,6 +97,36 @@ func TestStartSSHTunnelCreatesKnownHostsFile(t *testing.T) {
 
 	if _, statErr := os.Stat(path); statErr != nil {
 		t.Errorf("known_hosts was not created: %v", statErr)
+	}
+}
+
+// TestStartSSHTunnelRefusesMissingExplicitKnownHostsFile covers a
+// SAFE_KNOWN_HOSTS_FILE that names a curated file which is not there --
+// typically a typo'd path, or a mount that has not appeared yet. Before this
+// behavior was fixed, safe created an empty file at the mistake and silently
+// fell back to trust-on-first-use for whatever key the host offered, in
+// place of the verification the operator configured. A path the caller named
+// explicitly must fail hard instead, the way ssh itself refuses a bad
+// -o UserKnownHostsFile.
+func TestStartSSHTunnelRefusesMissingExplicitKnownHostsFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "curated", "known_hosts")
+
+	_, err := StartSSHTunnel(SOCKS5SSHConfig{
+		Host:           "127.0.0.1:22",
+		User:           "someone",
+		PrivateKey:     []byte("this is not a private key"),
+		KnownHostsFile: path,
+	})
+	if err == nil {
+		t.Fatal("expected the missing explicit known_hosts file to be refused")
+	}
+	if !strings.Contains(err.Error(), "known_hosts") && !strings.Contains(err.Error(), "known hosts") {
+		t.Errorf("tunnel failed for some reason other than the known_hosts file: %v", err)
+	}
+
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("explicit known_hosts file was created at a typo'd path: %v", statErr)
 	}
 }
 

--- a/pkg/vault/proxy_knownhosts_test.go
+++ b/pkg/vault/proxy_knownhosts_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cloudfoundry-community/safe/pkg/prompt"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -197,6 +198,60 @@ func TestKnownHostsMatchingKeyAccepted(t *testing.T) {
 	fakeAddr := fakeNetAddr("127.0.0.1:22")
 	if err := cb("good.host:22", fakeAddr, key); err != nil {
 		t.Errorf("expected nil error for matching key, got: %v", err)
+	}
+}
+
+// TestUnknownHostPromptGatesOnStdinNotStderr covers an unknown host key
+// reaching the interactive-accept branch. The prompt reads its yes/no answer
+// from stdin, so whether it runs has to depend on stdin being a terminal, not
+// stderr's: an interactive stderr with redirected stdin
+// (`safe -T bastion import < data.json`) must be refused without trying to
+// read the answer out of the redirected payload, and an interactive stdin
+// with redirected stderr must still be asked.
+func TestUnknownHostPromptGatesOnStdinNotStderr(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		stdinTTY   bool
+		stderrTTY  bool
+		wantAccept bool
+	}{
+		{"redirected stdin, interactive stderr: refused without reading", false, true, false},
+		{"interactive stdin, redirected stderr: prompt runs", true, false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "known_hosts")
+			if err := os.WriteFile(path, []byte{}, 0600); err != nil {
+				t.Fatalf("create empty known_hosts: %v", err)
+			}
+			cb, err := knownHostsPromptCallback(path)
+			if err != nil {
+				t.Fatalf("knownHostsPromptCallback: %v", err)
+			}
+
+			restore := isTerminal
+			isTerminal = func(fd uintptr) bool {
+				switch fd {
+				case os.Stdin.Fd():
+					return tc.stdinTTY
+				case os.Stderr.Fd():
+					return tc.stderrTTY
+				default:
+					return false
+				}
+			}
+			t.Cleanup(func() { isTerminal = restore })
+
+			prompt.SetReader(strings.NewReader("yes\n"))
+			t.Cleanup(func() { prompt.SetReader(nil) })
+
+			key := makeEd25519PublicKey(t)
+			cbErr := cb("unknown.example.com:22", fakeNetAddr("127.0.0.1:22"), key)
+			accepted := cbErr == nil
+			if accepted != tc.wantAccept {
+				t.Errorf("accepted = %v (err: %v), want %v", accepted, cbErr, tc.wantAccept)
+			}
+		})
 	}
 }
 

--- a/pkg/vault/proxy_socks5_url_test.go
+++ b/pkg/vault/proxy_socks5_url_test.go
@@ -10,10 +10,16 @@ import (
 )
 
 // openHelper runs openSOCKS5Helper against a throwaway known_hosts file, so a
-// test never reads or writes the one belonging to whoever is running it.
+// test never reads or writes the one belonging to whoever is running it. The
+// file is seeded empty up front: an explicitly named known_hosts file is
+// never auto-created, and these tests are checking failures unrelated to it.
 func openHelper(t *testing.T, proxyURL string) (string, error) {
 	t.Helper()
-	return openSOCKS5Helper(proxyURL, filepath.Join(t.TempDir(), "known_hosts"), false)
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	if err := ensureKnownHostsFile(path); err != nil {
+		t.Fatalf("seed known_hosts file: %v", err)
+	}
+	return openSOCKS5Helper(proxyURL, path, false)
 }
 
 // TestSOCKS5URLNamesThePrivateKey checks the two ways of naming the key, both

--- a/pkg/vault/proxy_tunnel_test.go
+++ b/pkg/vault/proxy_tunnel_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"io"
 	"net"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -213,7 +212,13 @@ func TestTunnelRefusesAnUnknownHostWithNoOneToAsk(t *testing.T) {
 	t.Parallel()
 	sshAddr, _ := startFakeSSHServer(t)
 
+	//An explicitly named known_hosts file is never auto-created; it must
+	//already exist, so seed an empty one to isolate this test's assertion
+	//to the unknown-host refusal it is checking.
 	knownHosts := filepath.Join(t.TempDir(), ".ssh", "known_hosts")
+	if err := ensureKnownHostsFile(knownHosts); err != nil {
+		t.Fatalf("seed known_hosts file: %v", err)
+	}
 	_, loginKey := makeSSHKeyPair(t)
 
 	_, err := StartSSHTunnel(SOCKS5SSHConfig{
@@ -227,12 +232,6 @@ func TestTunnelRefusesAnUnknownHostWithNoOneToAsk(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "host key verification failed") {
 		t.Errorf("unknown host refused for some other reason: %v", err)
-	}
-
-	//The file is made on the way past, so the next run has somewhere to record
-	// the key once it is accepted.
-	if _, statErr := os.Stat(knownHosts); statErr != nil {
-		t.Errorf("known_hosts was not created: %v", statErr)
 	}
 }
 

--- a/pkg/vault/rekey.go
+++ b/pkg/vault/rekey.go
@@ -76,12 +76,13 @@ func (v *Vault) ReKey(unsealKeyCount, numToUnseal int, pgpKeys []string) ([]stri
 	for i := range givenKeys {
 		key, err := prompt.SecureE("Unseal Key %d: ", i+1)
 		if err != nil {
-			// stdin closed before every key arrived. Submit what we have
-			// anyway: the submission is rejected, the deferred cancel runs,
-			// and the server is left without a half-started rekey. Returning
-			// here instead would report a safe-side error for what is a
-			// Vault-side validation failure.
-			break
+			// stdin closed before every key arrived, and the set can never
+			// be completed. Abort here rather than submitting the partial
+			// slice: Submit posts each key to the server in turn, so every
+			// key typed so far would be transmitted before the empty
+			// entries at the end drew a rejection. The deferred cancel
+			// above tells the server to forget the rekey.
+			return nil, fmt.Errorf("rekey aborted, unseal key %d was never entered: %w", i+1, err)
 		}
 		givenKeys[i] = key
 	}

--- a/pkg/vault/rekey_test.go
+++ b/pkg/vault/rekey_test.go
@@ -1,6 +1,8 @@
 package vault_test
 
 import (
+	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -13,9 +15,12 @@ import (
 // server. A prompt that terminates the process instead would skip that defer
 // and strand the Vault mid-rekey.
 //
-// Both cases assert on the fake's rekey state rather than on the cancel call
-// itself: the fake only clears rekeyActive when the DELETE arrives, and only
-// the deferred cancel sends one here.
+// It must also abort without submitting the keys already typed: Submit posts
+// each key to the server in turn, so padding the short slice with an empty
+// string and submitting it anyway would transmit real key material for a
+// rekey already known to be unsatisfiable, before the empty entry is even
+// reached. rekeyUpdateCalls never resets, unlike rekeyProgress, so it is what
+// proves no key reached the server.
 func TestReKeyCancelsOnClosedStdin(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -42,12 +47,10 @@ func TestReKeyCancelsOnClosedStdin(t *testing.T) {
 				t.Errorf("ReKey: expected no keys on failure, got %v", keys)
 			}
 
-			// The message comes from the client rejecting an empty key, and
-			// is what the caller prints. Asserting on it keeps safe out of
-			// the business of inventing its own wording for this failure.
-			want := "key submission failed: no key provided"
-			if !strings.Contains(err.Error(), want) {
-				t.Errorf("ReKey error = %q, want it to contain %q", err, want)
+			// The prompt hit EOF before every key arrived; the error must
+			// still say so, whatever wording wraps it.
+			if !errors.Is(err, io.EOF) {
+				t.Errorf("ReKey error = %v, want it to wrap io.EOF", err)
 			}
 
 			if fv.rekeyNonce == "" {
@@ -55,6 +58,9 @@ func TestReKeyCancelsOnClosedStdin(t *testing.T) {
 			}
 			if fv.rekeyActive {
 				t.Error("rekey still in progress: the deferred cancel did not run")
+			}
+			if fv.rekeyUpdateCalls != 0 {
+				t.Errorf("rekeyUpdateCalls = %d, want 0: a key was submitted although the set could not be completed", fv.rekeyUpdateCalls)
 			}
 		})
 	}

--- a/pkg/vault/tree.go
+++ b/pkg/vault/tree.go
@@ -882,11 +882,13 @@ func (w *treeWorker) workGet(t secretTree) ([]secretTree, error) {
 	}
 
 	s, err := w.vault.Read(EncodePath(path, "", uint64(t.Version)))
-	//For v1 backends, this is the first non-list Vault access.
-	// If we're unable to get a path that we could list because of permissions,
-	// don't explode.
+	//For v1 backends, this is the first non-list Vault access; for v2
+	// backends, workVersions already read the metadata, but a policy can
+	// grant metadata and deny the data read separately, so this is where
+	// that denial first shows up. Either way, a path we could list but
+	// cannot read is skipped rather than aborting the whole walk.
 	if err != nil {
-		if t.MountVersion == 1 && vaultkv.IsForbidden(err) {
+		if vaultkv.IsForbidden(err) {
 			w.opts.noteSkippedForbidden()
 			return nil, nil
 		}

--- a/pkg/vault/tree.go
+++ b/pkg/vault/tree.go
@@ -210,22 +210,30 @@ func PathLessThan(left, right string) bool {
 		}
 	}
 
-	if len(left) < len(right) {
-		return true
-	} else if len(left) > len(right) {
-		return false
+	if len(leftSplit) != len(rightSplit) {
+		return len(leftSplit) < len(rightSplit)
 	}
 
-	//No path is less than itself. Without this, every path that does not end
-	// in a slash compares less than a copy of itself, which is not an ordering
-	// sort.Slice is entitled to be given. Reaching here with different strings
-	// means they differ only in slashes -- `/secret/a` against `secret/a/` --
-	// and the one that is not a folder sorts first.
-	if left == right {
-		return false
+	//The canonical paths agree on every segment: the two are either the same
+	// path spelled differently -- `/secret/a` against `secret//a` -- or one
+	// names a folder and the other the secret at that folder's own path --
+	// `secret/a/` against `secret/a`. A folder sorts after the secret at its
+	// own path, since the folder's contents nest under that same prefix.
+	leftIsDir := strings.HasSuffix(left, "/")
+	rightIsDir := strings.HasSuffix(right, "/")
+	if leftIsDir != rightIsDir {
+		return !leftIsDir
 	}
 
-	return !strings.HasSuffix(left, "/")
+	//Neither the canonical path nor the folder/secret distinction tells the
+	// two apart, which happens for two raw spellings of the very same path
+	// (including left == right, where this reports false, satisfying no
+	// path being less than itself). Breaking the tie on the raw string
+	// itself, rather than looking at left alone, keeps the result the same
+	// regardless of which side of the call left and right land on --
+	// required for a strict weak ordering, and violated before this by
+	// depending only on left's own trailing slash.
+	return left < right
 }
 
 func (s Secrets) Sort() {

--- a/pkg/vault/tree.go
+++ b/pkg/vault/tree.go
@@ -1017,7 +1017,7 @@ func (w *treeWorker) workVersions(t secretTree) ([]secretTree, error) {
 		})
 	}
 
-	if !w.opts.FetchAllVersions {
+	if !w.opts.FetchAllVersions && len(ret) > 0 {
 		ret = ret[len(ret)-1:]
 	}
 

--- a/pkg/vault/tree_forbidden_test.go
+++ b/pkg/vault/tree_forbidden_test.go
@@ -52,6 +52,48 @@ func TestConstructSecrets_CountsForbiddenSkips(t *testing.T) {
 	}
 }
 
+// A KV v2 mount must skip and count a forbidden data read exactly like a v1
+// mount does: `safe values` promises that denied subtrees are skipped and
+// counted, regardless of the KV engine version behind them. A policy that
+// grants list/metadata but denies the data read on one leaf is a normal
+// per-team layout, and it must not abort the walk of the whole subtree.
+func TestConstructSecrets_CountsForbiddenSkipsOnKVv2(t *testing.T) {
+	t.Parallel()
+	v, fv := newTestVault(t)
+	fv.mountV2("kv")
+
+	fv.setV2("kv/ok", map[string]string{"k": "v"})
+	fv.setV2("kv/unreadable", map[string]string{"k": "v"})
+	fv.forbid("kv/unreadable") // data get 403s; list/metadata stay permitted
+
+	var skipped atomic.Uint64
+	s, err := v.ConstructSecrets("kv", vault.TreeOpts{
+		FetchKeys:        true,
+		SkippedForbidden: &skipped,
+	})
+	if err != nil {
+		t.Fatalf("ConstructSecrets: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, entry := range s {
+		got[entry.Path] = true
+		if entry.Path == "kv/unreadable" {
+			for _, ver := range entry.Versions {
+				if len(ver.Data.Keys()) != 0 {
+					t.Errorf("forbidden secret %s has key data: %v", entry.Path, ver.Data.Keys())
+				}
+			}
+		}
+	}
+	if !got["kv/ok"] {
+		t.Errorf("walk missing readable sibling kv/ok (got %v)", s.Paths())
+	}
+	if n := skipped.Load(); n != 1 {
+		t.Errorf("skipped = %d, want 1 (the forbidden data read)", n)
+	}
+}
+
 // Without a counter wired in, forbidden subtrees are still skipped silently
 // and the nil SkippedForbidden must not be touched.
 func TestConstructSecrets_NilSkipCounterUnused(t *testing.T) {

--- a/pkg/vault/tree_versions_panic_test.go
+++ b/pkg/vault/tree_versions_panic_test.go
@@ -1,0 +1,72 @@
+// workVersions truncating to the last-seen version assumes at least one
+// version came back. A KV v2 metadata read that answers 200 with no versions
+// at all -- a secret whose history was fully trimmed or destroyed but whose
+// metadata record is still there -- breaks that assumption. This is package
+// vault (not vault_test) so workVersions can be called directly against a
+// single-purpose fake server, without going through the tree walk's
+// discovery path, which normalizes an empty-but-present metadata record to
+// SecretNotFound before a child node like this is ever reached.
+package vault
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestWorkVersionsHandlesAnEmptyMetadataResponse(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/sys/internal/ui/mounts", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"secret": map[string]any{
+					"kv2/": map[string]any{
+						"type":    "kv",
+						"options": map[string]any{"version": "2"},
+					},
+				},
+			},
+		})
+	})
+	mux.HandleFunc("/v1/kv2/metadata/drained", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"created_time":    "2020-01-01T00:00:00Z",
+				"updated_time":    "2020-01-01T00:00:00Z",
+				"current_version": 0,
+				"oldest_version":  0,
+				"max_versions":    0,
+				"versions":        map[string]any{},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	v, err := NewVault(VaultConfig{URL: u.String(), Token: "test-token"})
+	if err != nil {
+		t.Fatalf("NewVault: %v", err)
+	}
+	if err := v.SetURL(u.String()); err != nil {
+		t.Fatalf("SetURL: %v", err)
+	}
+
+	w := treeWorker{vault: v, opts: TreeOpts{}}
+	got, err := w.workVersions(secretTree{Name: "kv2/drained", MountVersion: 2})
+	if err != nil {
+		t.Fatalf("workVersions: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("workVersions returned %d nodes, want 0", len(got))
+	}
+}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -1075,11 +1075,18 @@ func (v *Vault) FindSigningCA(cert *X509, certPath string, signPath string) (*X5
 			// with a different issuer than the one it went in with, which
 			// is not what renewing or reissuing was asked to do. Naming an
 			// authority explicitly still moves a certificate to a new one.
-			if err := ca.Certificate.CheckSignature(
-				cert.Certificate.SignatureAlgorithm,
-				cert.Certificate.RawTBSCertificate,
-				cert.Certificate.Signature,
-			); err != nil {
+			//
+			// A cryptographic signature check would also refuse the
+			// ordinary case of CA rotation: reissuing the CA itself with a
+			// fresh key (the ca == x branch in Sign) replaces its public
+			// key, so no certificate signed under the old key verifies
+			// against it anymore, even though the sibling is still the
+			// right authority. Comparing the sibling's Subject to the
+			// certificate's Issuer instead catches an unrelated stranger CA
+			// the same way, without being upset by a key rotation: the
+			// Subject and Issuer stay equal across one, and differ for a
+			// sibling that never issued the certificate at all.
+			if !bytes.Equal(ca.Certificate.RawSubject, cert.Certificate.RawIssuer) {
 				return nil, "", fmt.Errorf("%s did not sign %s; name its authority with --signed-by", caPath, certPath)
 			}
 			return ca, caPath, nil

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -1057,8 +1057,14 @@ func (v *Vault) FindSigningCA(cert *X509, certPath string, signPath string) (*X5
 		if err == nil {
 			return cert, certPath, nil
 		} else {
-			// Lets see if we can guess the CA if none was provided
-			caPath := certPath[0:strings.LastIndex(certPath, "/")] + "/ca"
+			// Lets see if we can guess the CA if none was provided. A path
+			// with no '/' at all has no parent directory to guess a sibling
+			// under.
+			slash := strings.LastIndex(certPath, "/")
+			if slash < 0 {
+				return nil, "", fmt.Errorf("no signing authority provided and no 'ca' sibling found")
+			}
+			caPath := certPath[0:slash] + "/ca"
 			s, err := v.Read(caPath)
 			if err != nil {
 				return nil, "", fmt.Errorf("no signing authority provided and no 'ca' sibling found")

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -1030,7 +1030,12 @@ func DecodeErrorResponse(body []byte) error {
 func (v *Vault) FindSigningCA(cert *X509, certPath string, signPath string) (*X509, string, error) {
 	/* find the CA */
 	if signPath != "" {
-		if certPath == signPath {
+		// Compared canonicalized: a leading or trailing slash, or a doubled
+		// one, still names the same secret as certPath, and Sign's
+		// CA-rotation branch (ca == x) depends on this returning the
+		// certificate object itself -- by pointer identity -- for that
+		// case, not a second copy read back from the Vault.
+		if Canonicalize(certPath) == Canonicalize(signPath) {
 			return cert, certPath, nil
 		} else {
 			s, err := v.Read(signPath)

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -292,7 +292,7 @@ func (v *Vault) Write(path string, s *Secret) error {
 	}
 
 	if s.Empty() {
-		return v.deleteIfPresent(path, DeleteOpts{})
+		return v.deleteIfPresent(EncodePath(path, "", 0), DeleteOpts{})
 	}
 
 	_, err := v.client.Set(path, s.data, nil)
@@ -712,7 +712,7 @@ func (v *Vault) Undelete(path string) error {
 // and if so, it deletes it. Otherwise, no error is thrown
 func (v *Vault) deleteIfPresent(path string, opts DeleteOpts) error {
 	secretpath, _, _ := ParsePath(path)
-	if _, err := v.Read(secretpath); err != nil {
+	if _, err := v.Read(EncodePath(secretpath, "", 0)); err != nil {
 		if IsSecretNotFound(err) {
 			return nil
 		}


### PR DESCRIPTION
Adversarial review of the work since `v1.10.0`, with test-first remediation. 25 commits, one finding per commit (failing test and fix together). Full suite green: `gofmt`/`go vet` clean, `go test ./...` passes across `internal/cli`, `pkg/prompt`, `pkg/rc`, `pkg/vault`.

## Critical

- **`safe init` destroyed the Vault it just initialized.** With `VAULT_ADDR` set and no `~/.saferc` target (the CI workflow), the token-store step returned "no target selected" *before* the unseal keys and root token were printed — the Vault came up initialized, sealed, and unreachable. Keys/token now print first; a store failure is a stderr warning.
- **`safe local --listener address=` sent root init to a foreign vault.** The stranger check was bypassable — reproduced sending init/unseal/mount/write plus root-token storage to a decoy. The probe/client/registered address is now derived from the rendered listener stanza (not `--port`), and a TLS-enabling override is refused.

## High

- Symlinked `~/.saferc`/`~/.vault-token`/`~/.svtoken` replaced by regular files (dotfiles detached) — atomic write now resolves symlinks first.
- `safe x509 issue`/`reissue`/`renew` could destroy their own signing CA via a respelled path (`secret/ca` vs `secret/ca/`); the aliasing also produced a CA whose public key didn't match its private key — path comparisons canonicalized.
- Legacy `no_strongbox` key ignored, silently disarming cluster seal/unseal/status — honored on read, documented migration in README.
- Every `die()`/signal/error path in `safe local` orphaned a live engine and left `~/.saferc` on a dead target; SIGTERM/SIGQUIT and CA-cert-target SIGINT bypassed teardown — unified teardown across all exit paths.

## Medium / Low

`rc.Update` reporting failure after the write landed; `--as` collision race outside the lock; double path-parse corrupting secrets with a literal `:`; KV v2 `403` aborting a whole tree walk instead of skip-and-count; `safe ls` hard-failing without metadata capability; `SAFE_KNOWN_HOSTS_FILE` typo degrading to trust-on-first-use; rekey submitting empty keys on EOF; host-key prompt draining redirected stdin; two unguarded slice-index panics; `PathLessThan` ordering; misleading lock-timeout advice; CI dependency/exit-status gaps and a double-firing cleanup trap; `safe option` announcing success before persist; prompt read errors swallowed into empty strings.

## Validation

All four critical/high exploits independently re-verified closed by behavior (subprocess + live HTTP decoy for `safe local`, isolated-`$HOME` binary run for `safe init`), not just by re-reading the fixes.