### PR TITLE
Pin the --no-clobber read on x509 issue

### DIFF
--- a/internal/cli/vault_fake_test.go
+++ b/internal/cli/vault_fake_test.go
@@ -46,6 +46,23 @@ type cliFakeVault struct {
 	// answers 403, for tests simulating a token without metadata-read
 	// capability. See denyMetadataGet.
 	forbidMetadataGet map[string]bool
+	//forbidGet names paths whose read answers 403, for tests that need a
+	// read to fail for a reason other than the secret not being there. See
+	// denyGet.
+	forbidGet map[string]bool
+}
+
+// denyGet makes a read of path answer 403, simulating a token without read
+// capability on it. A secret that is absent and a secret that cannot be
+// looked at are different answers, and commands that treat "not there" as
+// permission to proceed have to tell them apart.
+func (f *cliFakeVault) denyGet(path string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.forbidGet == nil {
+		f.forbidGet = map[string]bool{}
+	}
+	f.forbidGet[path] = true
 }
 
 // fakeVersion is one version of a version 2 secret. A version is alive until
@@ -139,6 +156,11 @@ func (f *cliFakeVault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 
 	default:
+		if f.forbidGet[path] {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"errors":["permission denied"]}`))
+			return
+		}
 		kv, ok := f.data[path]
 		if !ok {
 			w.WriteHeader(http.StatusNotFound)

--- a/internal/cli/x509.go
+++ b/internal/cli/x509.go
@@ -191,7 +191,11 @@ func (c *CLI) cmdX509Issue(command string, args ...string) error {
 				_, _ = fmt.Fprintf(os.Stderr, "@R{Cowardly refusing to create a new certificate in} @C{%s} @R{as it is already present in Vault}\n", args[0])
 			}
 			return nil
-		} else if err != nil && !vault.IsNotFound(err) {
+		} else if !vault.IsNotFound(err) {
+			//Reached only when the read failed, so err is not nil: a read
+			// that could not be made sense of is not the same answer as a
+			// path with nothing on it, and only the latter is permission
+			// to write.
 			return err
 		}
 	}

--- a/internal/cli/x509_issue_no_clobber_test.go
+++ b/internal/cli/x509_issue_no_clobber_test.go
@@ -1,0 +1,75 @@
+package cli
+
+// --no-clobber asks x509 issue to leave a certificate that is already there
+// alone. Deciding that rests on a read, and a read answers three different
+// ways: the secret is there, the secret is not there, or it could not be
+// looked at. Only the second is permission to go ahead and write.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIssueNoClobberLeavesAnExistingCertificateAlone(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	storeCert(t, fv, "secret/x/leaf", newLeaf(t, newCA(t, "signer"), "leaf"))
+	before := fv.get("secret/x/leaf")["certificate"]
+
+	c := newX509CLI(t)
+	c.opt.SkipIfExists = true
+	c.opt.X509.Issue.Name = []string{"leaf.example.com"}
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = c.cmdX509Issue("x509 issue", "secret/x/leaf")
+	})
+	if err != nil {
+		t.Fatalf("issue with --no-clobber over an existing certificate: %v", err)
+	}
+	if fv.get("secret/x/leaf")["certificate"] != before {
+		t.Error("the certificate was overwritten")
+	}
+	if !strings.Contains(stderr, "secret/x/leaf") {
+		t.Errorf("stderr = %q, want it to name the path left alone", stderr)
+	}
+}
+
+func TestIssueNoClobberWritesWhenNothingIsThere(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+
+	c := newX509CLI(t)
+	c.opt.SkipIfExists = true
+	c.opt.X509.Issue.Name = []string{"leaf.example.com"}
+
+	if err := c.cmdX509Issue("x509 issue", "secret/x/leaf"); err != nil {
+		t.Fatalf("issue with --no-clobber onto an empty path: %v", err)
+	}
+	if fv.get("secret/x/leaf")["certificate"] == "" {
+		t.Error("nothing was issued")
+	}
+}
+
+// A read that fails because the token may not look at the path says nothing
+// about whether a certificate is there. Treating it as absence would write
+// over one that is.
+func TestIssueNoClobberSurfacesAReadFailure(t *testing.T) {
+	isolateHome(t)
+	fv := newCLIFake(t)
+	fv.denyGet("secret/x/leaf")
+
+	c := newX509CLI(t)
+	c.opt.SkipIfExists = true
+	c.opt.X509.Issue.Name = []string{"leaf.example.com"}
+
+	err := c.cmdX509Issue("x509 issue", "secret/x/leaf")
+	if err == nil {
+		t.Fatal("issue with --no-clobber over an unreadable path = nil, want an error")
+	}
+	for _, r := range fv.requests() {
+		if strings.HasPrefix(r, "PUT ") {
+			t.Errorf("wrote %q after a read it could not make sense of", r)
+		}
+	}
+}


### PR DESCRIPTION
Housekeeping: a redundant condition flagged during the post-#63 review, plus the coverage it needed before touching it.

`cmdX509Issue`'s `--no-clobber` block read `} else if err != nil && !vault.IsNotFound(err) {` — inside the `else` of `if _, err := v.Read(...); err == nil`, so `err != nil` can never be false. A no-op, but the branch it guards had no test at all, so the tests come first and the simplification rides on them.

Pinned, all three answers the read can give:

- the secret is there → left alone, nothing written, the path named on stderr
- the secret is not there → issued
- the read failed for another reason (403) → error surfaced, nothing written

That last one is the branch in question: a read that could not be made sense of is not the same answer as a path with nothing on it, and treating it as absence would write over a certificate that is there.

Adds `denyGet` to the CLI fake Vault (test-only), matching the existing `denyMetadataGet` pattern, so a read can fail for a reason other than absence.

No behavior change. All three tests pass before and after the simplification — by construction, there is no red phase for removing a condition that is always true. `gofmt`/`go vet` clean; `go test ./...` green.