### PR TITLE
Announce a re-parenting under --signed-by

### DIFF
--- a/internal/cli/x509.go
+++ b/internal/cli/x509.go
@@ -15,6 +15,25 @@ import (
 	"github.com/cloudfoundry-community/safe/pkg/vault"
 )
 
+// warnIfReparenting says so on standard error when the authority a
+// certificate is about to be signed under is not the one that issued it.
+// Signing under it hands back a certificate carrying an issuer it did not go
+// in with, which is the point when --signed-by names a new authority
+// deliberately and a surprise when it does not: FindSigningCA refuses a
+// guessed sibling that did not issue the certificate by naming --signed-by,
+// so following that advice with the refused path lands here. Renewing or
+// reissuing under the authority that did issue it -- including one that has
+// rotated its key, and a self-signed certificate answering for itself --
+// says nothing.
+func warnIfReparenting(cert, ca *vault.X509, caPath string) {
+	if cert == nil || ca == nil || cert.IssuedBy(ca) {
+		return
+	}
+	_, _ = fmt.Fprintf(os.Stderr,
+		"@Y{!!} @C{%s} did not issue this certificate; it moves from @C{%s} to @C{%s}\n",
+		caPath, cert.Issuer(), ca.Subject())
+}
+
 func (c *CLI) cmdX509(command string, args ...string) error {
 	r := c.r
 
@@ -292,6 +311,7 @@ func (c *CLI) cmdX509Reissue(command string, args ...string) error {
 	if err != nil {
 		return err
 	}
+	warnIfReparenting(cert, ca, caPath)
 
 	if len(opt.X509.Reissue.Name) > 0 {
 		ips, dns, email := vault.CategorizeSANs(uniq(opt.X509.Reissue.Name))
@@ -430,6 +450,7 @@ func (c *CLI) cmdX509Renew(command string, args ...string) error {
 	if err != nil {
 		return err
 	}
+	warnIfReparenting(cert, ca, caPath)
 
 	if len(opt.X509.Renew.Name) > 0 {
 		ips, dns, email := vault.CategorizeSANs(uniq(opt.X509.Renew.Name))

--- a/internal/cli/x509_reparent_notice_test.go
+++ b/internal/cli/x509_reparent_notice_test.go
@@ -1,0 +1,106 @@
+package cli
+
+// An authority named with --signed-by that did not issue the certificate
+// re-parents it: the certificate comes back under an issuer it did not go in
+// with. That is allowed on purpose, since naming an authority is how a
+// certificate moves to a new one -- but the guessed-sibling check refuses
+// with a message that names --signed-by, so a user can arrive here by
+// following advice about a certificate they only meant to renew. It happens
+// out loud or not at all.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenewUnderANamedStrangerAnnouncesTheReparenting(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeCert(t, fv, "secret/x/leaf", newLeaf(t, newCA(t, "signer"), "leaf"))
+	storeCert(t, fv, "secret/new/ca", newCA(t, "new-authority"))
+
+	c := newX509CLI(t)
+	c.opt.X509.Renew.SignedBy = "secret/new/ca"
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = c.cmdX509Renew("x509 renew", "secret/x/leaf")
+	})
+	if err != nil {
+		t.Fatalf("renew under a named authority: %v", err)
+	}
+	for _, want := range []string{"secret/new/ca", "signer", "new-authority"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr = %q, want it to mention %q", stderr, want)
+		}
+	}
+}
+
+func TestReissueUnderANamedStrangerAnnouncesTheReparenting(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeCert(t, fv, "secret/x/leaf", newLeaf(t, newCA(t, "signer"), "leaf"))
+	storeCert(t, fv, "secret/new/ca", newCA(t, "new-authority"))
+
+	c := newX509CLI(t)
+	c.opt.X509.Reissue.SignedBy = "secret/new/ca"
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = c.cmdX509Reissue("x509 reissue", "secret/x/leaf")
+	})
+	if err != nil {
+		t.Fatalf("reissue under a named authority: %v", err)
+	}
+	for _, want := range []string{"secret/new/ca", "signer", "new-authority"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr = %q, want it to mention %q", stderr, want)
+		}
+	}
+}
+
+// Naming the authority that did issue it is an ordinary renewal. Warning
+// about that one would train the warning out of anyone who reads it.
+func TestRenewUnderTheNamedIssuerSaysNothing(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	signer := newCA(t, "signer")
+	storeCert(t, fv, "secret/x/leaf", newLeaf(t, signer, "leaf"))
+	storeCert(t, fv, "secret/real/ca", signer)
+
+	c := newX509CLI(t)
+	c.opt.X509.Renew.SignedBy = "secret/real/ca"
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = c.cmdX509Renew("x509 renew", "secret/x/leaf")
+	})
+	if err != nil {
+		t.Fatalf("renew under the issuing authority: %v", err)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Errorf("stderr = %q, want nothing said", stderr)
+	}
+}
+
+// Reissuing a CA under itself rotates its key. The certificate is its own
+// authority, so nothing moves anywhere.
+func TestReissueOfASelfSignedCAUnderItselfSaysNothing(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeCert(t, fv, "secret/ca", newCA(t, "root"))
+
+	c := newX509CLI(t)
+	c.opt.X509.Reissue.SignedBy = "secret/ca"
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = c.cmdX509Reissue("x509 reissue", "secret/ca")
+	})
+	if err != nil {
+		t.Fatalf("reissue a CA under itself: %v", err)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Errorf("stderr = %q, want nothing said", stderr)
+	}
+}

--- a/pkg/vault/issued_by_test.go
+++ b/pkg/vault/issued_by_test.go
@@ -1,0 +1,67 @@
+// IssuedBy answers whether an authority is the one a certificate came in
+// under. FindSigningCA vets its guessed sibling with that question, and
+// renewing or reissuing under a named authority needs the same answer to
+// tell an ordinary renewal from one that moves the certificate somewhere
+// else, so the two ask it the same way.
+
+package vault_test
+
+import (
+	"testing"
+)
+
+func TestIssuedByRecognizesTheIssuingAuthority(t *testing.T) {
+	t.Parallel()
+	ca := caNamed(t, "authority")
+	leaf := leafSignedBy(t, ca)
+
+	if !leaf.IssuedBy(ca) {
+		t.Error("IssuedBy = false for the authority that signed the certificate")
+	}
+}
+
+func TestIssuedByRejectsAStranger(t *testing.T) {
+	t.Parallel()
+	issuer := caNamed(t, "issuer")
+	stranger := caNamed(t, "stranger")
+	leaf := leafSignedBy(t, issuer)
+
+	if leaf.IssuedBy(stranger) {
+		t.Error("IssuedBy = true for an authority that never signed the certificate")
+	}
+}
+
+// Rotating a CA replaces its key but keeps its Subject, so the rotated
+// authority is still the one every leaf underneath came in under. A
+// signature check would say otherwise and block the ordinary rotation
+// workflow.
+func TestIssuedBySurvivesACAKeyRotation(t *testing.T) {
+	t.Parallel()
+	oldCA := caNamed(t, "authority")
+	rotated := caNamed(t, "authority") // same subject, fresh key
+	leaf := leafSignedBy(t, oldCA)
+
+	if !leaf.IssuedBy(rotated) {
+		t.Error("IssuedBy = false after a CA key rotation")
+	}
+}
+
+func TestIssuedByHoldsForASelfSignedCertificate(t *testing.T) {
+	t.Parallel()
+	ca := caNamed(t, "self")
+
+	if !ca.IssuedBy(ca) {
+		t.Error("IssuedBy = false for a self-signed certificate against itself")
+	}
+}
+
+// Nothing is not an authority. Callers reach this with whatever
+// FindSigningCA handed back, so it must answer rather than panic.
+func TestIssuedByRejectsANilAuthority(t *testing.T) {
+	t.Parallel()
+	leaf := leafSignedBy(t, caNamed(t, "authority"))
+
+	if leaf.IssuedBy(nil) {
+		t.Error("IssuedBy = true for a nil authority")
+	}
+}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -1097,8 +1097,13 @@ func (v *Vault) FindSigningCA(cert *X509, certPath string, signPath string) (*X5
 			// the same way, without being upset by a key rotation: the
 			// Subject and Issuer stay equal across one, and differ for a
 			// sibling that never issued the certificate at all.
-			if !bytes.Equal(ca.Certificate.RawSubject, cert.Certificate.RawIssuer) {
-				return nil, "", fmt.Errorf("%s did not sign %s; name its authority with --signed-by", caPath, certPath)
+			//
+			// --signed-by is taken at its word, so the remedy named here
+			// is also the way past this check: say so, rather than let it
+			// read as an instruction to run the same thing again naming
+			// the sibling that just got refused.
+			if !cert.IssuedBy(ca) {
+				return nil, "", fmt.Errorf("%s did not sign %s; name its authority with --signed-by (naming one that did not sign it moves the certificate under it)", caPath, certPath)
 			}
 			return ca, caPath, nil
 		}

--- a/pkg/vault/x509.go
+++ b/pkg/vault/x509.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -418,6 +419,22 @@ func (x *X509) Issuer() string {
 
 func (x *X509) IntermediarySubject(n int) string {
 	return formatSubject(x.Intermediaries[n].Subject)
+}
+
+// IssuedBy reports whether ca is the authority the certificate came in
+// under, by comparing the authority's Subject to the certificate's Issuer.
+//
+// A cryptographic signature check would answer "no" for an authority that
+// has since rotated to a fresh key -- the ordinary `safe x509 reissue` of a
+// CA -- even though it is still the same authority, and every leaf beneath
+// it would become unrenewable. Subject and Issuer stay equal across a
+// rotation, and differ for an authority that never issued the certificate
+// at all.
+func (x *X509) IssuedBy(ca *X509) bool {
+	if x == nil || ca == nil || x.Certificate == nil || ca.Certificate == nil {
+		return false
+	}
+	return bytes.Equal(ca.Certificate.RawSubject, x.Certificate.RawIssuer)
 }
 
 func ParseSubject(subj string) (pkix.Name, error) {


### PR DESCRIPTION
Closes the one gap left open by #63.

The `x509 renew`/`reissue` fix in #63 vets the *guessed* `ca` sibling — it must be the authority that issued the certificate, compared Subject-to-Issuer so an ordinary CA key rotation still renews. An explicit `--signed-by` is deliberately exempt: naming an authority is how a certificate moves to a new one, and that escape hatch stays.

The gap was that the refusal reads `... did not sign ...; name its authority with --signed-by` — so following the advice with the sibling that was just refused re-parents the certificate silently, past the very check that stopped it a moment earlier.

- `X509.IssuedBy` gives the Subject-to-Issuer question one home instead of two spellings; `FindSigningCA` now asks it through the helper.
- Renew and reissue print the move on stderr before signing, naming the issuer left behind and the authority landed under.
- The refusal now says that naming an authority which did not sign it moves the certificate, instead of reading as "run that again with `--signed-by`".

Renewing under the authority that *did* issue it stays silent — including a CA that has rotated its key, and a self-signed certificate answering for itself — so the warning keeps its meaning.

Tests cover both stranger paths (renew, reissue) and both silent paths, plus `IssuedBy` against a rotation, a stranger, a self-signed certificate, and nil. `gofmt`/`go vet` clean; `go test ./...` green.